### PR TITLE
Fix lockfile write problems on new install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,6 @@ upload-stable: bin/viam-agent-$(PATH_VERSION)-x86_64 bin/viam-agent-$(PATH_VERSI
 	test "$(PATH_VERSION)" != "custom"
 	gsutil -h "Cache-Control:no-cache" cp bin/viam-agent-$(PATH_VERSION)-x86_64 bin/viam-agent-$(PATH_VERSION)-aarch64 bin/viam-agent-stable-x86_64 bin/viam-agent-stable-aarch64 gs://packages.viam.com/apps/viam-agent/
 
-
 .PHONY: upload-installer
 upload-installer:
 	gsutil -h "Cache-Control:no-cache" cp install.sh uninstall.sh gs://packages.viam.com/apps/viam-agent/

--- a/cmd/viam-agent/main.go
+++ b/cmd/viam-agent/main.go
@@ -98,6 +98,9 @@ func main() {
 		}
 	}
 
+	// set up folder structure
+	exitIfError(agent.InitPaths())
+
 	// use a lockfile to prevent running two agents on the same machine
 	pidFile, err := lockfile.New(filepath.Join(agent.ViamDirs["tmp"], "viam-agent.pid"))
 	exitIfError(errors.Wrap(err, "cannot init lock file"))


### PR DESCRIPTION
Small fix, moving InitPaths() to startup (and not just install) so it's there on pre-provisioned systems BEFORE the lockfile is tried. (No functional changes in the actual function, just relocated.)