### PR TITLE
tolerate blank UnpackedPath case on windows

### DIFF
--- a/version_control.go
+++ b/version_control.go
@@ -209,6 +209,11 @@ func (c *VersionCache) UpdateBinary(ctx context.Context, binary string) (bool, e
 			}
 		}
 
+		if runtime.GOOS == "windows" && verData.UnpackedPath == "" {
+			// This case happens as a result of manual action to fix systems which used the old installer.
+			c.logger.Debug("replacing blank UnpackedPath with DlPath")
+			verData.UnpackedPath = verData.DlPath
+		}
 		shasum, err := utils.GetFileSum(verData.UnpackedPath)
 		if err == nil && bytes.Equal(shasum, verData.UnpackedSHA) {
 			return false, nil


### PR DESCRIPTION
## What changed
- on windows only, detect the UnpackedPath="" case and replace with DlPath
## Why
Protect against download looping
## Notes
Guessing this case comes about because UnpackedPath is a local-only field; it doesn't get set when version_cache.json is written after a recoverable error. (Have not confirmed this yet and may be misunderstanding the origin of the problem).
## Manual testing
- I edited the version_cache.json on my local machine to have UnpackedPath=""
- as expected, agent went into a download loop trying to update rdk
- I made this code change; it prevented the loop