### PR TITLE
Fix wifi candidate selection to include non-interface-bound candidates

### DIFF
--- a/cmd/viam-agent/main.go
+++ b/cmd/viam-agent/main.go
@@ -183,7 +183,7 @@ func main() {
 	}
 
 	// wait until now when we (potentially) have a network logger to record this
-	globalLogger.Infof("Viam Agent Version: %s\nGit Revision: %s\n", agent.GetVersion(), agent.GetRevision())
+	globalLogger.Infof("Viam Agent Version: %s Git Revision: %s", agent.GetVersion(), agent.GetRevision())
 
 	// if FastStart is set, skip updates and start viam-server immediately, then proceed as normal
 	var fastSuccess bool

--- a/subsystems/provisioning/definitions.go
+++ b/subsystems/provisioning/definitions.go
@@ -37,8 +37,6 @@ const (
 	NetworkTypeWired             = "wired"
 	NetworkTypeHotspot           = "hotspot"
 
-	IfNameAny = "any"
-
 	HealthCheckTimeout = time.Minute
 )
 

--- a/subsystems/provisioning/generators.go
+++ b/subsystems/provisioning/generators.go
@@ -2,7 +2,6 @@ package provisioning
 
 import (
 	"encoding/binary"
-	"fmt"
 	"net"
 	"regexp"
 	"strconv"
@@ -177,15 +176,4 @@ func generateAddress(addr string) (uint32, error) {
 	}
 
 	return binary.LittleEndian.Uint32(outBytes), nil
-}
-
-func genNetKey(ifName, ssid string) string {
-	if ifName == "" {
-		ifName = IfNameAny
-	}
-
-	if ssid == "" {
-		return ifName
-	}
-	return fmt.Sprintf("%s@%s", ssid, ifName)
 }

--- a/subsystems/provisioning/provisioning.go
+++ b/subsystems/provisioning/provisioning.go
@@ -312,6 +312,7 @@ func (w *Provisioning) Update(ctx context.Context, updateConf *agentpb.DeviceSub
 	if cfg.HotspotInterface == "" {
 		cfg.HotspotInterface = w.Config().HotspotInterface
 	}
+	w.netState.SetHotspotInterface(cfg.HotspotInterface)
 
 	if reflect.DeepEqual(cfg, w.cfg) {
 		return needRestart, nil

--- a/subsystems/provisioning/provisioning.go
+++ b/subsystems/provisioning/provisioning.go
@@ -162,6 +162,7 @@ func (w *Provisioning) init(ctx context.Context) error {
 	}
 
 	w.updateHotspotSSID(w.cfg)
+	w.netState.SetHotspotInterface(w.cfg.HotspotInterface)
 
 	if err := w.writeDNSMasq(); err != nil {
 		return errw.Wrap(err, "writing dnsmasq configuration")

--- a/subsystems/provisioning/scanning.go
+++ b/subsystems/provisioning/scanning.go
@@ -169,9 +169,13 @@ func (w *Provisioning) updateKnownConnections(ctx context.Context) error {
 		}
 
 		ifName, ssid, netType := getIfNameSSIDTypeFromSettings(settings)
-		if ifName == "" {
+		if netType == "" {
 			// unknown network type, or broken network
 			continue
+		}
+
+		if ifName == "" && netType == NetworkTypeWifi {
+			ifName = w.Config().HotspotInterface
 		}
 
 		_, ok := highestPriority[ifName]

--- a/subsystems/provisioning/setup.go
+++ b/subsystems/provisioning/setup.go
@@ -124,6 +124,7 @@ func (w *Provisioning) initDevices() error {
 
 			if w.cfg.HotspotInterface == "" || ifName == w.cfg.HotspotInterface {
 				w.cfg.HotspotInterface = ifName
+				w.netState.SetHotspotInterface(ifName)
 				w.logger.Infof("Using %s for hotspot/provisioning, will actively manage wifi only on this device.", ifName)
 			}
 		default:


### PR DESCRIPTION
Wifi networks found from scan were associated with the scanning interface (e.g. wlan0) but externally configured wifi settings (e.g. prexisting networks) might not be associated with a specific interface. Thus, duplicate networks (one for "any" and one for "wlan0" were causing issues.

This PR should deduplicate the two maps. If a connection/settings has no interface associated (and it's wifi) it gets handled as though it WAS associated with the current HotspotInterface (can be configured, otherwise first detected wifi adapter.)