### PR TITLE
[APP-7026] Handle rfkill, no-wifi-device cases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.1
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.0
-	github.com/Otterverse/gonetworkmanager/v2 v2.2.0
+	github.com/Otterverse/gonetworkmanager/v2 v2.2.1
 	github.com/google/uuid v1.6.0
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/nightlyone/lockfile v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/Masterminds/sprig v2.15.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuN
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmUx/1V+TNhjQvM=
-github.com/Otterverse/gonetworkmanager/v2 v2.2.0 h1:aYEOjBO2I+OMORNpCBXqvVgzHcGks5MWmKv0JmrT5po=
-github.com/Otterverse/gonetworkmanager/v2 v2.2.0/go.mod h1:Bc8kOugBgzCBC0R8oLa3wHnGet7k2ZpMHUobZtxlwhU=
+github.com/Otterverse/gonetworkmanager/v2 v2.2.1 h1:yNov3VIkatRprIhCkoshWEeUG4pyNPJQMLHSFXqi09g=
+github.com/Otterverse/gonetworkmanager/v2 v2.2.1/go.mod h1:Bc8kOugBgzCBC0R8oLa3wHnGet7k2ZpMHUobZtxlwhU=
 github.com/PuerkitoBio/goquery v1.6.0/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=

--- a/utils.go
+++ b/utils.go
@@ -332,12 +332,3 @@ func ConvertAttributes[T any](attributes *structpb.Struct) (*T, error) {
 
 	return newConfig, nil
 }
-
-func Sleep(ctx context.Context, timeout time.Duration) bool {
-	select {
-	case <-ctx.Done():
-		return false
-	case <-time.After(timeout):
-		return true
-	}
-}


### PR DESCRIPTION
This fixes two cases... the first, in the bug, is when the wifi is blocked by rfkill (aka, "airplane mode".) This has recently (past week) become the default for new Raspberry Pi image installs unless the user specifically adds a wifi network during the image creation process.

The second case is for devices that have no wifi adapters at all. Previously, results were undefined, and provisioning would continue trying to execute, scan, start hotspots, etc. even if that wasn't possible. Now the lack of wifi hardware causes provisioning to self-disable until the next restart of agent.