### PR TITLE
[APP-7364] [APP-7366] [RSDK-9684] [APP-7154] Add more logging, reduce monitoring loop time, misc small fixes.

### DIFF
--- a/cmd/viam-agent/main.go
+++ b/cmd/viam-agent/main.go
@@ -140,6 +140,8 @@ func main() {
 		// If the local /etc/viam.json config is corrupted, invalid, or missing (due to a new install), we can get stuck here.
 		// Rename the file (if it exists) and wait to provision a new one.
 		if !errors.Is(err, fs.ErrNotExist) {
+			globalLogger.Error(errors.Wrapf(err, "reading %s", absConfigPath))
+			globalLogger.Warn("renaming %s to %s.old", absConfigPath, absConfigPath)
 			if err := os.Rename(absConfigPath, absConfigPath+".old"); err != nil {
 				// if we can't rename the file, we're up a creek, and it's fatal
 				globalLogger.Error(errors.Wrapf(err, "removing invalid config file %s", absConfigPath))

--- a/manager.go
+++ b/manager.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	minimalCheckInterval  = time.Second * 60
+	minimalCheckInterval  = time.Second * 5
 	defaultNetworkTimeout = time.Second * 15
 	// stopAllTimeout must be lower than systemd subsystems/viamagent/viam-agent.service timeout of 4mins
 	// and higher than subsystems/viamserver/viamserver.go timeout of 2mins.

--- a/subsystems/provisioning/templates/index.html
+++ b/subsystems/provisioning/templates/index.html
@@ -37,7 +37,7 @@
     <div class="form-group">
       <label for="network">Network</label>
       {{if eq (len .VisibleSSIDs) 0}}
-        <input type="text" name="ssid" placeholder="Enter Wifi SSID" id="network" required>
+        <input type="text" name="ssid" placeholder="Enter Wifi SSID" id="network" required autocorrect="off" autocapitalize="off">
       {{else}}
         <div class="select-border">
           <select name="ssid" id="network" required>
@@ -52,14 +52,14 @@
 
     <div class="form-group">
       <label for="password">Password</label>
-      <input type="text" name="password" id="password" placeholder="Password">
+      <input type="text" name="password" id="password" placeholder="Password" autocorrect="off" autocapitalize="off">
     </div>
     {{end}}
 
     {{if not .IsConfigured}}
     <div class="form-group">
       <label for="viamconfig">Device Config</label>
-      <textarea type="textarea" name="viamconfig" id="viamconfig" required placeholder="No config found on device. Paste your viam.json file here."></textarea>
+      <textarea type="textarea" name="viamconfig" id="viamconfig" required placeholder="No config found on device. Paste your viam.json file here." autocorrect="off" autocapitalize="off"></textarea>
     </div>
     {{end}}
 

--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -172,6 +172,9 @@ func (s *viamServer) Start(ctx context.Context) error {
 				s.logger.Errorw("non-zero exit code", "exit code", s.lastExit)
 			}
 		}
+		if s.shouldRun {
+			s.logger.Infof("%s exited unexpectedly and will be restarted shortly", SubsysName)
+		}
 		close(s.exitChan)
 	}()
 


### PR DESCRIPTION
Quick PR for easy fixes.

Needs testing for the linked Jira issues

1. Install
2. Upgrade/downgrade viam-agent and ensure a "disabled" systemd service remains disabled after upgrade.
3. Confirm captive portal works for new wifi (mainly that browser doesn't throw errors) and fixes capitalization issue.
4. Corrupt /etc/viam.json, ensure errors are clear and file is renamed
5. Make sure it runs okay for a while (15+ minutes) with the new, shorter timeout.
6. Kill viam-server (or otherwise make it fail) and confirm it logs and restarts quickly.
