### PR TITLE
mdns provisioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.1
 require (
 	github.com/Masterminds/semver/v3 v3.3.0
 	github.com/Otterverse/gonetworkmanager/v2 v2.2.1
+	github.com/edaniels/zeroconf v1.0.10
 	github.com/google/uuid v1.6.0
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/nightlyone/lockfile v1.0.0
@@ -29,7 +30,6 @@ require (
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
 	github.com/dgottlieb/smarty-assertions v1.2.5 // indirect
 	github.com/edaniels/golog v0.0.0-20230215213219-28954395e8d0 // indirect
-	github.com/edaniels/zeroconf v1.0.10 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect

--- a/subsystems/provisioning/definitions.go
+++ b/subsystems/provisioning/definitions.go
@@ -372,6 +372,7 @@ type Config struct {
 	WifiPowerSave *bool `json:"wifi_power_save"`
 
 	// When true, advertise via mdns on pre-existing network instead of using static IP and captive portal.
+	// (Instead of the default behavior of starting a captive portal).
 	MDNSMode bool `json:"mdns_mode"`
 }
 

--- a/subsystems/provisioning/definitions.go
+++ b/subsystems/provisioning/definitions.go
@@ -370,6 +370,9 @@ type Config struct {
 
 	// If set, will explicitly enable or disable power save for all wifi connections managed by NetworkManager.
 	WifiPowerSave *bool `json:"wifi_power_save"`
+
+	// When true, advertise via mdns on pre-existing network instead of using static IP and captive portal.
+	MDNSMode bool `json:"mdns_mode"`
 }
 
 // Timeout allows parsing golang-style durations (1h20m30s) OR seconds-as-float from/to json.

--- a/subsystems/provisioning/grpc.go
+++ b/subsystems/provisioning/grpc.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"time"
 
 	errw "github.com/pkg/errors"
@@ -12,8 +13,10 @@ import (
 	"google.golang.org/grpc"
 )
 
+const GRPCPort = 4772
+
 func (w *Provisioning) startGRPC() error {
-	bind := PortalBindAddr + ":4772"
+	bind := w.listenAddr() + ":" + strconv.Itoa(GRPCPort)
 	lis, err := net.Listen("tcp", bind)
 	if err != nil {
 		return errw.Wrapf(err, "listening on: %s", bind)

--- a/subsystems/provisioning/networkmanager.go
+++ b/subsystems/provisioning/networkmanager.go
@@ -65,6 +65,9 @@ func (w *Provisioning) getLastNetworkTried() NetworkInfo {
 }
 
 func (w *Provisioning) checkOnline(force bool) error {
+	if w.cfg.MDNSMode {
+		return nil
+	}
 	if force {
 		if err := w.nm.CheckConnectivity(); err != nil {
 			w.logger.Error(err)

--- a/subsystems/provisioning/networkmanager.go
+++ b/subsystems/provisioning/networkmanager.go
@@ -169,7 +169,7 @@ func (w *Provisioning) StartProvisioning(ctx context.Context, inputChan chan<- u
 	defer w.opMu.Unlock()
 
 	w.logger.Info("Starting provisioning mode.")
-	if !w.mdnsMode {
+	if !w.cfg.MDNSMode {
 		_, err := w.addOrUpdateConnection(NetworkConfig{
 			Type:      NetworkTypeHotspot,
 			Interface: w.Config().HotspotInterface,
@@ -189,7 +189,7 @@ func (w *Provisioning) StartProvisioning(ctx context.Context, inputChan chan<- u
 		return errw.Wrap(err, "starting web/grpc portal")
 	}
 
-	if w.mdnsMode {
+	if w.cfg.MDNSMode {
 		w.logger.Infof("mdnsMode is set, advertising provisioning host %s", provisioningMDNSHost)
 		var err error
 		w.mdnsServer, err = zeroconf.RegisterDynamic(
@@ -301,7 +301,7 @@ func (w *Provisioning) DeactivateConnection(ifName, ssid string) error {
 }
 
 func (w *Provisioning) deactivateConnection(ifName, ssid string) error {
-	if w.mdnsMode {
+	if w.cfg.MDNSMode {
 		return nil
 	}
 	activeConn := w.netState.ActiveConn(ifName)

--- a/subsystems/provisioning/networkmanager.go
+++ b/subsystems/provisioning/networkmanager.go
@@ -571,6 +571,11 @@ func (w *Provisioning) backgroundLoop(ctx context.Context, scanChan chan<- bool)
 			return
 		}
 
+		if w.cfg.MDNSMode {
+			w.logger.Info("skipping background loop because mdnsmode")
+			return
+		}
+
 		w.checkConfigured()
 		if err := w.networkScan(ctx); err != nil {
 			w.logger.Error(err)

--- a/subsystems/provisioning/portal.go
+++ b/subsystems/provisioning/portal.go
@@ -47,7 +47,7 @@ func (w *Provisioning) startPortal(inputChan chan<- userInput) error {
 
 // the address to listen on.
 func (w *Provisioning) listenAddr() string {
-	if w.mdnsMode {
+	if w.cfg.MDNSMode {
 		return "0.0.0.0"
 	}
 	return PortalBindAddr

--- a/subsystems/provisioning/provisioning.go
+++ b/subsystems/provisioning/provisioning.go
@@ -39,11 +39,8 @@ type Provisioning struct {
 	cancel context.CancelFunc
 
 	// only set during NewProvisioning, no lock
-	nm       gnm.NetworkManager
-	settings gnm.Settings
-	// when mdnsMode is true, advertise via mdns on pre-existing network
-	// instead of using static IP and captive portal.
-	mdnsMode   bool
+	nm         gnm.NetworkManager
+	settings   gnm.Settings
 	hostname   string
 	logger     logging.Logger
 	AppCfgPath string

--- a/subsystems/provisioning/provisioning.go
+++ b/subsystems/provisioning/provisioning.go
@@ -145,6 +145,10 @@ func (w *Provisioning) init(ctx context.Context) error {
 	w.mainLoopHealth.MarkGood()
 	w.bgLoopHealth.MarkGood()
 
+	if w.cfg.MDNSMode {
+		w.logger.Info("skipping networkmanager init because mdnsmode")
+		return nil
+	}
 	nm, err := w.getNM()
 	if err != nil {
 		return err
@@ -386,6 +390,9 @@ func (w *Provisioning) updateHotspotSSID(cfg *Config) {
 
 // must be run inside dataMu lock.
 func (w *Provisioning) writeWifiPowerSave(ctx context.Context) error {
+	if w.cfg.MDNSMode {
+		return nil
+	}
 	contents := wifiPowerSaveContentsDefault
 	if w.cfg.WifiPowerSave != nil {
 		if *w.cfg.WifiPowerSave {

--- a/subsystems/provisioning/provisioning.go
+++ b/subsystems/provisioning/provisioning.go
@@ -11,6 +11,7 @@ import (
 
 	semver "github.com/Masterminds/semver/v3"
 	gnm "github.com/Otterverse/gonetworkmanager/v2"
+	"github.com/edaniels/zeroconf"
 	errw "github.com/pkg/errors"
 	"github.com/viamrobotics/agent"
 	"github.com/viamrobotics/agent/subsystems"
@@ -38,8 +39,11 @@ type Provisioning struct {
 	cancel context.CancelFunc
 
 	// only set during NewProvisioning, no lock
-	nm         gnm.NetworkManager
-	settings   gnm.Settings
+	nm       gnm.NetworkManager
+	settings gnm.Settings
+	// when mdnsMode is true, advertise via mdns on pre-existing network
+	// instead of using static IP and captive portal.
+	mdnsMode   bool
 	hostname   string
 	logger     logging.Logger
 	AppCfgPath string
@@ -60,6 +64,7 @@ type Provisioning struct {
 	// portal
 	webServer  *http.Server
 	grpcServer *grpc.Server
+	mdnsServer *zeroconf.Server
 	portalData *portalData
 
 	pb.UnimplementedProvisioningServiceServer


### PR DESCRIPTION
## What changed
- `mdns_mode` boolean in provisioning json config
- when mdns_mode true, instead of creating a captive portal, listen on 0.0.0.0 and advertise mdns
## Merge checklist
- [ ] careful review -- this is POC code, there are some edge cases where this will panic
## Why
POC of *viam* provisioning without *wifi* provisioning (micrordk style)