### PR TITLE
APP-7841 symlink agent binary in MSI

### DIFF
--- a/agent.wxs
+++ b/agent.wxs
@@ -17,11 +17,7 @@
                             <fire:FirewallException Id="AllowAllUDP" Name="viam-agent" Profile="all" Protocol="tcp" Scope="any" />
                         </Component>
                     </Directory>
-                    <Directory Id="BINFOLDER" Name="bin">
-                        <Component Id="MainServiceComponent" Guid="d478ceba-537c-4e49-9262-bf24ccfe4909">
-                            <CustomAction Id="Mklink" ExeCommand='cmd /c mklink viam-agent.exe ..\bin\viam-agent.exe' />
-                        </Component>
-                    </Directory>
+                    <Directory Id="BINFOLDER" Name="bin" />
                 </Directory>
             </Directory>
         </StandardDirectory>
@@ -29,5 +25,7 @@
         <Feature Id="MainFeature" Title="Main Feature" Level="1">
             <ComponentRef Id="MainServiceComponent" />
         </Feature>
+
+        <CustomAction Id="Mklink" Directory="BINFOLDER" ExeCommand='cmd /c mklink viam-agent.exe ..\bin\viam-agent.exe' />
     </Package>
 </Wix>

--- a/agent.wxs
+++ b/agent.wxs
@@ -8,13 +8,18 @@
         <StandardDirectory Id="TARGETDIR">
             <Directory Id="CustomInstallPath" Name="opt">
                 <Directory Id="ViamFolder" Name="viam">
-                    <Directory Id="INSTALLFOLDER" Name="bin">
+                    <Directory Id="CACHEFOLDER" Name="cache">
                         <Component Id="MainServiceComponent" Guid="d478ceba-537c-4e49-9262-bf24ccfe4909">
                             <File Id="ViamExe" Source="$(var.GoBinDir)\viam-agent.exe" KeyPath="yes" />
                             <ServiceInstall Id="InstallAgentervice" Name="viam-agent" DisplayName="viam-agent Service" Description="viam-agent Windows service" Start="auto" Type="ownProcess" ErrorControl="normal" Account="LocalSystem" Interactive="yes" />
                             <ServiceControl Id="ControlAgentService" Name="viam-agent" Start="install" Stop="both" Remove="uninstall" Wait="yes" />
                             <fire:FirewallException Id="AllowAllTCP" Name="viam-agent" Profile="all" Protocol="tcp" Scope="any" />
                             <fire:FirewallException Id="AllowAllUDP" Name="viam-agent" Profile="all" Protocol="tcp" Scope="any" />
+                        </Component>
+                    </Directory>
+                    <Directory Id="BINFOLDER" Name="bin">
+                        <Component Id="MainServiceComponent" Guid="d478ceba-537c-4e49-9262-bf24ccfe4909">
+                            <CustomAction Id="Mklink" ExeCommand='cmd /c mklink viam-agent.exe ..\bin\viam-agent.exe' />
                         </Component>
                     </Directory>
                 </Directory>

--- a/agent.wxs
+++ b/agent.wxs
@@ -8,8 +8,9 @@
         <StandardDirectory Id="TARGETDIR">
             <Directory Id="CustomInstallPath" Name="opt">
                 <Directory Id="ViamFolder" Name="viam">
-                    <Directory Id="CACHEFOLDER" Name="cache">
-                        <Component Id="MainServiceComponent" Guid="d478ceba-537c-4e49-9262-bf24ccfe4909">
+                    <Directory Id="CACHEFOLDER" Name="cache" />
+                    <Directory Id="BINFOLDER" Name="bin">
+                        <Component Id="binary" Guid="d478ceba-537c-4e49-9262-bf24ccfe4910">
                             <File Id="ViamExe" Source="$(var.GoBinDir)\viam-agent.exe" KeyPath="yes" />
                             <ServiceInstall Id="InstallAgentervice" Name="viam-agent" DisplayName="viam-agent Service" Description="viam-agent Windows service" Start="auto" Type="ownProcess" ErrorControl="normal" Account="LocalSystem" Interactive="yes" />
                             <ServiceControl Id="ControlAgentService" Name="viam-agent" Start="install" Stop="both" Remove="uninstall" Wait="yes" />
@@ -17,15 +18,20 @@
                             <fire:FirewallException Id="AllowAllUDP" Name="viam-agent" Profile="all" Protocol="tcp" Scope="any" />
                         </Component>
                     </Directory>
-                    <Directory Id="BINFOLDER" Name="bin" />
                 </Directory>
             </Directory>
         </StandardDirectory>
 
         <Feature Id="MainFeature" Title="Main Feature" Level="1">
-            <ComponentRef Id="MainServiceComponent" />
+            <ComponentRef Id="binary" />
         </Feature>
 
-        <CustomAction Id="Mklink" Directory="BINFOLDER" ExeCommand='cmd /c mklink viam-agent.exe ..\bin\viam-agent.exe' />
+        <CustomAction Id="MvCache" Directory="BINFOLDER" ExeCommand="cmd /c move viam-agent.exe ..\cache" />
+        <CustomAction Id="MkLink" Directory="BINFOLDER" ExeCommand="cmd /c mklink viam-agent.exe ..\cache\viam-agent.exe" />
+
+        <InstallExecuteSequence>
+            <Custom Action='MvCache' Before='MkLink' />
+            <Custom Action='MkLink' After='InstallFinalize' />
+        </InstallExecuteSequence>
     </Package>
 </Wix>


### PR DESCRIPTION
## What changed
- When installing agent-for-windows from MSI, install viam-agent.exe in cache/, symlink in bin/.
    - Note there is no native way to do symlinks in wix, *and* the ServiceInstall directive needs to point at a File entry that wix knows about. That's why the wix xml file is kind of odd now.
## Why
agent.bat and the MSI were putting the binary directly in /opt/viam/bin, which makes it impossible for agent to automatically self-upgrade.

(Because on windows the file for a running executable is locked).
## Testing
- [x] CI yaml can build an MSI https://github.com/viamrobotics/agent/actions/runs/13850097372
- [ ] MSI produced by CI yaml creates a working agent installation
    - [ ] including on device not in developer mode (because mklink is a privileged command)
- [ ] what happens when this is installed over existing msi install?