### PR TITLE
Fix network settings error when gateway empty

### DIFF
--- a/subsystems/provisioning/generators.go
+++ b/subsystems/provisioning/generators.go
@@ -120,9 +120,12 @@ func generateIPv4Settings(cfg NetworkConfig) (map[string]any, error) {
 		return nil, err
 	}
 
-	gateway, err := generateAddress(cfg.IPv4Gateway)
-	if err != nil {
-		return nil, err
+	var gateway uint32
+	if len(cfg.IPv4Gateway) > 0 {
+		gateway, err = generateAddress(cfg.IPv4Gateway)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	mask, err := strconv.ParseUint(ret[2], 10, 32)

--- a/subsystems/provisioning/networkmanager.go
+++ b/subsystems/provisioning/networkmanager.go
@@ -389,10 +389,11 @@ func (w *Provisioning) addOrUpdateConnection(cfg NetworkConfig) (bool, error) {
 		nw.isHotspot = true
 		settings = generateHotspotSettings(w.cfg.HotspotPrefix, w.Config().hotspotSSID, w.cfg.HotspotPassword, w.Config().HotspotInterface)
 	} else {
-		settings, err = generateNetworkSettings(w.cfg.Manufacturer+"-"+netKey, cfg)
+		id := w.cfg.Manufacturer + "-" + netKey
+		settings, err = generateNetworkSettings(id, cfg)
 		w.logger.Debugf("Network settings: ", settings)
 		if err != nil {
-			return changesMade, err
+			return changesMade, errw.Errorf("error generating network settings for %s: %v", id, err)
 		}
 	}
 

--- a/subsystems/provisioning/networkmanager.go
+++ b/subsystems/provisioning/networkmanager.go
@@ -390,6 +390,7 @@ func (w *Provisioning) addOrUpdateConnection(cfg NetworkConfig) (bool, error) {
 		settings = generateHotspotSettings(w.cfg.HotspotPrefix, w.Config().hotspotSSID, w.cfg.HotspotPassword, w.Config().HotspotInterface)
 	} else {
 		settings, err = generateNetworkSettings(w.cfg.Manufacturer+"-"+netKey, cfg)
+		w.logger.Debugf("Network settings: ", settings)
 		if err != nil {
 			return changesMade, err
 		}

--- a/subsystems/provisioning/provisioning.go
+++ b/subsystems/provisioning/provisioning.go
@@ -342,6 +342,7 @@ func (w *Provisioning) processAdditionalnetworks(ctx context.Context) {
 		_, err := w.addOrUpdateConnection(network)
 		if err != nil {
 			w.logger.Error(errw.Wrapf(err, "error adding network %s", network.SSID))
+			continue
 		}
 		if network.Interface != "" {
 			if err := w.activateConnection(ctx, network.Interface, network.SSID); err != nil {


### PR DESCRIPTION
* Make network gateway "optional" as there are cases where it may not be needed (local network)
* Add debug log line with parsed network settings
* Skip activating connection if error to add or update