### PR TITLE
[APP-5068] fix agent install issue with service file

### DIFF
--- a/subsystems/viamagent/viamagent.go
+++ b/subsystems/viamagent/viamagent.go
@@ -227,7 +227,7 @@ func getServiceFilePath(logger *zap.SugaredLogger) (string, bool, error) {
 	if err == nil {
 		return serviceFilePath, true, nil
 	}
-	if errw.Is(err, fs.ErrNotExist) {
+	if !errw.Is(err, fs.ErrNotExist) {
 		// unknown error
 		return "", false, err
 	}

--- a/subsystems/viamagent/viamagent.go
+++ b/subsystems/viamagent/viamagent.go
@@ -228,7 +228,7 @@ func getServiceFilePath(logger *zap.SugaredLogger) (string, bool, error) {
 		return serviceFilePath, true, nil
 	}
 	if !errw.Is(err, fs.ErrNotExist) {
-		// unknown error
+		// unknown error when checking old service file path
 		return "", false, err
 	}
 


### PR DESCRIPTION
Thanks @abe-winter  for trying on your laptop. I was able to reproduce it on a new flashed rpi image. \

And tested the fix by running the custom `sudo /tmp/viam-agent-custom-aarch64 --install` 

```
2024-05-28T09:46:48.164-0400	INFO	viam-agent	viamagent/viamagent.go:129	adding a symlink to /tmp/viam-agent-custom-aarch64 at /opt/viam/bin/viam-agent
2024-05-28T09:46:48.171-0400	INFO	viam-agent	viamagent/viamagent.go:148	writing systemd service file to /usr/local/lib/systemd/system/viam-agent.service
2024-05-28T09:46:48.171-0400	INFO	viam-agent	viamagent/viamagent.go:163	enabling systemd viam-agent service
2024-05-28T09:46:48.792-0400	INFO	viam-agent	viamagent/viamagent.go:185	Install complete. Please (re)start the service with 'systemctl restart viam-agent' when ready.
```

[agent bin](https://github.com/viamrobotics/agent/files/15470764/Archive.zip)

https://viam.atlassian.net/browse/APP-5068
