### PR TITLE
Favor starting viam-server first 

### DIFF
--- a/cmd/viam-agent/main.go
+++ b/cmd/viam-agent/main.go
@@ -175,7 +175,7 @@ func main() {
 		if errors.Is(err, agent.ErrSubsystemDisabled) {
 			globalLogger.Warn("viam-server subsystem disabled, please manually update /etc/viam.json and connect to internet")
 		} else {
-			globalLogger.Error("could not start viam-server subsystem, please manually update /etc/viam.json and connect to internet")
+			globalLogger.Errorf("could not start viam-server subsystem: %s", err)
 		}
 	}
 


### PR DESCRIPTION
Favor starting viam-server and then, update checks and other subsystems. See startup logs, only a couple seconds between systemd starting viam-agent and viam-server returning its first log. 

```
Mar 12 17:00:29 raspi4agent systemd[1]: Started viam-agent.service - Viam Services Agent.
Mar 12 17:00:29 raspi4agent viam-agent[30462]: 2024-03-12T17:00:29.603-0400        INFO        viam-agent        viam-agent/main.go:127        config file path: /etc/viam.json
Mar 12 17:00:29 raspi4agent viam-agent[30462]: 2024-03-12T17:00:29.605-0400        INFO        viam-agent.viam-server        viamserver/viamserver.go:69        Starting viam-server
Mar 12 17:00:32 raspi4agent viam-agent[30462]: 2024-03-12T21:00:32.638Z        INFO        robot_server        config/logging_level.go:36        Log level initialized: info
Mar 12 17:00:32 raspi4agent viam-agent[30462]: 2024-03-12T21:00:32.638Z        INFO        robot_server        server/entrypoint.go:92        Viam RDK        {"version":"v0.22.0","git_rev":"eb1f095d062e1a170059a887b5f857800a24942d"}
```
