### PR TITLE
Allow provisioning mode to exit quickly when new wifi is added, fix bluetooth tethering retry rate.

### DIFF
--- a/subsystems/networking/connstate_linux.go
+++ b/subsystems/networking/connstate_linux.go
@@ -126,6 +126,12 @@ func (c *connectionState) setLastInteraction() {
 	c.lastInteraction = time.Now()
 }
 
+func (c *connectionState) resetLastInteraction() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lastInteraction = time.Time{}
+}
+
 func (c *connectionState) getLastInteraction() time.Time {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/subsystems/networking/definitions_linux.go
+++ b/subsystems/networking/definitions_linux.go
@@ -188,11 +188,13 @@ func (u *userInputData) sendInput() {
 		u.input.AppAddr = ""
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 	select {
 	case u.inputChan <- inputSnapshot:
+		u.connState.resetLastInteraction()
 	case <-ctx.Done():
+		u.connState.logger.Warn("user input not received by main loop after 60 seconds")
 	}
 }
 

--- a/subsystems/networking/scanning_linux.go
+++ b/subsystems/networking/scanning_linux.go
@@ -140,7 +140,7 @@ func (n *Networking) networkScan(ctx context.Context) error {
 		}
 		nw.mu.Lock()
 		// if a network isn't visible, reset the times so we'll retry if it comes back
-		if nw.lastSeen.Before(time.Now().Add(VisibleNetworkTimeout * -1)) {
+		if nw.netType == NetworkTypeWifi && nw.lastSeen.Before(time.Now().Add(VisibleNetworkTimeout*-1)) {
 			nw.firstSeen = time.Time{}
 			nw.lastTried = time.Time{}
 		}


### PR DESCRIPTION
This fixes two subtle but ugly bugs. The first was that provisioning wouldn't always exit right away when new wifi was added. The second is that if a bluetooth tethering connection is present (but not working, e.g. disabled on phone that's paired) limit the connection attempts to the visibility timeout (one minute.)


Test build: https://storage.googleapis.com/packages.viam.com/temp/viam-agent-v0.18.0-rc1-aarch64