### PR TITLE
bump golang min version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/viamrobotics/agent
 
-go 1.21.4
+go 1.21.13
 
 require (
 	github.com/jessevdk/go-flags v1.5.0


### PR DESCRIPTION
## What changed
- bump go.mod min version to 1.21.13
## Why
netip vuln https://pkg.go.dev/vuln/GO-2024-2887