### PR TITLE
CI to vet + build on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version: "1.21"
+    - name: vet
+      run: go vet ./... 
+    - name: build
+      run: go build ./... 


### PR DESCRIPTION
## What changed
- add workflow on every push which vets and builds agent
## Why
Minimal, non-invasive linter coverage. We can improve later as needed.