### PR TITLE
Let addOrUpdateConnection() handle live connection deletion

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,3 +1,5 @@
+name: Test and Build
+
 on:
   pull_request:
   workflow_dispatch:

--- a/subsystems/networking/networkmanager.go
+++ b/subsystems/networking/networkmanager.go
@@ -442,7 +442,7 @@ func (n *Networking) addOrUpdateConnection(cfg utils.NetworkDefinition) (bool, e
 		return changesMade, errw.Wrapf(err, "getting new settings for %s", netKey)
 	}
 
-	changesMade = !reflect.DeepEqual(oldSettings, newSettings) || changesMade
+	changesMade = changesMade || !reflect.DeepEqual(oldSettings, newSettings)
 
 	return changesMade, nil
 }

--- a/subsystems/networking/networkmanager.go
+++ b/subsystems/networking/networkmanager.go
@@ -419,7 +419,7 @@ func (n *Networking) addOrUpdateConnection(cfg utils.NetworkDefinition) (bool, e
 		oldSettings, err = nw.conn.GetSettings()
 		if err != nil {
 			nw.conn = nil
-			n.logger.Error(errw.Wrapf(err, "getting current settings for %s", netKey))
+			n.logger.Warn(errw.Wrapf(err, "getting current settings for %s, attempting to add as new network", netKey))
 		} else if err := nw.conn.Update(settings); err != nil {
 			// we may be out of sync with NetworkManager
 			nw.conn = nil


### PR DESCRIPTION
Tiny fix, handle the case where an underlying connection has been deleted from networkmanager while running. Fix incidental lock (lack of) usage as well.