### PR TITLE
Fix panic on errors.As()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,10 @@ else ifeq ($(GOARCH),arm64)
 LINUX_ARCH = aarch64
 endif
 
-GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
-TAG_VERSION ?= $(shell git tag --points-at | sort -Vr | head -n1 | cut -c2-)
+ifeq ($(shell git status -s),)
+	TAG_VERSION ?= $(shell git tag --points-at | sort -Vr | head -n1 | cut -c2-)
+	GIT_REVISION = $(shell git rev-parse HEAD | tr -d '\n')
+endif
 ifeq ($(TAG_VERSION),)
 PATH_VERSION = custom
 else

--- a/cmd/viam-agent/main.go
+++ b/cmd/viam-agent/main.go
@@ -186,7 +186,7 @@ func main() {
 				break
 			}
 
-			if errors.As(err, &exec.ExitError{}) {
+			if e := (&exec.ExitError{}); !errors.As(err, &e) {
 				// if it's not an ExitError, that means it didn't even start, so bail out
 				globalLogger.Error(errors.Wrap(err, "running 'systemctl is-active network-online.target'"))
 				break


### PR DESCRIPTION
Quick fix for a panic I hit during some manual testing. Don't think it's critical enough to warrant its own release, but didn't want to lose/forget the fix.

Also, tweaked the makefile so it won't accidentally tag binaries with stable versions when uncommitted changes are present.