### PR TITLE
[AW-MDNS-Provision] Skip Background Loop 

### DIFF
--- a/subsystems/provisioning/networkmanager.go
+++ b/subsystems/provisioning/networkmanager.go
@@ -571,6 +571,11 @@ func (w *Provisioning) backgroundLoop(ctx context.Context, scanChan chan<- bool)
 			return
 		}
 
+		if w.cfg.MDNSMode {
+			w.logger.Info("skipping background loop because mdnsmode")
+			return
+		}
+
 		w.checkConfigured()
 		if err := w.networkScan(ctx); err != nil {
 			w.logger.Error(err)


### PR DESCRIPTION
This PR skips the process initiated in the "background loop" when MDNS mode is enabled - as done [here](https://github.com/viamrobotics/agent/blob/aw-mdns-provision/subsystems/provisioning/provisioning.go#L149).