### PR TITLE
APP-6990 consume debug level from cloud config

### DIFF
--- a/cmd/viam-agent/main.go
+++ b/cmd/viam-agent/main.go
@@ -76,7 +76,7 @@ func main() {
 	}
 
 	if opts.Debug {
-		globalLogger = logging.NewDebugLogger("viam-agent")
+		globalLogger.SetLevel(logging.DEBUG)
 	}
 
 	// need to be root to go any further than this

--- a/manager.go
+++ b/manager.go
@@ -426,16 +426,18 @@ func (m *Manager) dial(ctx context.Context) error {
 // process non-subsystem effects of a config (i.e. agent-specific stuff that needs to happen when loading cache and when updating).
 func (m *Manager) processConfig(cfg map[string]*pb.DeviceSubsystemConfig) {
 	if agent, ok := cfg["viam-agent"]; ok {
-		if debug, ok := agent.GetAttributes().AsMap()["debug"].(bool); !ok {
-			m.logger.Error("viam-agent debug attribute is present but is not a bool")
-		} else {
-			// note: if this is present (true or false, rather than missing) it overrides the CLI debug switch.
-			// if the user removes the `debug` attribute, we don't revert to the CLI debug switch state. (we ideally should).
-			// note: this assumes m.logger is the global logger shared by the other subsystems.
-			if debug {
-				m.logger.SetLevel(logging.DEBUG)
+		if debugRaw, ok := agent.GetAttributes().AsMap()["debug"]; ok {
+			if debug, ok := debugRaw.(bool); !ok {
+				m.logger.Error("viam-agent debug attribute is present but is not a bool")
 			} else {
-				m.logger.SetLevel(logging.INFO)
+				// note: if this is present (true or false, rather than missing) it overrides the CLI debug switch.
+				// if the user removes the `debug` attribute, we don't revert to the CLI debug switch state. (we ideally should).
+				// note: this assumes m.logger is the global logger shared by the other subsystems.
+				if debug {
+					m.logger.SetLevel(logging.DEBUG)
+				} else {
+					m.logger.SetLevel(logging.INFO)
+				}
 			}
 		}
 	}

--- a/manager.go
+++ b/manager.go
@@ -345,8 +345,8 @@ func (m *Manager) getCachedConfig() (map[string]*pb.DeviceSubsystemConfig, error
 	cachedConfig := map[string]*pb.DeviceSubsystemConfig{SubsystemName: {}}
 
 	cacheFilePath := filepath.Join(ViamDirs["cache"], agentCachePath)
-	//nolint:gosec
-	cacheBytes, err := os.ReadFile(cacheFilePath)
+
+	cacheBytes, err := os.ReadFile(cacheFilePath) //nolint:gosec
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return cachedConfig, nil
@@ -423,10 +423,10 @@ func (m *Manager) dial(ctx context.Context) error {
 	return nil
 }
 
-// process non-subsystem effects of a config (i.e. agent-specific stuff that needs to happen when loading cache).
+// process non-subsystem effects of a config (i.e. agent-specific stuff that needs to happen when loading cache and when updating).
 func (m *Manager) processConfig(cfg map[string]*pb.DeviceSubsystemConfig) {
 	if agent, ok := cfg["viam-agent"]; ok {
-		if debug, ok := agent.Attributes.AsMap()["debug"].(bool); !ok {
+		if debug, ok := agent.GetAttributes().AsMap()["debug"].(bool); !ok {
 			m.logger.Error("viam-agent debug attribute is present but is not a bool")
 		} else {
 			// note: if this is present (true or false, rather than missing) it overrides the CLI debug switch.


### PR DESCRIPTION
## What changed
- consume `debug` field from cloud config, instead of only from CLI switch
## Why
It's difficult to set this currently.
## Notes
Where is the right place for this? I put it in the attributes for the viam-agent subsystem, but the `map[string]DeviceSubsystemConfig` approach seems less ergonomic post unification.
## Manual test
With debug set to true:
> 2024-12-04T08:51:22.774Z	INFO	viam-agent	viamserver/viamserver.go:183	viam-server started
> 2024-12-04T08:51:22.774Z	**DEBUG**	viam-agent	agent/manager.go:277	starting background checks
> 2024-12-04T08:51:22.774Z	**DEBUG**	viam-agent	agent/manager.go:185	Checking cloud for update
> 2024-12-04T08:51:22.882Z	INFO	rdk.package_manager	packages/deferred_package_manager.go:143	cloud package manager created asyncronously


With debug set to false (second restart):
> 2024-12-04T08:51:28.572Z	INFO	viam-agent	viamserver/viamserver.go:183	viam-server started
> 2024-12-04T08:51:28.654Z	INFO	rdk.package_manager	packages/deferred_package_manager.go:143	cloud package manager created asyncronously

## Sample config
```json
{
  "agent": {
    "viam-agent": {
      "attributes": {"debug": true}
    }
}
```