### PR TITLE
[APP-7257] Support older NM (>1.30.0) and hardware that cannot scan in hotspot mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -68,7 +68,7 @@ fetch_config() {
 	fi
 }
 
-# Verifies that NetworkManager is 1.42 or newer.
+# Verifies that NetworkManager is 1.30 or newer.
 check_nm_version() {
 	which nmcli >/dev/null 2>&1 || return 1
 
@@ -77,7 +77,7 @@ check_nm_version() {
 	NM_VERSION_MAJOR=$(echo $NM_VERSION | cut -d. -f1)
 	NM_VERSION_MINOR=$(echo $NM_VERSION | cut -d. -f2)
 
-	if [ $NM_VERSION_MAJOR -ge 1 ] && [ $NM_VERSION_MINOR -ge 42 ]; then
+	if [ $NM_VERSION_MAJOR -ge 1 ] && [ $NM_VERSION_MINOR -ge 30 ]; then
 		return 0
 	fi
 
@@ -139,7 +139,7 @@ enable_networkmanager() {
 	systemctl is-enabled NetworkManager && check_nm_version && return
 
 	echo
-	echo "Viam provides a wifi management and device provisioning service. To use it, NetworkManager 1.42 (or newer) must be installed and active."
+	echo "Viam provides a wifi management and device provisioning service. To use it, NetworkManager 1.30 (or newer) must be installed and active."
 
 	if check_nm_version || is_bullseye; then
 		# We can automate this.
@@ -177,7 +177,7 @@ enable_networkmanager() {
 	fi
 
 	if systemctl cat NetworkManager >/dev/null; then
-		systemctl enable --now NetworkManager || (echo "Failed to active NetworkManager" && return 1)
+		systemctl enable --now NetworkManager || (echo "Failed to activate NetworkManager" && return 1)
 		systemctl disable dhcpcd
 	else
 		return 1

--- a/subsystems/provisioning/definitions.go
+++ b/subsystems/provisioning/definitions.go
@@ -63,6 +63,7 @@ var (
 	ErrConnCheckDisabled       = errors.New("NetworkManager connectivity checking disabled by user, network management will be unavailable")
 	ErrNoActiveConnectionFound = errors.New("no active connection found")
 	scanLoopDelay              = time.Second * 15
+	scanTimeout                = time.Second * 30
 	connectTimeout             = time.Second * 50 // longer than the 45 second timeout in NetworkManager
 )
 

--- a/subsystems/provisioning/networkmanager.go
+++ b/subsystems/provisioning/networkmanager.go
@@ -746,7 +746,7 @@ func (w *Provisioning) mainLoop(ctx context.Context) {
 		offlineRebootTimeout := w.cfg.DeviceRebootAfterOfflineMinutes > 0 &&
 			lastConnectivity.Before(now.Add(time.Duration(w.cfg.DeviceRebootAfterOfflineMinutes)*-1))
 		if offlineRebootTimeout {
-			w.logger.Infof("device has been offline for more than %s minutes, rebooting", w.cfg.DeviceRebootAfterOfflineMinutes)
+			w.logger.Infof("device has been offline for more than %s, rebooting", time.Duration(w.cfg.DeviceRebootAfterOfflineMinutes))
 			cmd := exec.Command("systemctl", "reboot")
 			output, err := cmd.CombinedOutput()
 			if err != nil {

--- a/subsystems/provisioning/networkmanager.go
+++ b/subsystems/provisioning/networkmanager.go
@@ -44,6 +44,7 @@ func (w *Provisioning) warnIfMultiplePrimaryNetworks() {
 func (w *Provisioning) getVisibleNetworks() []NetworkInfo {
 	var visible []NetworkInfo
 	for _, nw := range w.netState.Networks() {
+		// note this does NOT use VisibleNetworkTimeout (like getCandidates does)
 		recentlySeen := nw.lastSeen.After(w.connState.getProvisioningChange().Add(time.Duration(w.Config().OfflineTimeout * -2)))
 
 		if !nw.isHotspot && recentlySeen {
@@ -511,8 +512,8 @@ func (w *Provisioning) getCandidates(ifName string) []string {
 		if nw.netType != NetworkTypeWifi || (nw.interfaceName != "" && nw.interfaceName != ifName) {
 			continue
 		}
-		// ssid seen within the past two minutes
-		visible := nw.lastSeen.After(time.Now().Add(time.Minute * -2))
+		// ssid seen within the past minute
+		visible := nw.lastSeen.After(time.Now().Add(VisibleNetworkTimeout * -1))
 
 		// ssid has a connection known to network manager
 		configured := nw.conn != nil

--- a/subsystems/provisioning/scanning.go
+++ b/subsystems/provisioning/scanning.go
@@ -11,7 +11,13 @@ import (
 	errw "github.com/pkg/errors"
 )
 
+var ErrScanTimeout = errw.New("wifi scanning timed out")
+
 func (w *Provisioning) networkScan(ctx context.Context) error {
+	if w.connState.getProvisioning() && w.netState.NoScanInHotspot() {
+		return nil
+	}
+
 	wifiDev := w.netState.WifiDevice(w.Config().HotspotInterface)
 	if wifiDev == nil {
 		return errw.Errorf("cannot find hotspot interface: %s", w.Config().HotspotInterface)
@@ -27,17 +33,26 @@ func (w *Provisioning) networkScan(ctx context.Context) error {
 		return errw.Wrap(err, "scanning wifi")
 	}
 
-	var lastScan int64
+	scanDeadline := time.Now().Add(scanTimeout)
 	for {
-		lastScan, err = wifiDev.GetPropertyLastScan()
+		lastScan, err := wifiDev.GetPropertyLastScan()
 		if err != nil {
 			return errw.Wrap(err, "scanning wifi")
 		}
 		if lastScan > prevScan {
+			if w.connState.getProvisioning() {
+				w.netState.ResetFailScan()
+			}
 			break
 		}
 		if !w.bgLoopHealth.Sleep(ctx, time.Second) {
 			return nil
+		}
+		if time.Now().After(scanDeadline) {
+			if w.connState.getProvisioning() {
+				w.netState.IncrementFailScan()
+			}
+			return ErrScanTimeout
 		}
 	}
 
@@ -116,7 +131,7 @@ func (w *Provisioning) networkScan(ctx context.Context) error {
 		nw.mu.Unlock()
 	}
 
-	return w.updateKnownConnections(ctx)
+	return nil
 }
 
 func parseWPAFlags(apFlags, wpaFlags, rsnFlags uint32) string {

--- a/subsystems/provisioning/scanning.go
+++ b/subsystems/provisioning/scanning.go
@@ -11,7 +11,12 @@ import (
 	errw "github.com/pkg/errors"
 )
 
-var ErrScanTimeout = errw.New("wifi scanning timed out")
+var (
+	ErrScanTimeout = errw.New("wifi scanning timed out")
+
+	// how long is a scanned network "visible" for candidate selection?
+	VisibleNetworkTimeout = time.Minute
+)
 
 func (w *Provisioning) networkScan(ctx context.Context) error {
 	if w.connState.getProvisioning() && w.netState.NoScanInHotspot() {
@@ -124,7 +129,7 @@ func (w *Provisioning) networkScan(ctx context.Context) error {
 		}
 		nw.mu.Lock()
 		// if a network isn't visible, reset the times so we'll retry if it comes back
-		if nw.lastSeen.Before(time.Now().Add(time.Minute * -1)) {
+		if nw.lastSeen.Before(time.Now().Add(VisibleNetworkTimeout * -1)) {
 			nw.firstSeen = time.Time{}
 			nw.lastTried = time.Time{}
 		}

--- a/subsystems/provisioning/setup.go
+++ b/subsystems/provisioning/setup.go
@@ -14,6 +14,12 @@ import (
 	errw "github.com/pkg/errors"
 )
 
+var (
+	ErrNM = errw.New("NetworkManager does not appear to be responding as expected. " +
+		"Please ensure NetworkManger >= v1.30 is installed and enabled. Disabling agent-provisioning until next restart.")
+	ErrNoWifi = errw.New("No WiFi devices available. Disabling agent-provisioning until next restart.")
+)
+
 func (w *Provisioning) writeDNSMasq() error {
 	DNSMasqContents := DNSMasqContentsRedirect
 	if w.cfg.DisableDNSRedirect {
@@ -137,7 +143,7 @@ func (w *Provisioning) initDevices() error {
 	}
 
 	if w.cfg.HotspotInterface == "" {
-		return errors.New("cannot find wifi device for provisioning/hotspot")
+		return ErrNoWifi
 	}
 
 	return nil


### PR DESCRIPTION
EDIT: rc2 replaces rc1. Fix a timeout issue that caused erratic behavior on "normal" (read, previously fully working) systems.
EDIT: rc1 replaces rc0. Minor fix for unrelated reboot timeout code.

Two main changes...

1. If NM older than 1.38, avoid using RadioFlags to disable when wifi hardware is absent, and rely on later device scan.

2. Modify wifi scanning to detect repeated failures when in hotspot mode, and (after 3) disable such scans after warning the user. This means the network list in the web portal or provided to the mobile app may be several minutes out of date, as scan data had to come from before the hotspot was started. May want to advise users to reduce the fallback timeout to a lower interval if this causes them problems. Otherwise we hang out in hotspot for 10 minutes, even if a wifi network we know comes in range, we can't see it until hotspot exits to allow a scan.


Test build:

     ` "pin_url": "http://packages.viam.com/temp/viam-agent-v0.12.0-rc2-aarch64",`
