### PR TITLE
[RSDK-10343][RSDK-10341][RSDK-10342] Windows Fixes

### DIFF
--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -1,6 +1,4 @@
 // Package viamserver contains the viam-server agent subsystem.
-//
-//nolint:goconst
 package viamserver
 
 import (
@@ -244,10 +242,6 @@ func (s *viamServer) HealthCheck(ctx context.Context) (errRet error) {
 		return errw.Errorf("%s not running", SubsysName)
 	}
 	if s.checkURL == "" {
-		if runtime.GOOS == "windows" {
-			// todo(windows): we hit this case on windows; debug why. note: it also can't signal the subprocess to stop.
-			return nil
-		}
 		return errw.Errorf("can't find listening URL for %s", SubsysName)
 	}
 
@@ -291,10 +285,6 @@ func (s *viamServer) HealthCheck(ctx context.Context) (errRet error) {
 // Must be called with `s.mu` held, as `s.checkURL` and `s.checkURLAlt` are
 // both accessed.
 func (s *viamServer) isRestartAllowed(ctx context.Context) (bool, error) {
-	if runtime.GOOS == "windows" {
-		// todo(windows): this function throws 'unsupported protocol scheme', needs debugging
-		return true, nil
-	}
 	for _, url := range []string{s.checkURL, s.checkURLAlt} {
 		s.logger.Debugf("starting restart allowed check for %s using %s", SubsysName, url)
 


### PR DESCRIPTION
General cleanup and bug fixes for windows. Fixes red-herring bugs enumerated in title (mostly all related to something that was accidentally broken by a bad rebase, but actually DO work, so removing the windows-specific bypass logic.) ALSO fixes the use of "file:///" version control URLs on windows.