### PR TITLE
[APP-7919] Add option forward Kernel Logs

### DIFF
--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -1,0 +1,61 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+# Viam Agent .cursorrules
+
+The Viam Agent is an open-source service manager that automates the installation, execution, and monitoring of `viam-server` and associated services. It includes a self-update capability to keep itself and the services current, reducing manual maintenance. Additionally, it provides device provisioning and network configuration tools for seamless integration and connectivity within a network.
+
+## Scope of Changes
+- **Relevance**:
+  - Only modify code explicitly requested by the change request or task description. Avoid any unrelated or unnecessary changes to maintain clarity and focus.
+
+## Coding Conventions
+- **Linting Configuration**:
+  - Follow all linting standards as defined in the project's authoritative `golangci.yml` file located at the repository root.
+
+## Architecture & File Structure
+- **Directories**:
+  - Keep core business logic and service interactions in the `/subsystems/` directory.
+- **Agent Configuration**:
+  - When changing agent configurations, ensure updates are consistently applied in both `DefaultConfiguration` (in `config.go`) and `agent-config.jsonc`. Include clear, contextual comments explaining default values.
+
+## Service Management & Error Handling
+- **Error Handling**:
+  - Always handle errors explicitly and gracefully; avoid using `panic`.
+  - Use `errors.Wrap` from `github.com/pkg/errors` to annotate additional context when returning an error.
+  - Rare cases requiring skipping error checks must explicitly use `goutils.UncheckedError`, with clear explanatory comments justifying the decision.
+- **Process Management**:
+  - Log all service lifecycle events explicitly, including start, stop, crash, and recovery actions.
+  - Log all executed system commands (e.g., file operations or interactions with external processes like `systemd`), log both the command executed and its output clearly for audit purposes.
+  - Example:
+    ```go
+    logger.Infof("Executing system command: %s", cmd)
+    output, err := exec.Command(cmd).CombinedOutput()
+    logger.Infof("Command output: %s", string(output))
+    ```
+
+## Logging & Observability
+- **Logging Standard**:
+  - Exclusively use the logging library provided by `go.viam.com/rdk/logging` for consistent log management.
+
+## Testing Standards
+-  Place code used solely for testing in files ending with _test.go or in dedicated test helper files.
+- **Unit Tests**:
+  - Always include unit tests for any new or changed cod
+- **Test Assertions**:
+  - Exclusively use `test.That` assertions from `go.viam.com/test` in all `*_test.go` files. Avoid other assertion libraries.
+  - When comparing values that render identically and share the same type, use `test.ShouldResemble`.
+
+## Cross-Platform Compatibility
+- **Platform-specific Code**:
+  - Store OS-specific implementations in clearly named files (e.g., `_linux.go`). 
+  - Avoid build tags to manage platform-specific implementations.
+  - Example:
+    ✅ file_linux.go (correct)
+    ❌ file.go with build tags (incorrect)
+
+
+
+

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,26 @@
+FROM golang:1.23.1
+
+# Install required system packages
+RUN apt-get update && apt-get install -y \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy everything at once to preserve module structure
+COPY . .
+
+# Download dependencies
+RUN go mod download
+
+# Create a shell script to run tests
+RUN echo '#!/bin/sh\n\
+if [ -n "$TEST_TARGET" ]; then\n\
+    go test -race -v ./... -run "^$TEST_TARGET\$"\n\
+else\n\
+    go test -race -v ./...\n\
+fi' > /app/run-tests.sh && chmod +x /app/run-tests.sh
+
+# Run tests
+CMD ["/app/run-tests.sh"] 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,13 @@ lint: bin/golangci-lint
 test:
 	go test -race ./...
 
+# For convenience of non-linux devs, -race requires CGO which means it must run on a Linux environment
+# make test-docker-linux TEST_TARGET=<test_name> will run a specific test
+.PHONY: test-docker-linux
+test-docker-linux:
+	docker build -t viam-agent-test -f Dockerfile.test .
+	docker run --rm $(if $(TEST_TARGET),-e TEST_TARGET=$(TEST_TARGET)) viam-agent-test
+
 .PHONY: manifest
 manifest: bin/viam-agent-$(PATH_VERSION)-x86_64 bin/viam-agent-$(PATH_VERSION)-aarch64
 	echo $(PATH_VERSION) | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+' || exit 1

