### PR TITLE
configurable `startTimeout` for viam-server subsystem

### DIFF
--- a/cmd/viam-agent/main.go
+++ b/cmd/viam-agent/main.go
@@ -76,7 +76,7 @@ func main() {
 	// need to be root to go any further than this
 	curUser, err := user.Current()
 	exitIfError(err)
-	if curUser.Uid != "0" {
+	if curUser.Uid != "0" && os.Getenv("VIAM_AGENT_DEVMODE") == "" {
 		//nolint:forbidigo
 		fmt.Printf("viam-agent must be run as root (uid 0), but current user is %s (uid %s)\n", curUser.Username, curUser.Uid)
 		return

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	go.viam.com/test v1.1.1-0.20220913152726-5da9916c08a2
 	go.viam.com/utils v0.1.85
 	golang.org/x/sys v0.20.0
+	google.golang.org/protobuf v1.34.1
 )
 
 require (
@@ -86,7 +87,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20231016165738-49dd2c1f3d0b // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231016165738-49dd2c1f3d0b // indirect
 	google.golang.org/grpc v1.59.0 // indirect
-	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	nhooyr.io/websocket v1.8.9 // indirect

--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -53,7 +53,7 @@ type viamServer struct {
 	exitChan    chan struct{}
 	checkURL    string
 	checkURLAlt string
-	config      pb.DeviceSubsystemConfig
+	config      *pb.DeviceSubsystemConfig
 
 	// for blocking start/stop/check ops while another is in progress
 	startStopMu sync.Mutex
@@ -63,8 +63,8 @@ type viamServer struct {
 
 // try to parse duration string from s.config, otherwise use default.
 func (s *viamServer) startTimeout() time.Duration {
-	if s.config.Attributes != nil {
-		if raw, ok := s.config.Attributes.AsMap()["start_timeout"]; ok {
+	if s.config != nil && s.config.GetAttributes() != nil {
+		if raw, ok := s.config.GetAttributes().AsMap()["start_timeout"]; ok {
 			if str, ok := raw.(string); ok {
 				durt, err := time.ParseDuration(str)
 				if err == nil {
@@ -288,7 +288,7 @@ func (s *viamServer) Update(ctx context.Context, cfg *pb.DeviceSubsystemConfig, 
 
 func NewSubsystem(ctx context.Context, logger logging.Logger, updateConf *pb.DeviceSubsystemConfig) (subsystems.Subsystem, error) {
 	setFastStart(updateConf)
-	return agent.NewAgentSubsystem(ctx, SubsysName, logger, &viamServer{logger: logger, config: *updateConf})
+	return agent.NewAgentSubsystem(ctx, SubsysName, logger, &viamServer{logger: logger, config: updateConf})
 }
 
 func setFastStart(cfg *pb.DeviceSubsystemConfig) {


### PR DESCRIPTION
## What changed
- make the start timeout for the viam-server subsystem configurable
- incidental -- expand VIAM_AGENT_DEVMODE to include running as non-root. (convenience feature for local testing)
## Why
On slow connections and with large binaries, the default 5 minute timeout isn't enough to download viam-server and modules.
## Example config
(attributes.start_timeout is the new part)
```json
{
  "agent": {
    "viam-server": {
      "release_channel": "stable",
      "pin_version": "",
      "pin_url": "",
      "attributes": {"start_timeout": "1h"},
      "disable_subsystem": false
    }
  },
  "components": [
```
## Testing
Tested on my local machine with the new config value missing and present. When present it logs as expected:
> 2024-08-28T15:12:44.807Z DEBUG   viam-agent      viamserver/viamserver.go:91     parsed duration 10m0s from key start_timeout