### PR TITLE
workflow to lint + upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
     inputs:
       channel:
         type: choice
-        options: [latest, stable, rc]
+        options: [stable]
       upload:
         type: boolean
 
@@ -16,7 +16,7 @@ jobs:
     - name: lint
       run: make lint
     - name: build
-      run: PATH_VERSION=latest make all
+      run: PATH_VERSION=${{ inputs.channel }} make all
     - uses: google-github-actions/auth@v2
       if: inputs.upload
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+    - name: lint
+      run: make lint
+    - name: build
+      run: PATH_VERSION=latest make all
+    - name: upload
+      if: false
+      run: echo todo upload

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 on:
-  push:
   workflow_dispatch:
+    inputs:
+      channel:
+        type: choice
+        options: [latest, stable, rc]
+      upload:
+        type: boolean
 
 jobs:
   build:
@@ -12,6 +17,15 @@ jobs:
       run: make lint
     - name: build
       run: PATH_VERSION=latest make all
-    - name: upload
-      if: false
-      run: echo todo upload
+    - uses: google-github-actions/auth@v2
+      if: inputs.upload
+      with:
+        credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+    - name: Upload Files (PR)
+      if: inputs.upload
+      uses: google-github-actions/upload-cloud-storage@v2
+      with:
+        path: bin
+        destination: packages.viam.com/apps/viam-agent/
+        glob: 'viam-agent-*'
+        parent: false


### PR DESCRIPTION
## What changed
- add workflow to build viam-agent binaries for a channel + upload them
- this is manual for now
## Why
Clarity + repeatability around releases.
## Example run
Everything but the upload steps ran [here](https://github.com/viamrobotics/agent/actions/runs/9656039320/job/26632877666)
## Checklist
- [ ] set secret