--- a/examples/agent-config.jsonc
+++ b/examples/agent-config.jsonc
@@ -45,7 +45,8 @@
 	"system_configuration": {
 			"logging_journald_system_max_use_megabytes": 512, // can be -1 to disable
 			"logging_journald_runtime_max_use_megabytes": 512, // can be -1 to disable
-			"os_auto_upgrade_type": "security" // can be "" to do nothing, or "disable" to remove customization, "all", or "security"
+			"os_auto_upgrade_type": "security", // can be "" to do nothing, or "disable" to remove customization, "all", or "security"
+			"forward_kernel_logs": false // enables forwarding of kernel logs to the cloud when true
 	}
 }
 }

--- a/subsystems/syscfg/kernel_logs.go
+++ b/subsystems/syscfg/kernel_logs.go
@@ -1,0 +1,227 @@
+package syscfg
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	errw "github.com/pkg/errors"
+	"github.com/viamrobotics/agent/utils"
+	"go.uber.org/zap/zapcore"
+	"go.viam.com/rdk/logging"
+)
+
+// KernelLogForwarder handles forwarding kernel logs to the cloud.
+type KernelLogForwarder struct {
+	logger logging.Logger
+	cfg    utils.SystemConfiguration
+	cmd    *exec.Cmd
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup // waitgroup to track the reader goroutine
+
+	// mu protects access to cmd and cfg
+	mu sync.RWMutex
+}
+
+// NewKernelLogForwarder creates a new kernel log forwarder.
+func NewKernelLogForwarder(ctx context.Context, logger logging.Logger, cfg utils.SystemConfiguration) *KernelLogForwarder {
+	ctx, cancel := context.WithCancel(ctx)
+	return &KernelLogForwarder{
+		logger: logger,
+		cfg:    cfg,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+// cleanup stops the kernel log forwarding process.
+func (k *KernelLogForwarder) cleanup() error {
+	if k.cmd == nil {
+		return nil
+	}
+
+	// Cancel the context to signal the reader goroutine to stop
+	k.cancel()
+
+	// Create a fresh context for the cleanup operation
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	// Interrupt the process first for a clean shutdown
+	if err := k.cmd.Process.Signal(os.Interrupt); err != nil {
+		k.logger.Warn("Failed to interrupt kernel log process:", err)
+	}
+
+	// Wait for the process to exit with a timeout
+	done := make(chan error, 1)
+	go func() {
+		done <- k.cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil && !strings.Contains(err.Error(), "signal:") {
+			k.logger.Warn("Process exited with error:", err)
+		}
+	case <-cleanupCtx.Done():
+		// Process didn't exit gracefully, force kill
+		if err := k.cmd.Process.Kill(); err != nil {
+			k.logger.Warn("Failed to kill process:", err)
+		}
+		<-done // Drain channel
+	}
+
+	// Wait for the reader goroutine to finish
+	k.wg.Wait()
+
+	// Reset state
+	k.cmd = nil
+	k.logger.Info("Stopped Kernel logs forwarding")
+
+	// Create a new context for future starts
+	k.ctx, k.cancel = context.WithCancel(context.Background())
+
+	return nil
+}
+
+// Start begins forwarding kernel logs if enabled.
+func (k *KernelLogForwarder) Start() error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	// If forwarding is disabled and we have a running command, stop it
+	if !k.cfg.ForwardKernelLogs && k.cmd != nil {
+		return k.cleanup()
+	}
+
+	// If forwarding is disabled or we already have a running command, do nothing
+	if !k.cfg.ForwardKernelLogs || k.cmd != nil {
+		return nil
+	}
+
+	if _, err := exec.LookPath("journalctl"); err != nil {
+		k.logger.Error("journalctl not available, kernel log forwarding disabled")
+		return nil
+	}
+
+	cmd := exec.Command("journalctl", "-f", "-k", "-o", "json")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return errw.Wrap(err, "creating stdout pipe")
+	}
+
+	if err := cmd.Start(); err != nil {
+		return errw.Wrap(err, "starting kernel log forwarding")
+	}
+
+	// Start a goroutine to read and process the output
+	k.wg.Add(1)
+	go func() {
+		defer k.wg.Done()
+		defer stdout.Close()
+		decoder := json.NewDecoder(stdout)
+		for {
+			select {
+			case <-k.ctx.Done():
+				return
+			default:
+				var entry struct {
+					Message          string `json:"MESSAGE"`
+					Priority         string `json:"PRIORITY"`
+					SyslogIdentifier string `json:"SYSLOG_IDENTIFIER"`
+					BootID           string `json:"_BOOT_ID"`
+					RealtimeTS       string `json:"__REALTIME_TIMESTAMP"`
+					MonotonicTS      string `json:"__MONOTONIC_TIMESTAMP"`
+				}
+				if err := decoder.Decode(&entry); err != nil {
+					// Ignore EOF errors as they're expected when the stream ends
+					if err != io.EOF {
+						k.logger.Error(errw.Wrap(err, "decoding journalctl output"))
+					}
+					return // Exit goroutine on any error to prevent tight loops
+				}
+
+				// Use the shared levels map from utils/logger.go
+				level := getLevel(entry.Priority)
+
+				// Convert timestamps to readable format
+				realtime := "unknown"
+				if ts, err := strconv.ParseInt(entry.RealtimeTS, 10, 64); err == nil {
+					realtime = time.Unix(0, ts*1000).UTC().Format(time.RFC3339Nano)
+				}
+
+				monotonic := "unknown"
+				if ts, err := strconv.ParseInt(entry.MonotonicTS, 10, 64); err == nil {
+					monotonic = fmt.Sprintf("%s since boot", time.Duration(ts).String())
+				}
+
+				// Format message with additional context
+				message := entry.Message
+				context := []string{}
+				context = append(context, fmt.Sprintf("syslog_id=%s", entry.SyslogIdentifier))
+				context = append(context, fmt.Sprintf("boot_id=%s", entry.BootID))
+				context = append(context, fmt.Sprintf("realtime=%s", realtime))
+				context = append(context, fmt.Sprintf("monotonic=%s", monotonic))
+				message = fmt.Sprintf("[%s] %s", strings.Join(context, " "), message)
+
+				logEntry := &logging.LogEntry{
+					Entry: zapcore.Entry{
+						Level:      level,
+						Time:       time.Now().UTC(),
+						LoggerName: k.logger.Desugar().Name(),
+						Message:    message,
+						Caller:     zapcore.EntryCaller{Defined: false},
+					},
+				}
+
+				k.logger.Write(logEntry)
+			}
+		}
+	}()
+
+	k.logger.Info("Started Kernel logs forwarding")
+	k.cmd = cmd
+	return nil
+}
+
+// Stop stops the kernel log forwarding.
+func (k *KernelLogForwarder) Stop() error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	return k.cleanup()
+}
+
+// Update updates the kernel log forwarding configuration.
+func (k *KernelLogForwarder) Update(cfg utils.SystemConfiguration) error {
+	k.mu.Lock()
+	k.cfg = cfg
+	k.mu.Unlock()
+	return nil
+}
+
+// getLevel converts a systemd priority to zapcore.Level
+func getLevel(priority string) zapcore.Level {
+	switch priority {
+	case "0", "1", "2", "3": // emerg, alert, crit, err
+		return zapcore.ErrorLevel
+	case "4": // warning
+		return zapcore.WarnLevel
+	case "5": // notice
+		return zapcore.InfoLevel
+	case "6": // info
+		return zapcore.InfoLevel
+	case "7": // debug
+		return zapcore.DebugLevel
+	default:
+		return zapcore.InfoLevel
+	}
+}

