### PR TITLE
[APP-7889][APP-7791][APP-7636][APP-7946] Bluetooth Provisioning

### DIFF
--- a/cmd/provisioning-client/bluetooth.go
+++ b/cmd/provisioning-client/bluetooth.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	errw "github.com/pkg/errors"
+	"tinygo.org/x/bluetooth"
+)
+
+// Copied from subsystems/networking/bluetooth_characteristics_linux.go.
+const (
+	// Random (v4) UUID for namespace.
+	uuidNamespace = "74a942f4-0f45-43f4-88ca-f87021ae36ea"
+
+	// These values will be combined into Sha1 (v5) UUIDs along with the above namespace.
+	serviceNameKey           = "viam-provisioning"
+	ssidKey                  = "ssid"
+	pskKey                   = "psk"
+	robotPartIDKey           = "id"
+	robotPartSecretKey       = "secret"
+	appAddressKey            = "app_address"
+	availableWiFiNetworksKey = "networks"
+	statusKey                = "status"
+	errorsKey                = "errors"
+)
+
+func btClient() error {
+	adapter := bluetooth.DefaultAdapter
+
+	if err := adapter.Enable(); err != nil {
+		return err
+	}
+
+	if opts.BTScan {
+		return BTScanOnly(adapter)
+	}
+
+	device, err := connect()
+	if err != nil {
+		return errw.Wrap(err, "connecting")
+	}
+	defer disconnect(device)
+	chars, err := getCharicteristicsMap(device)
+	if err != nil {
+		return err
+	}
+
+	if opts.Status {
+		if err := BTGetStatus(chars); err != nil {
+			return err
+		}
+	}
+
+	if opts.Networks {
+		if err := BTGetNetworks(chars); err != nil {
+			return err
+		}
+	}
+
+	if opts.PartID != "" {
+		if err := BTSetDeviceCreds(chars); err != nil {
+			return err
+		}
+	}
+
+	if opts.SSID != "" {
+		if err := BTSetWifiCreds(chars); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func BTScanOnly(adapter *bluetooth.Adapter) error {
+	fmt.Println("Scanning for bluetooth devices...")
+
+	seen := make(map[string]bool)
+	var err error
+	go func() {
+		err = adapter.Scan(
+			func(adapter *bluetooth.Adapter, device bluetooth.ScanResult) {
+				if device.LocalName() != "" {
+					if seen[device.Address.String()] {
+						return
+					}
+					seen[device.Address.String()] = true
+					fmt.Printf("Found device: %s [%s]\n", device.LocalName(), device.Address.String())
+				}
+			},
+		)
+		if err != nil {
+			fmt.Printf("error while scanning: %s", err.Error())
+		}
+	}()
+
+	time.Sleep(time.Minute)
+	err2 := adapter.StopScan()
+	return errors.Join(err, err2)
+}
+
+func BTScan(adapter *bluetooth.Adapter) (bluetooth.Address, error) {
+	fmt.Printf("Searching for device name that includes filter string: %s\n", opts.BTFilter)
+	fmt.Println("Scanning...")
+
+	ch := make(chan bluetooth.ScanResult, 1)
+
+	go func() {
+		err := adapter.Scan(
+			func(adapter *bluetooth.Adapter, device bluetooth.ScanResult) {
+				if strings.Contains(device.LocalName(), opts.BTFilter) {
+					fmt.Printf("Found device: %s [%s]\n", device.LocalName(), device.Address.String())
+					ch <- device
+				}
+			},
+		)
+		if err != nil {
+			fmt.Printf("error while scanning: %s", err.Error())
+		}
+	}()
+
+	var addr bluetooth.Address
+	var good bool
+
+	select {
+	case result := <-ch:
+		good = true
+		addr = result.Address
+	case <-time.After(time.Second * 30):
+	}
+	err := adapter.StopScan()
+	if !good {
+		return addr, errors.Join(err, fmt.Errorf("failed to find device matching filter: %s", opts.BTFilter))
+	}
+
+	return addr, err
+}
+
+func BTGetStatus(chars map[string]bluetooth.DeviceCharacteristic) error {
+	buf := make([]byte, 512)
+	size, err := chars[statusKey].Read(buf)
+	if err != nil {
+		return errw.Wrap(err, "reading status")
+	}
+
+	if size != 1 {
+		return fmt.Errorf("status characteristic is the wrong size: %d", size)
+	}
+
+	// status is a bitpacked byte, bit 0=isConfigured, bit 1=isConnected is
+	var isConfigured, isConnected bool
+	switch buf[0] {
+	case 0:
+	case 1:
+		isConfigured = true
+	case 2:
+		isConnected = true
+	case 3:
+		isConfigured = true
+		isConnected = true
+	default:
+		fmt.Printf("Unknown status raw value: %d\n", buf[0])
+	}
+
+	fmt.Printf("Viam Device Status: Configured: %t, Connected: %t\n", isConfigured, isConnected)
+	return nil
+}
+
+func BTGetNetworks(chars map[string]bluetooth.DeviceCharacteristic) error {
+	buf := make([]byte, 512)
+	size, err := chars[availableWiFiNetworksKey].Read(buf)
+	if err != nil {
+		return errw.Wrap(err, "reading network list")
+	}
+
+	// networks are split on null bytes, and the first byte of each is a single bit for security, and 7 bits for signal strength (0-100)
+	nets := bytes.Split(buf[:size], []byte{0x0})
+
+	fmt.Println("Networks:")
+	for _, net := range nets {
+		if len(net) < 2 {
+			// last network gets terminated with a null, so we get one empty []byte at the end
+			continue
+		}
+
+		meta := net[0]
+		isSecure := meta > 127
+		signal := meta &^ byte(1<<7)
+		ssid := net[1:]
+		fmt.Printf("SSID: %s, Signal: %d, IsSecure: %t\n", ssid, signal, isSecure)
+	}
+	return nil
+}
+
+func BTSetDeviceCreds(chars map[string]bluetooth.DeviceCharacteristic) error {
+	fmt.Println("Writing device credentials...")
+
+	_, err := chars[robotPartIDKey].WriteWithoutResponse([]byte(opts.PartID))
+	if err != nil {
+		return errw.Wrap(err, "writing part id")
+	}
+
+	_, err = chars[robotPartSecretKey].WriteWithoutResponse([]byte(opts.Secret))
+	if err != nil {
+		return errw.Wrap(err, "writing secret")
+	}
+
+	_, err = chars[appAddressKey].WriteWithoutResponse([]byte(opts.AppAddr))
+	if err != nil {
+		return errw.Wrap(err, "writing app address")
+	}
+
+	return nil
+}
+
+func BTSetWifiCreds(chars map[string]bluetooth.DeviceCharacteristic) error {
+	fmt.Println("Writing wifi credentials...")
+	_, err := chars[ssidKey].WriteWithoutResponse([]byte(opts.SSID))
+	if err != nil {
+		return errw.Wrap(err, "writing ssid")
+	}
+
+	_, err = chars[pskKey].WriteWithoutResponse([]byte(opts.PSK))
+	if err != nil {
+		return errw.Wrap(err, "writing psk")
+	}
+	return nil
+}
+
+func getUUID(key string) bluetooth.UUID {
+	return bluetooth.NewUUID(uuid.NewSHA1(uuid.MustParse(uuidNamespace), []byte(key)))
+}
+
+func connect() (*bluetooth.Device, error) {
+	adapter := bluetooth.DefaultAdapter
+	addr, err := BTScan(adapter)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println("Connecting...")
+	device, err := adapter.Connect(addr, bluetooth.ConnectionParams{})
+	if err != nil {
+		return nil, errw.Wrap(err, "connecting device")
+	}
+	return &device, nil
+}
+
+func disconnect(device *bluetooth.Device) {
+	fmt.Println("Disconnecting...")
+	err := device.Disconnect()
+	if err != nil {
+		println(err)
+	}
+}
+
+func getCharicteristicsMap(device *bluetooth.Device) (map[string]bluetooth.DeviceCharacteristic, error) {
+	charMap := make(map[string]bluetooth.DeviceCharacteristic)
+
+	fmt.Printf("Discovering characteristics for service UUID: %s\n", getUUID(serviceNameKey))
+	srvcs, err := device.DiscoverServices([]bluetooth.UUID{getUUID(serviceNameKey)})
+	if err != nil {
+		return charMap, errw.Wrap(err, "discovering service")
+	}
+	chars, err := srvcs[0].DiscoverCharacteristics(nil)
+	if err != nil {
+		return charMap, errw.Wrap(err, "discovering characteristics")
+	}
+
+	for _, char := range chars {
+		var key string
+		switch char.UUID() {
+		case getUUID(statusKey):
+			key = statusKey
+			charMap[statusKey] = char
+		case getUUID(availableWiFiNetworksKey):
+			key = availableWiFiNetworksKey
+			charMap[availableWiFiNetworksKey] = char
+		case getUUID(errorsKey):
+			key = errorsKey
+			charMap[errorsKey] = char
+		case getUUID(ssidKey):
+			key = ssidKey
+			charMap[ssidKey] = char
+		case getUUID(pskKey):
+			key = pskKey
+			charMap[pskKey] = char
+		case getUUID(appAddressKey):
+			key = appAddressKey
+			charMap[appAddressKey] = char
+		case getUUID(robotPartIDKey):
+			key = robotPartIDKey
+			charMap[robotPartIDKey] = char
+		case getUUID(robotPartSecretKey):
+			key = robotPartSecretKey
+			charMap[robotPartSecretKey] = char
+		default:
+			fmt.Printf("Unknown characteristic discovered with UUID: %s", char.String())
+		}
+		fmt.Printf("Found: %s (%s)\n", char.UUID().String(), key)
+	}
+
+	return charMap, nil
+}

--- a/cmd/provisioning-client/grpc.go
+++ b/cmd/provisioning-client/grpc.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/viamrobotics/agent/subsystems/networking"
+	pb "go.viam.com/api/provisioning/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func grpcClient() error {
+	ctx := context.Background()
+
+	conn, err := grpc.NewClient(opts.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		fmt.Println(err)
+	}
+	defer func() {
+		err := conn.Close()
+		if err != nil {
+			fmt.Println(err)
+		}
+	}()
+
+	client := pb.NewProvisioningServiceClient(conn)
+
+	if opts.Status {
+		return GetStatus(ctx, client)
+	}
+
+	if opts.Networks {
+		return GetNetworks(ctx, client)
+	}
+
+	if opts.PartID != "" {
+		return SetDeviceCreds(ctx, client, opts.PartID, opts.Secret, opts.AppAddr)
+	}
+
+	if opts.SSID != "" {
+		return SetWifiCreds(ctx, client, opts.SSID, opts.PSK)
+	}
+	return nil
+}
+
+func GetStatus(ctx context.Context, client pb.ProvisioningServiceClient) error {
+	resp, err := client.GetSmartMachineStatus(ctx, &pb.GetSmartMachineStatusRequest{})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Online: %t, Configured: %t, Provisioning: %v, Last: %v, Errors: %s\n",
+		resp.GetIsOnline(),
+		resp.GetHasSmartMachineCredentials(),
+		resp.GetProvisioningInfo(),
+		resp.GetLatestConnectionAttempt(),
+		strings.Join(resp.GetErrors(), "\n"),
+	)
+	return nil
+}
+
+func GetNetworks(ctx context.Context, client pb.ProvisioningServiceClient) error {
+	resp, err := client.GetNetworkList(ctx, &pb.GetNetworkListRequest{})
+	if err != nil {
+		return err
+	}
+
+	for _, network := range resp.GetNetworks() {
+		fmt.Printf("SSID: %s, Signal: %d%%, Security: %s\n", network.GetSsid(), network.GetSignal(), network.GetSecurity())
+	}
+	return nil
+}
+
+func SetDeviceCreds(ctx context.Context, client pb.ProvisioningServiceClient, id, secret, appaddr string) error {
+	req := &pb.SetSmartMachineCredentialsRequest{
+		Cloud: &pb.CloudConfig{
+			Id:         id,
+			Secret:     secret,
+			AppAddress: appaddr,
+		},
+	}
+
+	_, err := client.SetSmartMachineCredentials(ctx, req)
+	return err
+}
+
+func SetWifiCreds(ctx context.Context, client pb.ProvisioningServiceClient, ssid, psk string) error {
+	req := &pb.SetNetworkCredentialsRequest{
+		Type: networking.NetworkTypeWifi,
+		Ssid: ssid,
+		Psk:  psk,
+	}
+
+	_, err := client.SetNetworkCredentials(ctx, req)
+	return err
+}

