### PR TITLE
ignore healthcheck failure on windows

### DIFF
--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -1,4 +1,6 @@
 // Package viamserver contains the viam-server agent subsystem.
+//
+//nolint:goconst
 package viamserver
 
 import (

--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -242,6 +242,10 @@ func (s *viamServer) HealthCheck(ctx context.Context) (errRet error) {
 		return errw.Errorf("%s not running", SubsysName)
 	}
 	if s.checkURL == "" {
+		if runtime.GOOS == "windows" {
+			// note: the log matcher works when running in cmd.exe but not as a service.
+			return nil
+		}
 		return errw.Errorf("can't find listening URL for %s", SubsysName)
 	}
 

--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -289,6 +289,10 @@ func (s *viamServer) HealthCheck(ctx context.Context) (errRet error) {
 // Must be called with `s.mu` held, as `s.checkURL` and `s.checkURLAlt` are
 // both accessed.
 func (s *viamServer) isRestartAllowed(ctx context.Context) (bool, error) {
+	if runtime.GOOS == "windows" {
+		// note: this throws 'unsupported protocol scheme', probably because checkURL is missing
+		return true, nil
+	}
 	for _, url := range []string{s.checkURL, s.checkURLAlt} {
 		s.logger.Debugf("starting restart allowed check for %s using %s", SubsysName, url)
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -65,6 +65,12 @@ var (
 	CLIWaitForUpdateCheck = false
 )
 
+func init() {
+	if runtime.GOOS == "windows" {
+		DefaultConfiguration.AdvancedSettings.ViamServerStartTimeoutMinutes = Timeout(time.Minute)
+	}
+}
+
 type AgentConfig struct {
 	AdvancedSettings     AdvancedSettings     `json:"advanced_settings,omitempty"`
 	SystemConfiguration  SystemConfiguration  `json:"system_configuration,omitempty"`


### PR DESCRIPTION
## What changed
- ignore missing checkURL in HealthCheck when GOOS=windows
- always allow restart on windows
- shorten default startup timeout on windows (for user convenience so upgrades show up promptly, because we will always hit the timeout)
## Why
Otherwise agent will stop RDK when `ViamServerStartTimeoutMinutes` hits (see logs below).

Note: the matchinglogger *does* find checkURL when you run the agent from cmd.exe. This only fails in service mode. Not sure why, needs follow-up work.

To see this in prod, toggle between 0.16.1-dev.10 (behaves) and dev.11 (restarts when healthcheck fails).

## Logs showing healthcheck failure + restart

Example of health check / restart behavior

> 4/10/2025, 10:16:54 PM info rdk   server/entrypoint.go:96   Viam RDK   version 0.70.0  git_rev xxxxxx
4/10/2025, 10:16:53 PM info viam-agent   viamserver/viamserver.go:89   Starting viam-server
4/10/2025, 10:16:53 PM error viam-agent   viamserver/viamserver.go:141   non-zero exit code
4/10/2025, 10:16:53 PM error viam-agent   viamserver/viamserver.go:136   error while getting process status   error exit status 1
4/10/2025, 10:16:53 PM info viam-agent   viamserver/viamserver.go:134   viam-server exited
4/10/2025, 10:16:53 PM info viam-agent   viamserver/viamserver.go:184   Stopping viam-server
4/10/2025, 10:16:53 PM error viam-agent   agent/manager.go:348   Subsystem healthcheck failed for viam-server: can't find listening URL for viam-server
4/10/2025, 10:16:47 PM error viam-agent   agent/manager.go:360   restarting subsystem viam-server: startup timed out 

Same with restart allowance

> 4/10/2025, 11:04:30 PM warn viam-agent   viamserver/viamserver.go:313   checking whether viam-server allows restart: Get "/restart_status": unsupported protocol scheme "" 