--- a/subsystems/syscfg/kernel_logs.go
+++ b/subsystems/syscfg/kernel_logs.go
@@ -126,7 +126,11 @@ func (k *KernelLogForwarder) Start() error {
 	k.wg.Add(1)
 	go func() {
 		defer k.wg.Done()
-		defer stdout.Close()
+		defer func() {
+			if err := stdout.Close(); err != nil {
+				k.logger.Error(errw.Wrap(err, "closing stdout"))
+			}
+		}()
 		decoder := json.NewDecoder(stdout)
 		for {
 			select {
@@ -208,7 +212,7 @@ func (k *KernelLogForwarder) Update(cfg utils.SystemConfiguration) error {
 	return nil
 }
 
-// getLevel converts a systemd priority to zapcore.Level
+// getLevel converts a systemd priority to zapcore.Level.
 func getLevel(priority string) zapcore.Level {
 	switch priority {
 	case "0", "1", "2", "3": // emerg, alert, crit, err

--- a/subsystems/syscfg/kernel_logs_test.go
+++ b/subsystems/syscfg/kernel_logs_test.go
@@ -1,0 +1,287 @@
+package syscfg
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/viamrobotics/agent/utils"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/test"
+)
+
+// createMockJournalctl creates a temporary mock journalctl command and modifies PATH to find it.
+func createMockJournalctl(t *testing.T) func() {
+	// Create a temporary directory for the mock command
+	tmpDir := t.TempDir()
+	mockPath := filepath.Join(tmpDir, "journalctl")
+
+	// Create the mock command that outputs test log entries and reads from stdin for new entries
+	//nolint:lll
+	mockContent := `#!/bin/bash
+# Initial entries
+echo '{"PRIORITY":"3","SYSLOG_IDENTIFIER":"kernel","_HOSTNAME":"raspberrypi","_BOOT_ID":"test-boot-id","__REALTIME_TIMESTAMP":"1709234567890123","__MONOTONIC_TIMESTAMP":"1234567890","MESSAGE":"Test kernel error"}'
+echo '{"PRIORITY":"4","SYSLOG_IDENTIFIER":"kernel","_HOSTNAME":"raspberrypi","_BOOT_ID":"test-boot-id","__REALTIME_TIMESTAMP":"1709234567890124","__MONOTONIC_TIMESTAMP":"1234567891","MESSAGE":"Test kernel warning"}'
+echo '{"PRIORITY":"6","SYSLOG_IDENTIFIER":"kernel","_HOSTNAME":"raspberrypi","_BOOT_ID":"test-boot-id","__REALTIME_TIMESTAMP":"1709234567890125","__MONOTONIC_TIMESTAMP":"1234567892","MESSAGE":"Test kernel info"}'
+
+# Sleep to simulate time passing
+sleep 2
+
+# Output new entries after delay
+echo '{"PRIORITY":"3","SYSLOG_IDENTIFIER":"kernel","_HOSTNAME":"raspberrypi","_BOOT_ID":"test-boot-id","__REALTIME_TIMESTAMP":"1709234567890126","__MONOTONIC_TIMESTAMP":"1234567893","MESSAGE":"New kernel entry after forwarder started"}'
+`
+	if err := os.WriteFile(mockPath, []byte(mockContent), 0o755); err != nil {
+		t.Fatalf("Failed to create mock journalctl: %v", err)
+	}
+
+	// Save original PATH
+	oldPath := os.Getenv("PATH")
+
+	// Modify PATH to find our mock command
+	t.Setenv("PATH", tmpDir+":"+oldPath)
+
+	// Return cleanup function
+	return func() {
+		t.Setenv("PATH", oldPath)
+	}
+}
+
+func TestKernelLogForwarder(t *testing.T) {
+	cleanup := createMockJournalctl(t)
+	defer cleanup()
+
+	logger, logs := logging.NewObservedTestLogger(t)
+
+	cfg := utils.SystemConfiguration{
+		ForwardKernelLogs: true,
+	}
+
+	k := NewKernelLogForwarder(context.Background(), logger, cfg)
+
+	// On start, we should see kernel forwarder start log
+	err := k.Start()
+	test.That(t, err, test.ShouldBeNil)
+
+	// Wait for initial logs
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify initial logs
+	initialLogs := logs.All()
+	test.That(t, len(initialLogs), test.ShouldEqual, 4) // 3 kernel logs + start message
+
+	// Wait for new logs
+	time.Sleep(3 * time.Second)
+
+	// Stop forwarding to ensure all logs are flushed
+	err = k.Stop()
+	test.That(t, err, test.ShouldBeNil)
+
+	// Get all logs and verify
+	allLogs := logs.All()
+	test.That(t, len(allLogs), test.ShouldEqual, 6) // 4 kernel logs + start + stop messages
+
+	// Verify the logs in order
+	expectedLogs := []string{
+		"Started Kernel logs forwarding",
+		"[syslog_id=kernel boot_id=test-boot-id realtime=2024-02-29T19:22:47.890123Z monotonic=1.23456789s since boot] Test kernel error",
+		"[syslog_id=kernel boot_id=test-boot-id realtime=2024-02-29T19:22:47.890124Z monotonic=1.234567891s since boot] Test kernel warning",
+		"[syslog_id=kernel boot_id=test-boot-id realtime=2024-02-29T19:22:47.890125Z monotonic=1.234567892s since boot] Test kernel info",
+		"[syslog_id=kernel boot_id=test-boot-id realtime=2024-02-29T19:22:47.890126Z monotonic=1.234567893s since boot] New kernel entry after forwarder started",
+		"Stopped Kernel logs forwarding",
+	}
+
+	for i, log := range allLogs {
+		test.That(t, log.Message, test.ShouldEqual, expectedLogs[i])
+	}
+}
+
+func TestKernelLogForwarderDisabled(t *testing.T) {
+	cleanup := createMockJournalctl(t)
+	defer cleanup()
+
+	logger, logs := logging.NewObservedTestLogger(t)
+	cfg := utils.SystemConfiguration{
+		ForwardKernelLogs: false,
+	}
+	k := NewKernelLogForwarder(context.Background(), logger, cfg)
+	err := k.Start()
+	test.That(t, err, test.ShouldBeNil)
+
+	// Wait a bit to ensure no logs are forwarded
+	time.Sleep(100 * time.Millisecond)
+
+	// Stop forwarding to ensure all logs are flushed
+	err = k.Stop()
+	test.That(t, err, test.ShouldBeNil)
+
+	// Verify no logs were forwarded
+	allLogs := logs.All()
+	test.That(t, len(allLogs), test.ShouldEqual, 0)
+}
+
+func TestKernelLogForwarderUpdate(t *testing.T) {
+	cleanup := createMockJournalctl(t)
+	defer cleanup()
+
+	logger, logs := logging.NewObservedTestLogger(t)
+
+	cfg := utils.SystemConfiguration{
+		ForwardKernelLogs: false,
+	}
+
+	k := NewKernelLogForwarder(context.Background(), logger, cfg)
+
+	// Start with forwarding disabled
+	err := k.Start()
+	test.That(t, err, test.ShouldBeNil)
+
+	// Update to enable forwarding
+	cfg.ForwardKernelLogs = true
+	err = k.Update(cfg)
+	test.That(t, err, test.ShouldBeNil)
+
+	err = k.Start()
+	test.That(t, err, test.ShouldBeNil)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Stop forwarding to ensure all logs are flushed
+	err = k.Stop()
+	test.That(t, err, test.ShouldBeNil)
+
+	// Verify logs are forwarded
+	allLogs := logs.All()
+	test.That(t, len(allLogs), test.ShouldBeGreaterThan, 0)
+}
+
+func TestKernelLogForwarderErrorHandling(t *testing.T) {
+	cleanup := createMockJournalctl(t)
+	defer cleanup()
+
+	logger := logging.NewTestLogger(t)
+
+	cfg := utils.SystemConfiguration{
+		ForwardKernelLogs: true,
+	}
+
+	k := NewKernelLogForwarder(context.Background(), logger, cfg)
+
+	t.Run("command error", func(t *testing.T) {
+		// Temporarily modify PATH to make journalctl unavailable
+		oldPath := os.Getenv("PATH")
+		t.Setenv("PATH", "")
+		defer t.Setenv("PATH", oldPath)
+
+		err := k.Start()
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("stop after context cancellation", func(t *testing.T) {
+		err := k.Start()
+		test.That(t, err, test.ShouldBeNil)
+
+		// Cancel context
+		k.cancel()
+
+		err = k.Stop()
+		test.That(t, err, test.ShouldBeNil)
+	})
+}
+
+func TestKernelLogForwarderCleanup(t *testing.T) {
+	cleanup := createMockJournalctl(t)
+	defer cleanup()
+
+	logger, logs := logging.NewObservedTestLogger(t)
+	cfg := utils.SystemConfiguration{
+		ForwardKernelLogs: true,
+	}
+	k := NewKernelLogForwarder(context.Background(), logger, cfg)
+
+	// Start the forwarder
+	err := k.Start()
+	test.That(t, err, test.ShouldBeNil)
+
+	// Wait for start message
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify forwarder is running
+	test.That(t, k.cmd, test.ShouldNotBeNil)
+
+	// Test cleanup during Stop
+	err = k.Stop()
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, k.cmd, test.ShouldBeNil)
+	test.That(t, logs.All()[len(logs.All())-1].Message, test.ShouldEqual, "Stopped Kernel logs forwarding")
+
+	// Start again
+	err = k.Start()
+	test.That(t, err, test.ShouldBeNil)
+
+	// Test cleanup during Start when disabled
+	cfg.ForwardKernelLogs = false
+	err = k.Update(cfg)
+	test.That(t, err, test.ShouldBeNil)
+
+	err = k.Start()
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, k.cmd, test.ShouldBeNil)
+	test.That(t, logs.All()[len(logs.All())-1].Message, test.ShouldEqual, "Stopped Kernel logs forwarding")
+}
+
+func TestKernelLogForwarderToggle(t *testing.T) {
+	cleanup := createMockJournalctl(t)
+	defer cleanup()
+
+	logger, logs := logging.NewObservedTestLogger(t)
+	cfg := utils.SystemConfiguration{
+		ForwardKernelLogs: true,
+	}
+	k := NewKernelLogForwarder(context.Background(), logger, cfg)
+
+	// Start with forwarding enabled
+	err := k.Start()
+	test.That(t, err, test.ShouldBeNil)
+
+	// Wait for initial logs
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify we got initial logs
+	initialLogs := logs.All()
+	test.That(t, len(initialLogs), test.ShouldBeGreaterThan, 0)
+
+	// Disable forwarding
+	cfg.ForwardKernelLogs = false
+	err = k.Update(cfg)
+	test.That(t, err, test.ShouldBeNil)
+	err = k.Start()
+	test.That(t, err, test.ShouldBeNil)
+
+	// Create new logger to check only new logs
+	logger, logs = logging.NewObservedTestLogger(t)
+	k.logger = logger
+
+	// Wait a bit to ensure no logs are forwarded while disabled
+	time.Sleep(100 * time.Millisecond)
+	test.That(t, len(logs.All()), test.ShouldEqual, 0)
+
+	// Re-enable forwarding
+	cfg.ForwardKernelLogs = true
+	err = k.Update(cfg)
+	test.That(t, err, test.ShouldBeNil)
+	err = k.Start()
+	test.That(t, err, test.ShouldBeNil)
+
+	// Wait for new logs
+	time.Sleep(3 * time.Second)
+
+	// Verify we got new logs after re-enabling
+	newLogs := logs.All()
+	test.That(t, len(newLogs), test.ShouldBeGreaterThan, 0)
+
+	// Stop forwarding
+	err = k.Stop()
+	test.That(t, err, test.ShouldBeNil)
+}

--- a/subsystems/syscfg/kernel_logs_test.go
+++ b/subsystems/syscfg/kernel_logs_test.go
@@ -83,6 +83,7 @@ func TestKernelLogForwarder(t *testing.T) {
 	test.That(t, len(allLogs), test.ShouldEqual, 6) // 4 kernel logs + start + stop messages
 
 	// Verify the logs in order
+	//nolint:lll
 	expectedLogs := []string{
 		"Started Kernel logs forwarding",
 		"[syslog_id=kernel boot_id=test-boot-id realtime=2024-02-29T19:22:47.890123Z monotonic=1.23456789s since boot] Test kernel error",

--- a/subsystems/syscfg/syscfg.go
+++ b/subsystems/syscfg/syscfg.go
@@ -23,12 +23,15 @@ type syscfg struct {
 	logger  logging.Logger
 	healthy bool
 	started bool
+
+	kernelLogForwarder *KernelLogForwarder
 }
 
 func NewSubsystem(ctx context.Context, logger logging.Logger, cfg utils.AgentConfig) subsystems.Subsystem {
 	return &syscfg{
-		logger: logger,
-		cfg:    cfg.SystemConfiguration,
+		logger:             logger,
+		cfg:                cfg.SystemConfiguration,
+		kernelLogForwarder: NewKernelLogForwarder(ctx, logger, cfg.SystemConfiguration),
 	}
 }
 
@@ -41,6 +44,9 @@ func (s *syscfg) Update(ctx context.Context, cfg utils.AgentConfig) (needRestart
 	}
 
 	s.cfg = cfg.SystemConfiguration
+	if err := s.kernelLogForwarder.Update(s.cfg); err != nil {
+		s.logger.Error(errw.Wrap(err, "updating kernel log forwarding"))
+	}
 	return
 }
 
@@ -60,7 +66,7 @@ func (s *syscfg) Start(ctx context.Context) error {
 	s.logger.Debugf("Starting syscfg")
 
 	s.started = true
-	var healthyLog, healthyUpgrades bool
+	var healthyLog, healthyUpgrades, healthyKernelLogs bool
 	defer func() {
 		// if something panicked, log it and allow things to continue
 		r := recover()
@@ -69,7 +75,7 @@ func (s *syscfg) Start(ctx context.Context) error {
 			s.logger.Error(r)
 		}
 
-		s.healthy = healthyLog && healthyUpgrades
+		s.healthy = healthyLog && healthyUpgrades && healthyKernelLogs
 	}()
 
 	// set journald max size limits
@@ -86,6 +92,14 @@ func (s *syscfg) Start(ctx context.Context) error {
 	}
 	healthyUpgrades = true
 
+	// start kernel log forwarding
+	err = s.kernelLogForwarder.Start()
+	if err != nil {
+		s.logger.Error(errw.Wrap(err, "starting kernel log forwarding"))
+	} else {
+		healthyKernelLogs = true
+	}
+
 	return nil
 }
 
@@ -93,6 +107,10 @@ func (s *syscfg) Stop(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.started = false
+
+	if err := s.kernelLogForwarder.Stop(); err != nil {
+		s.logger.Error(errw.Wrap(err, "stopping kernel log forwarding"))
+	}
 	return nil
 }
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -32,6 +32,7 @@ var (
 		SystemConfiguration{
 			LoggingJournaldSystemMaxUseMegabytes:  512,
 			LoggingJournaldRuntimeMaxUseMegabytes: 512,
+			ForwardKernelLogs:                     false,
 			OSAutoUpgradeType:                     "",
 		},
 		NetworkConfiguration{
@@ -98,6 +99,9 @@ type SystemConfiguration struct {
 	// can set either to -1 to disable, defaults to 512M (when int is 0)
 	LoggingJournaldSystemMaxUseMegabytes  int `json:"logging_journald_system_max_use_megabytes,omitempty"`
 	LoggingJournaldRuntimeMaxUseMegabytes int `json:"logging_journald_runtime_max_use_megabytes,omitempty"`
+
+	// Enable forwarding of kernel logs to the cloud (disabled by default)
+	ForwardKernelLogs bool `json:"forward_kernel_logs,omitempty"`
 
 	// UpgradeType can be
 	// Empty/missing ("") to make no changes

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -56,7 +56,8 @@ func TestConvertJson(t *testing.T) {
 	"system_configuration": {
 			"logging_journald_system_max_use_megabytes": 512,
 			"logging_journald_runtime_max_use_megabytes": 512,
-			"os_auto_upgrade_type": ""
+			"os_auto_upgrade_type": "",
+			"forward_kernel_logs": false
 	}
 }
 `


### PR DESCRIPTION
No rush on getting this merged. This was 95% written by Claude 3.7 and my main goal here was learning how would it go using Cursor Agent.

This PR includes 
* adding forward_kernel_logs (disabled by defaul) config and updating syscfg
* adding test-docker-linux target to make it easier to test changes on linux for non-linux devs. Since I was using Cursor Agent for the code changes, I wanted it to be able to validate the code changes so tests need to be able to run on my environment so cursor can use the output to self correct. 
* adding cursorrules (which i don't need to commit), so you don't have to repeat yourself on every prompt and also to get cursor to produce code in a consistent style. I found this one 👇  to be particularly useful because for some reason it would do unrelated fly-by refactors on every prompt 
> - Only modify code explicitly requested by the change request or task description. Avoid any unrelated or unnecessary changes to maintain clarity and focus 

PS: I also tested this on a Pi and tried enabling, disabling, as well as, restarting viam-agent and it seemed to work fine. 