--- a/cmd/provisioning-client/main.go
+++ b/cmd/provisioning-client/main.go
@@ -1,147 +1,22 @@
 package main
 
-import (
-	"bytes"
-	"context"
-	"fmt"
-	"strings"
-
-	"github.com/jessevdk/go-flags"
-	"github.com/viamrobotics/agent/subsystems/networking"
-	pb "go.viam.com/api/provisioning/v1"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-)
+import "go.viam.com/rdk/logging"
 
 func main() {
-	ctx := context.TODO()
-
-	var opts struct {
-		Address string `description:"Address/port to dial (ex: 'localhost:4772')" long:"address" short:"a"`
-
-		SSID string `description:"SSID to set"           long:"ssid"`
-		PSK  string `description:"PSK/Password for wifi" long:"psk"`
-
-		AppAddr string `default:"https://app.viam.com:443"              description:"Cloud address to set in viam.json" long:"appaddr"`
-		PartID  string `description:"PartID to set in viam.json"        long:"partID"`
-		Secret  string `description:"Device secret to set in viam.json" long:"secret"`
-
-		Status   bool `description:"Get device status"      long:"status"   short:"s"`
-		Networks bool `description:"List networks"          long:"networks" short:"n"`
-		Help     bool `description:"Show this help message" long:"help"     short:"h"`
-	}
-
-	parser := flags.NewParser(&opts, flags.IgnoreUnknown)
-	parser.Usage = "runs as a background service and manages updates and the process lifecycle for viam-server."
-
-	_, err := parser.Parse()
-	if err != nil {
-		panic(err)
-	}
-
-	if opts.Address == "" || (opts.PartID == "" && opts.SSID == "" && !opts.Networks && !opts.Status) {
-		opts.Help = true
-	}
-
-	if opts.Help {
-		var b bytes.Buffer
-		parser.WriteHelp(&b)
-
-		fmt.Println(b.String())
+	if !parseOpts() {
 		return
 	}
 
-	if opts.PartID != "" || opts.Secret != "" {
-		if opts.PartID == "" || opts.Secret == "" || opts.AppAddr == "" {
-			fmt.Println("Error: Must set both Secret and PartID (and optionally AppAddr) at the same time!")
-			return
+	// using the logger because it handily unwraps errors for us
+	logger := logging.NewDebugLogger("provisioning-client")
+
+	if opts.BTScan || opts.BTMode {
+		if err := btClient(); err != nil {
+			logger.Error(err)
 		}
-	}
-
-	conn, err := grpc.NewClient(opts.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		fmt.Println(err)
-	}
-	defer func() {
-		err := conn.Close()
-		if err != nil {
-			fmt.Println(err)
+	} else {
+		if err := grpcClient(); err != nil {
+			logger.Error(err)
 		}
-	}()
-
-	client := pb.NewProvisioningServiceClient(conn)
-
-	if opts.Status {
-		GetStatus(ctx, client)
-	}
-
-	if opts.Networks {
-		GetNetworks(ctx, client)
-	}
-
-	if opts.PartID != "" {
-		SetDeviceCreds(ctx, client, opts.PartID, opts.Secret, opts.AppAddr)
-	}
-
-	if opts.SSID != "" {
-		SetWifiCreds(ctx, client, opts.SSID, opts.PSK)
-	}
-}
-
-func GetStatus(ctx context.Context, client pb.ProvisioningServiceClient) {
-	resp, err := client.GetSmartMachineStatus(ctx, &pb.GetSmartMachineStatusRequest{})
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	fmt.Printf("Online: %t, Configured: %t, Provisioning: %v, Last: %v, Errors: %s\n",
-		resp.GetIsOnline(),
-		resp.GetHasSmartMachineCredentials(),
-		resp.GetProvisioningInfo(),
-		resp.GetLatestConnectionAttempt(),
-		strings.Join(resp.GetErrors(), "\n"),
-	)
-}
-
-func GetNetworks(ctx context.Context, client pb.ProvisioningServiceClient) {
-	resp, err := client.GetNetworkList(ctx, &pb.GetNetworkListRequest{})
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	for _, network := range resp.GetNetworks() {
-		fmt.Printf("SSID: %s, Signal: %d%%, Security: %s\n", network.GetSsid(), network.GetSignal(), network.GetSecurity())
-	}
-}
-
-func SetDeviceCreds(ctx context.Context, client pb.ProvisioningServiceClient, id, secret, appaddr string) {
-	req := &pb.SetSmartMachineCredentialsRequest{
-		Cloud: &pb.CloudConfig{
-			Id:         id,
-			Secret:     secret,
-			AppAddress: appaddr,
-		},
-	}
-
-	_, err := client.SetSmartMachineCredentials(ctx, req)
-	if err != nil {
-		fmt.Println("Error setting device credentials ", err)
-		return
-	}
-}
-
-func SetWifiCreds(ctx context.Context, client pb.ProvisioningServiceClient, ssid, psk string) {
-	req := &pb.SetNetworkCredentialsRequest{
-		Type: networking.NetworkTypeWifi,
-		Ssid: ssid,
-		Psk:  psk,
-	}
-
-	_, err := client.SetNetworkCredentials(ctx, req)
-	if err != nil {
-		fmt.Println("Error setting wifi credentials ", err)
-		return
 	}
 }

--- a/cmd/provisioning-client/opts.go
+++ b/cmd/provisioning-client/opts.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/jessevdk/go-flags"
+)
+
+var opts struct {
+	BTMode   bool   `description:"Bluetooth Mode" long:"bluetooth"                           short:"b"`
+	BTScan   bool   `description:"Bluetooth Scan" long:"scan"`
+	BTFilter string `default:"viam-setup"         description:"Bluetooth Device Name Prefix" long:"filter" short:"f"`
+
+	Address string `description:"GRPC address/port to dial (ex: 'localhost:4772')" long:"address" short:"a"`
+
+	SSID string `description:"SSID to set"           long:"ssid"`
+	PSK  string `description:"PSK/Password for wifi" long:"psk"`
+
+	AppAddr string `default:"https://app.viam.com:443"              description:"Cloud address to set in viam.json" long:"appaddr"`
+	PartID  string `description:"PartID to set in viam.json"        long:"partID"`
+	Secret  string `description:"Device secret to set in viam.json" long:"secret"`
+
+	Status   bool `description:"Get device status"      long:"status"   short:"s"`
+	Networks bool `description:"List networks"          long:"networks" short:"n"`
+	Help     bool `description:"Show this help message" long:"help"     short:"h"`
+}
+
+func parseOpts() bool {
+	parser := flags.NewParser(&opts, flags.IgnoreUnknown)
+	parser.Usage = "runs as a background service and manages updates and the process lifecycle for viam-server."
+
+	_, err := parser.Parse()
+	if err != nil {
+		panic(err)
+	}
+
+	if (!opts.BTScan && !opts.BTMode) && (opts.Address == "" || (opts.PartID == "" && opts.SSID == "" && !opts.Networks && !opts.Status)) {
+		opts.Help = true
+	}
+
+	if opts.Help {
+		var b bytes.Buffer
+		parser.WriteHelp(&b)
+
+		fmt.Println(b.String())
+		return false
+	}
+
+	if opts.PartID != "" || opts.Secret != "" {
+		if opts.PartID == "" || opts.Secret == "" || opts.AppAddr == "" {
+			fmt.Println("Error: Must set both Secret and PartID (and optionally AppAddr) at the same time!")
+			return false
+		}
+	}
+
+	return true
+}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	golang.org/x/sys v0.30.0
 	google.golang.org/grpc v1.67.1
 	google.golang.org/protobuf v1.35.1
+	tinygo.org/x/bluetooth v0.11.0
 )
 
 require (
@@ -32,6 +33,7 @@ require (
 	github.com/dgottlieb/smarty-assertions v1.2.6 // indirect
 	github.com/edaniels/golog v0.0.0-20230215213219-28954395e8d0 // indirect
 	github.com/edaniels/zeroconf v1.0.10 // indirect
+	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/godbus/dbus/v5 v5.1.1-0.20241109141230-b9236d654833 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
@@ -69,8 +71,14 @@ require (
 	github.com/pion/turn/v2 v2.1.6 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.11.1 // indirect
+	github.com/saltosystems/winrt-go v0.0.0-20240509164145-4f7860a3bd2b // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/soypat/cyw43439 v0.0.0-20241116210509-ae1ce0e084c5 // indirect
+	github.com/soypat/seqs v0.0.0-20240527012110-1201bab640ef // indirect
 	github.com/srikrsna/protoc-gen-gotag v0.6.2 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
+	github.com/tinygo-org/cbgo v0.0.4 // indirect
+	github.com/tinygo-org/pio v0.0.0-20231216154340-cd888eb58899 // indirect
 	github.com/viamrobotics/webrtc/v3 v3.99.10 // indirect
 	github.com/wlynxg/anet v0.0.3 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
@@ -83,6 +91,7 @@ require (
 	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.35.0 // indirect
+	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.36.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,8 @@ github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ4
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
+github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
+github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
@@ -579,6 +581,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryancurrah/gomodguard v1.2.0/go.mod h1:rNqbC4TOIdUDcVMSIpNNAzTbzXAZa6W5lnUepvuMMgQ=
 github.com/ryanrolds/sqlclosecheck v0.3.0/go.mod h1:1gREqxyTGR3lVtpngyFo3hZAgk0KCtEdgEkHwDbigdA=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/saltosystems/winrt-go v0.0.0-20240509164145-4f7860a3bd2b h1:du3zG5fd8snsFN6RBoLA7fpaYV9ZQIsyH9snlk2Zvik=
+github.com/saltosystems/winrt-go v0.0.0-20240509164145-4f7860a3bd2b/go.mod h1:CIltaIm7qaANUIvzr0Vmz71lmQMAIbGJ7cvgzX7FMfA=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sanposhiho/wastedassign v0.1.3/go.mod h1:LGpq5Hsv74QaqM47WtIsRSF/ik9kqk07kchgv66tLVE=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -592,15 +596,22 @@ github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOms
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.0/go.mod h1:4GuYW9TZmE769R5STWrRakJc4UqQ3+QQ95fyz7ENv1A=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sonatard/noctx v0.0.1/go.mod h1:9D2D/EoULe8Yy2joDHJj7bv3sZoq9AaSb8B4lqBjiZI=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
+github.com/soypat/cyw43439 v0.0.0-20241116210509-ae1ce0e084c5 h1:arwJFX1x5zq+wUp5ADGgudhMQEXKNMQOmTh+yYgkwzw=
+github.com/soypat/cyw43439 v0.0.0-20241116210509-ae1ce0e084c5/go.mod h1:1Otjk6PRhfzfcVHeWMEeku/VntFqWghUwuSQyivb2vE=
+github.com/soypat/seqs v0.0.0-20240527012110-1201bab640ef h1:phH95I9wANjTYw6bSYLZDQfNvao+HqYDom8owbNa0P4=
+github.com/soypat/seqs v0.0.0-20240527012110-1201bab640ef/go.mod h1:oCVCNGCHMKoBj97Zp9znLbQ1nHxpkmOY9X+UAGzOxc8=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
@@ -645,6 +656,10 @@ github.com/tetafro/godot v1.4.4/go.mod h1:FVDd4JuKliW3UgjswZfJfHq4vAx0bD/Jd5brJj
 github.com/tidwall/jsonc v0.3.2 h1:ZTKrmejRlAJYdn0kcaFqRAKlxxFIC21pYq8vLa4p2Wc=
 github.com/tidwall/jsonc v0.3.2/go.mod h1:dw+3CIxqHi+t8eFSpzzMlcVYxKp08UP5CD8/uSFCyJE=
 github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
+github.com/tinygo-org/cbgo v0.0.4 h1:3D76CRYbH03Rudi8sEgs/YO0x3JIMdyq8jlQtk/44fU=
+github.com/tinygo-org/cbgo v0.0.4/go.mod h1:7+HgWIHd4nbAz0ESjGlJ1/v9LDU1Ox8MGzP9mah/fLk=
+github.com/tinygo-org/pio v0.0.0-20231216154340-cd888eb58899 h1:/DyaXDEWMqoVUVEJVJIlNk1bXTbFs8s3Q4GdPInSKTQ=
+github.com/tinygo-org/pio v0.0.0-20231216154340-cd888eb58899/go.mod h1:LU7Dw00NJ+N86QkeTGjMLNkYcEYMor6wTDpTCu0EaH8=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomarrell/wrapcheck v0.0.0-20201130113247-1683564d9756/go.mod h1:yiFB6fFoV7saXirUGfuK+cPtUh4NX/Hf5y2WC2lehu0=
@@ -758,6 +773,8 @@ golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxT
 golang.org/x/exp v0.0.0-20190829153037-c13cbed26979/go.mod h1:86+5VVa7VpoJ4kLfm080zCjGlMRFzhUhsZKEZO7MGek=
 golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
+golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e h1:I88y4caeGeuDQxgdoFPUq097j7kNfw6uvuiNxUBfcBk=
+golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -862,6 +879,7 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -888,6 +906,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1107,3 +1126,5 @@ nhooyr.io/websocket v1.8.9/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
+tinygo.org/x/bluetooth v0.11.0 h1:32ludjNnqz6RyVRpmw2qgod7NvDePbBTWXkJm6jj4cg=
+tinygo.org/x/bluetooth v0.11.0/go.mod h1:XLRopLvxWmIbofpZSXc7BGGCpgFOV5lrZ1i/DQN0BCw=

--- a/manager.go
+++ b/manager.go
@@ -182,6 +182,10 @@ func (m *Manager) SubsystemUpdates(ctx context.Context) {
 		m.logger.Error(err)
 	}
 	if needRestart {
+		_, err := InstallNewVersion(ctx, m.logger)
+		if err != nil {
+			m.logger.Errorw("running install of new agent version", "error", err)
+		}
 		m.logger.Info("viam-agent update complete, please restart using 'systemctl restart viam-agent'")
 	}
 

--- a/subsystems/networking/bluetooth_characteristics_linux.go
+++ b/subsystems/networking/bluetooth_characteristics_linux.go
@@ -16,6 +16,7 @@ const (
 	uuidNamespace = "74a942f4-0f45-43f4-88ca-f87021ae36ea"
 
 	// These values will be combined into Sha1 (v5) UUIDs along with the above namespace.
+	serviceNameKey           = "viam-provisioning"
 	ssidKey                  = "ssid"
 	pskKey                   = "psk"
 	robotPartIDKey           = "id"
@@ -23,7 +24,6 @@ const (
 	appAddressKey            = "app_address"
 	availableWiFiNetworksKey = "networks"
 	statusKey                = "status"
-	serviceNameKey           = "viam-provisioning"
 	errorsKey                = "errors"
 )
 
@@ -85,7 +85,7 @@ func (b *btCharacteristics) initWOCharacteristic(cName string) bluetooth.Charact
 	b.logger.Debugf("%s can be written to BT characteristic: %s", cName, cUUID.String())
 	return bluetooth.CharacteristicConfig{
 		UUID:  cUUID,
-		Flags: bluetooth.CharacteristicWritePermission,
+		Flags: bluetooth.CharacteristicWritePermission | bluetooth.CharacteristicWriteWithoutResponsePermission,
 
 		// WriteEvent is triggered by BT, and we store it in the valuesByName map
 		WriteEvent: func(client bluetooth.Connection, offset int, value []byte) {
@@ -106,7 +106,7 @@ func (b *btCharacteristics) initROCharacteristic(cName string) bluetooth.Charact
 	return bluetooth.CharacteristicConfig{
 		Handle: &bluetooth.Characteristic{},
 		UUID:   cUUID,
-		Flags:  bluetooth.CharacteristicReadPermission,
+		Flags:  bluetooth.CharacteristicReadPermission | bluetooth.CharacteristicNotifyPermission,
 	}
 }
 

--- a/subsystems/networking/bluetooth_characteristics_linux.go
+++ b/subsystems/networking/bluetooth_characteristics_linux.go
@@ -120,7 +120,7 @@ func (b *btCharacteristics) initWOCharacteristic(cName string) bluetooth.Charact
 
 			plaintext, err := b.decrypt(value)
 			if err != nil {
-				b.logger.Errorf("could not decrypt incoming value for %s: %w", cName, err)
+				b.logger.Error(fmt.Errorf("could not decrypt incoming value for %s: %w", cName, err))
 			}
 
 			b.values[cName] = string(plaintext)

--- a/subsystems/networking/bluetooth_characteristics_linux.go
+++ b/subsystems/networking/bluetooth_characteristics_linux.go
@@ -1,0 +1,239 @@
+package networking
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"go.viam.com/rdk/logging"
+	"tinygo.org/x/bluetooth"
+)
+
+const (
+	// Random (v4) UUID for namespace.
+	uuidNamespace = "74a942f4-0f45-43f4-88ca-f87021ae36ea"
+
+	// These values will be combined into Sha1 (v5) UUIDs along with the above namespace.
+	ssidKey                  = "ssid"
+	pskKey                   = "psk"
+	robotPartIDKey           = "id"
+	robotPartSecretKey       = "secret"
+	appAddressKey            = "app_address"
+	availableWiFiNetworksKey = "networks"
+	statusKey                = "status"
+	serviceNameKey           = "viam-provisioning"
+	errorsKey                = "errors"
+)
+
+var (
+	characteristicsWO = []string{ssidKey, pskKey, robotPartIDKey, robotPartSecretKey, appAddressKey}
+	characteristicsRO = []string{statusKey, availableWiFiNetworksKey, errorsKey}
+)
+
+type btCharacteristics struct {
+	logger logging.Logger
+
+	// Used to store user input values written to this bluetooth service.
+	mu        sync.RWMutex
+	values    map[string]string
+	writables map[string]*bluetooth.Characteristic
+
+	workers sync.WaitGroup
+	cancel  context.CancelFunc
+	health  *health
+}
+
+func newBTCharacteristics(logger logging.Logger) *btCharacteristics {
+	return &btCharacteristics{
+		logger: logger,
+		values: map[string]string{
+			ssidKey:            "",
+			pskKey:             "",
+			robotPartIDKey:     "",
+			robotPartSecretKey: "",
+			appAddressKey:      "",
+		},
+		writables: map[string]*bluetooth.Characteristic{},
+		health:    &health{},
+	}
+}
+
+func (b *btCharacteristics) initCharacteristics() []bluetooth.CharacteristicConfig {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var charList []bluetooth.CharacteristicConfig
+	for _, char := range characteristicsWO {
+		charList = append(charList, b.initWOCharacteristic(char))
+	}
+
+	for _, char := range characteristicsRO {
+		cfg := b.initROCharacteristic(char)
+		charList = append(charList, cfg)
+		b.writables[char] = cfg.Handle
+	}
+
+	return charList
+}
+
+// initWOCharacteristic returns a bluetooth characteristic config.
+func (b *btCharacteristics) initWOCharacteristic(cName string) bluetooth.CharacteristicConfig {
+	// Generate predictable (v5) UUID from common namespace+cName
+	cUUID := bluetooth.NewUUID(uuid.NewSHA1(uuid.MustParse(uuidNamespace), []byte(cName)))
+
+	b.logger.Debugf("%s can be written to BT characteristic: %s", cName, cUUID.String())
+	return bluetooth.CharacteristicConfig{
+		UUID:  cUUID,
+		Flags: bluetooth.CharacteristicWritePermission,
+
+		// WriteEvent is triggered by BT, and we store it in the valuesByName map
+		WriteEvent: func(client bluetooth.Connection, offset int, value []byte) {
+			b.logger.Infof("Received %s: %s", cName, value)
+			b.mu.Lock()
+			defer b.mu.Unlock()
+			b.values[cName] = string(value)
+		},
+	}
+}
+
+// initROCharacteristic returns a bluetooth characteristic config.
+func (b *btCharacteristics) initROCharacteristic(cName string) bluetooth.CharacteristicConfig {
+	// Generate predictable (v5) UUID from common namespace+cName
+	cUUID := bluetooth.NewUUID(uuid.NewSHA1(uuid.MustParse(uuidNamespace), []byte(cName)))
+
+	b.logger.Debugf("%s can be read from BT characteristic: %s", cName, cUUID.String())
+	return bluetooth.CharacteristicConfig{
+		Handle: &bluetooth.Characteristic{},
+		UUID:   cUUID,
+		Flags:  bluetooth.CharacteristicReadPermission,
+	}
+}
+
+func (b *btCharacteristics) writeCharacteristic(cName string, value []byte) error {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	char, ok := b.writables[cName]
+	if !ok {
+		return fmt.Errorf("no writable characteristic named %s", cName)
+	}
+	_, err := char.Write(value)
+	return err
+}
+
+func (b *btCharacteristics) readCharacteristic(cName string) string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	value, ok := b.values[cName]
+	if !ok {
+		b.logger.Warnf("no readable characteristic named %s", cName)
+		return ""
+	}
+	return value
+}
+
+func (b *btCharacteristics) updateNetworks(networks []NetworkInfo) error {
+	// Writes are capped at a maximum of 512 bytes (bluetooth-low-energy protocol defines this behavior).
+	var msg []byte
+	for _, network := range networks {
+		remainingBytes := 512 - len(msg)
+		// Can convert network
+		if network.Signal > 100 {
+			network.Signal = 100
+		}
+		if network.Signal < 0 {
+			network.Signal = 0
+		}
+		meta := uint8(network.Signal)
+		if network.Security != "" && network.Security != "-" {
+			meta |= (1 << 7)
+		}
+		compressedNetwork := []byte{meta}
+		compressedNetwork = append(compressedNetwork, []byte(network.SSID)...)
+		compressedNetwork = append(compressedNetwork, 0x0)
+
+		// Break from loop if we don't have the space
+		if len(compressedNetwork) > remainingBytes {
+			break
+		}
+		msg = append(msg, compressedNetwork...)
+	}
+	return b.writeCharacteristic(availableWiFiNetworksKey, msg)
+}
+
+func (b *btCharacteristics) updateStatus(isConfigured, isConnected bool) error {
+	var status uint8
+	if isConfigured {
+		status = 0b00000001
+	}
+	if isConnected {
+		status |= 0b00000010
+	}
+	return b.writeCharacteristic(statusKey, []byte{status})
+}
+
+func (b *btCharacteristics) updateErrors(errList []string) error {
+	var msg []byte
+	for _, e := range errList {
+		remainingBytes := 512 - len(msg)
+		newErr := []byte(e)
+		newErr = append(newErr, 0x0)
+
+		// Break from loop if we don't have the space
+		if len(newErr) > remainingBytes {
+			break
+		}
+		msg = append(msg, newErr...)
+	}
+	return b.writeCharacteristic(errorsKey, msg)
+}
+
+// startBTLoop returns credentials, the minimum required information to provision a robot and/or its WiFi.
+func (b *btCharacteristics) startBTLoop(ctx context.Context, inputChan chan<- userInput) {
+	input := &userInput{}
+	ctx, b.cancel = context.WithCancel(ctx)
+	b.health.MarkGood()
+	b.workers.Add(1)
+	go func() {
+		defer b.workers.Done()
+		for {
+			// If new values are provided, persist them to in-memory storage.
+			input.SSID = b.readCharacteristic(ssidKey)
+			input.PSK = b.readCharacteristic(pskKey)
+
+			input.PartID = b.readCharacteristic(robotPartIDKey)
+			input.Secret = b.readCharacteristic(robotPartSecretKey)
+			input.AppAddr = b.readCharacteristic(appAddressKey)
+
+			// If we've received a "set" of required credentials, pass them through inputChan.
+			hasWifiInput := input.SSID != "" && input.PSK != ""
+			hasCredInput := input.AppAddr != "" && input.PartID != "" && input.Secret != ""
+
+			if hasWifiInput || hasCredInput {
+				inputChan <- *input
+				if hasWifiInput {
+					// reset for next round
+					input.SSID = ""
+					input.PSK = ""
+				}
+				if hasCredInput {
+					input.AppAddr = ""
+					input.PartID = ""
+					input.Secret = ""
+				}
+			}
+
+			// If we haven't received all required credentials, sleep and try again.
+			if !b.health.Sleep(ctx, time.Second*5) {
+				return
+			}
+		}
+	}()
+}
+
+func (b *btCharacteristics) stopBTLoop() {
+	if b.cancel != nil {
+		b.cancel()
+	}
+	b.workers.Wait()
+}

--- a/subsystems/networking/bluetooth_characteristics_linux.go
+++ b/subsystems/networking/bluetooth_characteristics_linux.go
@@ -34,8 +34,8 @@ const (
 )
 
 var (
-	characteristicsWO = []string{ssidKey, pskKey, robotPartIDKey, robotPartSecretKey, appAddressKey}
-	characteristicsRO = []string{cryptoKey, statusKey, availableWiFiNetworksKey, errorsKey}
+	characteristicsWriteOnly = []string{ssidKey, pskKey, robotPartIDKey, robotPartSecretKey, appAddressKey}
+	characteristicsReadOnly  = []string{cryptoKey, statusKey, availableWiFiNetworksKey, errorsKey}
 )
 
 type btCharacteristics struct {
@@ -72,12 +72,12 @@ func (b *btCharacteristics) initCharacteristics() []bluetooth.CharacteristicConf
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	var charList []bluetooth.CharacteristicConfig
-	for _, char := range characteristicsWO {
-		charList = append(charList, b.initWOCharacteristic(char))
+	for _, char := range characteristicsWriteOnly {
+		charList = append(charList, b.initWriteOnlyCharacteristic(char))
 	}
 
-	for _, char := range characteristicsRO {
-		cfg := b.initROCharacteristic(char)
+	for _, char := range characteristicsReadOnly {
+		cfg := b.initReadOnlyCharacteristic(char)
 		charList = append(charList, cfg)
 		b.writables[char] = cfg.Handle
 	}
@@ -103,8 +103,8 @@ func (b *btCharacteristics) initCrypto() error {
 	return err
 }
 
-// initWOCharacteristic returns a bluetooth characteristic config.
-func (b *btCharacteristics) initWOCharacteristic(cName string) bluetooth.CharacteristicConfig {
+// initWriteOnlyCharacteristic returns a bluetooth characteristic config.
+func (b *btCharacteristics) initWriteOnlyCharacteristic(cName string) bluetooth.CharacteristicConfig {
 	// Generate predictable (v5) UUID from common namespace+cName
 	cUUID := bluetooth.NewUUID(uuid.NewSHA1(uuid.MustParse(uuidNamespace), []byte(cName)))
 
@@ -129,8 +129,8 @@ func (b *btCharacteristics) initWOCharacteristic(cName string) bluetooth.Charact
 	}
 }
 
-// initROCharacteristic returns a bluetooth characteristic config.
-func (b *btCharacteristics) initROCharacteristic(cName string) bluetooth.CharacteristicConfig {
+// initReadOnlyCharacteristic returns a bluetooth characteristic config.
+func (b *btCharacteristics) initReadOnlyCharacteristic(cName string) bluetooth.CharacteristicConfig {
 	// Generate predictable (v5) UUID from common namespace+cName
 	cUUID := bluetooth.NewUUID(uuid.NewSHA1(uuid.MustParse(uuidNamespace), []byte(cName)))
 

--- a/subsystems/networking/bluetooth_linux.go
+++ b/subsystems/networking/bluetooth_linux.go
@@ -71,9 +71,6 @@ func (n *Networking) initializeBluetoothService(deviceName string, characteristi
 	if err := adapter.AddService(&bluetooth.Service{UUID: serviceUUID, Characteristics: characteristics}); err != nil {
 		return fmt.Errorf("unable to add bluetooth service to default adapter: %w", err)
 	}
-	// if err := adapter.Enable(); err != nil {
-	// 	return nil, fmt.Errorf("failed to enable bluetooth adapter: %w", err)
-	// }
 	adv := adapter.DefaultAdvertisement()
 	opts := bluetooth.AdvertisementOptions{
 		LocalName:    deviceName,

--- a/subsystems/networking/bluetooth_linux.go
+++ b/subsystems/networking/bluetooth_linux.go
@@ -1,0 +1,86 @@
+package networking
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"tinygo.org/x/bluetooth"
+)
+
+// startProvisioningBluetooth should only be called by 'StartProvisioning' (to ensure opMutex is acquired).
+func (n *Networking) startProvisioningBluetooth(ctx context.Context, inputChan chan<- userInput) error {
+	if n.Config().DisableBTProvisioning || n.noBT {
+		return nil
+	}
+	if n.btAdv != nil {
+		return errors.New("invalid request, advertising already active")
+	}
+
+	// Create a bluetooth service comprised of the above configs.
+	if err := n.initializeBluetoothService(n.Config().HotspotSSID, n.btChar.initCharacteristics()); err != nil {
+		n.noBT = true
+		return fmt.Errorf("failed to initialize bluetooth service: %w", err)
+	}
+
+	// Update bluetooth read-only characteristics
+	if err := n.btChar.updateStatus(n.connState.getConfigured(), n.connState.getConnected() || n.connState.getOnline()); err != nil {
+		n.logger.Warn("could not update BT status characteristic")
+	}
+	if err := n.btChar.updateNetworks(n.getVisibleNetworks()); err != nil {
+		n.logger.Warn("could not update BT networks characteristic")
+	}
+
+	// Start the loop that monitors for BT writes.
+	n.btChar.startBTLoop(ctx, inputChan)
+
+	// Start advertising the bluetooth service.
+	if err := n.btAdv.Start(); err != nil {
+		return fmt.Errorf("failed to start advertising: %w", err)
+	}
+
+	n.logger.Info("Bluetooth provisioning started.")
+	return nil
+}
+
+// stop stops advertising a bluetooth service which (when enabled) accepts WiFi and Viam cloud config credentials.
+func (n *Networking) stopProvisioningBluetooth() error {
+	if n.btAdv == nil {
+		return nil
+	}
+	if err := n.btAdv.Stop(); err != nil {
+		return fmt.Errorf("failed to stop BT advertising: %w", err)
+	}
+	n.btAdv = nil
+	n.btChar.stopBTLoop()
+	n.logger.Debug("Stopped advertising bluetooth service.")
+	return nil
+}
+
+// initializeBluetoothService performs low-level system configuration to enable bluetooth advertisement.
+func (n *Networking) initializeBluetoothService(deviceName string, characteristics []bluetooth.CharacteristicConfig) error {
+	serviceUUID := bluetooth.NewUUID(uuid.NewSHA1(uuid.MustParse(uuidNamespace), []byte(serviceNameKey)))
+
+	adapter := bluetooth.DefaultAdapter
+	if err := adapter.Enable(); err != nil {
+		return fmt.Errorf("failed to enable bluetooth adapter: %w", err)
+	}
+	if err := adapter.AddService(&bluetooth.Service{UUID: serviceUUID, Characteristics: characteristics}); err != nil {
+		return fmt.Errorf("unable to add bluetooth service to default adapter: %w", err)
+	}
+	// if err := adapter.Enable(); err != nil {
+	// 	return nil, fmt.Errorf("failed to enable bluetooth adapter: %w", err)
+	// }
+	adv := adapter.DefaultAdvertisement()
+	opts := bluetooth.AdvertisementOptions{
+		LocalName:    deviceName,
+		ServiceUUIDs: []bluetooth.UUID{serviceUUID},
+	}
+	if err := adv.Configure(opts); err != nil {
+		return fmt.Errorf("failed to configure default advertisement: %w", err)
+	}
+	n.btAdv = adv
+	n.logger.Debugf("Bluetooth service UUID: %s.", serviceUUID.String())
+	return nil
+}

--- a/subsystems/networking/bluetooth_linux.go
+++ b/subsystems/networking/bluetooth_linux.go
@@ -82,6 +82,11 @@ func (n *Networking) initializeBluetoothService(deviceName string, characteristi
 	if err := adv.Configure(opts); err != nil {
 		return fmt.Errorf("failed to configure default advertisement: %w", err)
 	}
+	err := n.btChar.initCrypto()
+	if err != nil {
+		return err
+	}
+
 	n.btAdv = adv
 	n.logger.Debugf("Bluetooth service UUID: %s.", serviceUUID.String())
 	return nil

--- a/subsystems/networking/definitions_linux.go
+++ b/subsystems/networking/definitions_linux.go
@@ -219,14 +219,6 @@ func (h *health) MarkGood() {
 	h.last = time.Now()
 }
 
-func (h *health) MarkBad() {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	// Fast-forward to make this health expire now.
-	h.last = time.Now().Add(-1 * HealthCheckTimeout)
-}
-
 func (h *health) Sleep(ctx context.Context, timeout time.Duration) bool {
 	select {
 	case <-ctx.Done():

--- a/subsystems/networking/definitions_linux.go
+++ b/subsystems/networking/definitions_linux.go
@@ -219,6 +219,14 @@ func (h *health) MarkGood() {
 	h.last = time.Now()
 }
 
+func (h *health) MarkBad() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// Fast-forward to make this health expire now.
+	h.last = time.Now().Add(-1 * HealthCheckTimeout)
+}
+
 func (h *health) Sleep(ctx context.Context, timeout time.Duration) bool {
 	select {
 	case <-ctx.Done():

--- a/subsystems/networking/definitions_linux.go
+++ b/subsystems/networking/definitions_linux.go
@@ -28,6 +28,10 @@ const (
 	wifiPowerSaveContentsDefault = "# This file intentionally left blank.\n"
 	wifiPowerSaveContentsDisable = "[connection]\n# Explicitly disable\nwifi.powersave = 2\n"
 	wifiPowerSaveContentsEnable  = "[connection]\n# Explicitly enable\nwifi.powersave = 3\n"
+
+	BTDiscoveryFilepath        = "/etc/bluetooth/viam-disable-reverse-discovery.conf"
+	BTDiscoveryContentsDefault = "# This file intentionally left blank.\n"
+	BTDiscoveryContentsDisable = "[General]\n# Explicitly disable\nReverseServiceDiscovery = false\n"
 )
 
 var (

--- a/subsystems/networking/networking_linux.go
+++ b/subsystems/networking/networking_linux.go
@@ -217,6 +217,10 @@ func (n *Networking) Start(ctx context.Context) error {
 		n.logger.Error(errw.Wrap(err, "applying wifi power save configuration"))
 	}
 
+	if err := n.writeBTDisableDiscovery(ctx); err != nil {
+		n.logger.Error(errw.Wrap(err, "applying bluetooth configuration"))
+	}
+
 	n.processAdditionalnetworks(ctx)
 
 	if err := n.checkOnline(true); err != nil {

--- a/subsystems/networking/networking_linux.go
+++ b/subsystems/networking/networking_linux.go
@@ -2,7 +2,6 @@ package networking
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"reflect"
 	"sync"
@@ -16,6 +15,7 @@ import (
 	pb "go.viam.com/api/provisioning/v1"
 	"go.viam.com/rdk/logging"
 	"google.golang.org/grpc"
+	"tinygo.org/x/bluetooth"
 )
 
 type Networking struct {
@@ -42,6 +42,7 @@ type Networking struct {
 
 	mainLoopHealth *health
 	bgLoopHealth   *health
+	btLoopHealth   *health
 
 	// locking for config updates
 	dataMu sync.Mutex
@@ -52,6 +53,11 @@ type Networking struct {
 	webServer  *http.Server
 	grpcServer *grpc.Server
 	portalData *portalData
+
+	// bluetooth
+	noBT   bool
+	btChar *btCharacteristics
+	btAdv  *bluetooth.Advertisement
 
 	pb.UnimplementedProvisioningServiceServer
 }
@@ -69,22 +75,23 @@ func NewSubsystem(ctx context.Context, logger logging.Logger, cfg utils.AgentCon
 		banner:     &banner{},
 		portalData: &portalData{},
 
+		btChar: newBTCharacteristics(logger),
+
 		mainLoopHealth: &health{},
 		bgLoopHealth:   &health{},
+		btLoopHealth:   &health{},
 	}
 }
 
 func (n *Networking) getNM() (gnm.NetworkManager, error) {
 	nm, err := gnm.NewNetworkManager()
 	if err != nil {
-		n.noNM = true
 		n.logger.Error(err)
 		return nil, ErrNM
 	}
 
 	ver, err := nm.GetPropertyVersion()
 	if err != nil {
-		n.noNM = true
 		n.logger.Error(err)
 		return nil, ErrNM
 	}
@@ -93,13 +100,11 @@ func (n *Networking) getNM() (gnm.NetworkManager, error) {
 
 	sv, err := semver.NewVersion(ver)
 	if err != nil {
-		n.noNM = true
 		n.logger.Error(err)
 		return nil, ErrNM
 	}
 
 	if !sv.GreaterThanEqual(semver.MustParse("1.30.0")) {
-		n.noNM = true
 		return nil, ErrNM
 	}
 
@@ -108,13 +113,11 @@ func (n *Networking) getNM() (gnm.NetworkManager, error) {
 	if sv.GreaterThanEqual(semver.MustParse("1.38.0")) {
 		flags, err := nm.GetPropertyRadioFlags()
 		if err != nil {
-			n.noNM = true
 			n.logger.Error(err)
 			return nil, ErrNoWifi
 		}
 
 		if flags&gnm.NmRadioFlagsWlanAvailable != gnm.NmRadioFlagsWlanAvailable {
-			n.noNM = true
 			return nil, ErrNoWifi
 		}
 	}
@@ -128,6 +131,7 @@ func (n *Networking) init(ctx context.Context) error {
 
 	nm, err := n.getNM()
 	if err != nil {
+		n.noNM = true
 		return err
 	}
 
@@ -154,9 +158,7 @@ func (n *Networking) init(ctx context.Context) error {
 	}
 
 	if err := n.initDevices(); err != nil {
-		if errors.Is(err, ErrNoWifi) {
-			n.noNM = true
-		}
+		n.noNM = true
 		return err
 	}
 
@@ -200,7 +202,7 @@ func (n *Networking) init(ctx context.Context) error {
 func (n *Networking) Start(ctx context.Context) error {
 	n.opMu.Lock()
 	defer n.opMu.Unlock()
-	if n.running {
+	if n.running || n.noNM {
 		return nil
 	}
 	n.logger.Debugf("Starting networking")
@@ -221,14 +223,18 @@ func (n *Networking) Start(ctx context.Context) error {
 		n.logger.Error(err)
 	}
 
-	cancelCtx, cancel := context.WithCancel(ctx)
-	n.cancel = cancel
+	if !n.Config().DisableBTProvisioning || !n.Config().DisableWifiProvisioning {
+		cancelCtx, cancel := context.WithCancel(ctx)
+		n.cancel = cancel // This will loop indefinitely until context cancellation or serious error
+		n.monitorWorkers.Add(1)
+		n.mainLoopHealth.MarkGood()
+		n.bgLoopHealth.MarkGood()
+		go n.mainLoop(cancelCtx)
+	} else {
+		n.logger.Warn("Both wifi and bluetooth provisioning have been disabled by configuration. Provisioning will not be available.")
+	}
 
-	// This will loop indefinitely until context cancellation or serious error
-	n.monitorWorkers.Add(1)
-	go n.mainLoop(cancelCtx)
-
-	n.logger.Info("networking startup complete")
+	n.logger.Info("Networking startup complete")
 	n.running = true
 	return nil
 }
@@ -299,15 +305,16 @@ func (n *Networking) Update(ctx context.Context, cfg utils.AgentConfig) (needRes
 func (n *Networking) HealthCheck(ctx context.Context) error {
 	n.opMu.Lock()
 	defer n.opMu.Unlock()
-	if n.noNM {
+	if n.noNM || (n.Config().DisableBTProvisioning && n.Config().DisableWifiProvisioning) {
 		return nil
 	}
 
-	if n.bgLoopHealth.IsHealthy() && n.mainLoopHealth.IsHealthy() {
+	if n.bgLoopHealth.IsHealthy() && n.mainLoopHealth.IsHealthy() &&
+		(n.noBT || n.btAdv == nil || n.btChar.health.IsHealthy()) {
 		return nil
 	}
 
-	return errw.New("provisioning not responsive")
+	return errw.New("networking system not responsive")
 }
 
 func (n *Networking) Config() utils.NetworkConfiguration {

--- a/utils/config.go
+++ b/utils/config.go
@@ -49,6 +49,8 @@ var (
 			RetryConnectionTimeoutMinutes:       Timeout(time.Minute * 10),
 			DeviceRebootAfterOfflineMinutes:     Timeout(0),
 			HotspotSSID:                         "",
+			DisableBTProvisioning:               false,
+			DisableWifiProvisioning:             false,
 		},
 		AdditionalNetworks{},
 	}
@@ -144,6 +146,10 @@ type NetworkConfiguration struct {
 	// If set, will reboot the device after it has been offline for this duration
 	// 0, default, will disable this feature.
 	DeviceRebootAfterOfflineMinutes Timeout `json:"device_reboot_after_offline_minutes,omitempty"`
+
+	// Disable flags for provisioning types.
+	DisableBTProvisioning   bool `json:"disable_bt_provisioning,omitempty"`
+	DisableWifiProvisioning bool `json:"disable_wifi_provisioning,omitempty"`
 }
 
 type AdditionalNetworks map[string]NetworkDefinition


### PR DESCRIPTION
Update 03-28: I believe this is now feature complete. I've added full bluetooth functionality to cmd/provisioning-client and validated it works at least linux->linux.

Set the following in the agent version control:
EDIT: Updated to ble.3 rev as of 03-28 afternoon

Added encryption for all client>device writes, using rsa.OAEP, and encoding the public key with x509 PKIX (ASN.1 DER)

```
  "agent": "http://packages.viam.com/temp/viam-agent-v0.16.0-ble.3-aarch64"
```

Outstanding issues:
* ~Automatic pairing: Not working on Android, may not be required at all, need to investigate further. Removed for now.~
* ~Advertised device name may conflict with OS settings for device.~
Update: Both of the above issues were resolved by adding code to disable ReverseDiscovery in the host's bluetooth config. ReverseDiscovery caused the Pi to try to discover services on the client/phone, some of which require higher security (including MIDI audio, which is weirdly the ultimate culprit), and thus initiate a pairing request, which fails, and causes an instant disconnection.

Features:
Can separately disable wifi and ble provisioning in the network_configuration section.
```
  "disable_bt_provisioning": false,
  "disable_wifi_provisioning": false,
```
Note these only block the starting of that provisioning method, not the whole network system like the main "disable_network_configuration" flag in the advanced settings does.


This also fixes a couple of small bugs. Post-upgrade install scripting wasn't running if "wait_for_online..." wasn't set. Similarly, self-disable when there's no wifi or network manager available wasn't working, and would keep retrying and making noise. Both of those _should_ be resolved, but haven't been thoroughly tested yet.



To use the new provisioning client: `go run ./cmd/provisioning-client/` to get started (it'll print basic help/usage)
Add the following options as needed:
* ` --scan` will scan for all (named) bluetooth devices visible.
* `-f SEARCH_TERM` will modify the filter (substring match on the device name.) Optional, and defaults to "viam-setup"
* `-b` enables bluetooth mode
* `-s` shows status
* `-n` shows network list
* `-b --ssid="MY_SSID" --psk="MY_PSK" --appaddr="https://app.viam.com:443" --partID="UUID_PART_ID" --secret="PART_SECRET"` will set both a wifi network AND the machine credentials. Can do only the three for creds or the two for the wifi if not needing/wanting both.