### PR TITLE
[APP-8059] [APP-7835] Improve windows service functionality

### DIFF
--- a/cmd/viam-agent/main_windows.go
+++ b/cmd/viam-agent/main_windows.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	"strconv"
+	"strings"
 
 	"github.com/viamrobotics/agent"
 	"github.com/viamrobotics/agent/utils"
@@ -80,8 +83,7 @@ func main() {
 	}
 	// wait first so viam-server doesn't try to restart
 	activeBackgroundWorkers.Wait()
-	// KillTree to catch any stragglers
-	if err := utils.KillTree(-1); err != nil {
+	if err := zapChildren(); err != nil {
 		goutils.UncheckedError(elog.Error(1, fmt.Sprintf("error killing subtree %s", err)))
 	}
 	goutils.UncheckedError(elog.Info(1, fmt.Sprintf("%s service stopped", serviceName)))
@@ -97,4 +99,55 @@ func waitOnline(logger logging.Logger, _ context.Context) {
 
 func runPlatformProvisioning(_ context.Context, _ utils.AgentConfig, _ *agent.Manager, _ error) bool {
 	return false
+}
+
+// zapChildren kills any stray processes we might have upon exit.
+func zapChildren() error {
+	elog, err := eventlog.Open("viam-agent")
+	if err != nil {
+		// Check error but continue since we want this to work
+		elog = nil
+	}
+
+	pid := os.Getpid()
+
+	// Use a fixed command string to prevent injection
+	//nolint:gosec // WMIC.exe is a fixed command
+	cmd := exec.Command("WMIC.exe", "process", "where", fmt.Sprintf("ParentProcessId=%d", pid), "get", "ProcessId")
+	output, err := cmd.Output()
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(output), "\r\n")
+	if elog != nil {
+		goutils.UncheckedError(elog.Info(1, fmt.Sprintf("KillTree stopping %d children of pid %d", len(lines), pid)))
+	}
+	for _, line := range lines[1:] {
+		if line == "" {
+			continue
+		}
+		var childPID int
+		_, err := fmt.Sscan(line, &childPID)
+		if err != nil {
+			if elog != nil {
+				goutils.UncheckedError(elog.Error(1, fmt.Sprintf("not a valid childProcess line %q, #%s", line, err)))
+			}
+			continue
+		}
+
+		//nolint:gosec // taskkill is a fixed command
+		cmd = exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(childPID))
+		err = cmd.Run()
+		if elog != nil {
+			if err != nil {
+				goutils.UncheckedError(elog.Error(1, fmt.Sprintf("error running taskkill pid %d: #%s", childPID, err)))
+			} else {
+				goutils.UncheckedError(elog.Info(1, fmt.Sprintf("killed pid %d", childPID)))
+			}
+		}
+	}
+	if elog != nil {
+		goutils.UncheckedError(elog.Info(1, "KillTree finished"))
+	}
+	return nil
 }

--- a/cmd/viam-agent/main_windows.go
+++ b/cmd/viam-agent/main_windows.go
@@ -9,6 +9,7 @@ import (
 	"github.com/viamrobotics/agent/utils"
 	"go.viam.com/rdk/logging"
 	goutils "go.viam.com/utils"
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/debug"
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -47,6 +48,11 @@ func main() {
 		globalLogger.Info("no service detected -- running as normal process")
 		commonMain()
 		return
+	}
+
+	// in service mode we have to alloc our own console to be able to send interrupts
+	if r, _, err := windows.NewLazySystemDLL("kernel32.dll").NewProc("AllocConsole").Call(); r == 0 {
+		panic(err)
 	}
 
 	var err error

--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -1,6 +1,4 @@
 // Package viamserver contains the viam-server agent subsystem.
-//
-//nolint:goconst
 package viamserver
 
 import (
@@ -77,7 +75,6 @@ func (s *viamServer) Start(ctx context.Context) error {
 	}
 	binPath := path.Join(utils.ViamDirs["bin"], SubsysName)
 	if runtime.GOOS == "windows" {
-		// SMURF
 		binPath += ".exe"
 	}
 	if pathMissing(binPath) {

--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -77,6 +77,7 @@ func (s *viamServer) Start(ctx context.Context) error {
 	}
 	binPath := path.Join(utils.ViamDirs["bin"], SubsysName)
 	if runtime.GOOS == "windows" {
+		// SMURF
 		binPath += ".exe"
 	}
 	if pathMissing(binPath) {
@@ -186,6 +187,7 @@ func (s *viamServer) Stop(ctx context.Context) error {
 	s.logger.Infof("Stopping %s", SubsysName)
 
 	if runtime.GOOS == "windows" {
+		// SMURF
 		// note: Signal(SIGTERM) returns 'not supported on windows' error on windows
 		// note: this kills all subprocesses, not just RDK
 		if err := utils.KillTree(-1); err != nil {
@@ -244,10 +246,6 @@ func (s *viamServer) HealthCheck(ctx context.Context) (errRet error) {
 		return errw.Errorf("%s not running", SubsysName)
 	}
 	if s.checkURL == "" {
-		if runtime.GOOS == "windows" {
-			// note: the log matcher works when running in cmd.exe but not as a service.
-			return nil
-		}
 		return errw.Errorf("can't find listening URL for %s", SubsysName)
 	}
 
@@ -291,10 +289,6 @@ func (s *viamServer) HealthCheck(ctx context.Context) (errRet error) {
 // Must be called with `s.mu` held, as `s.checkURL` and `s.checkURLAlt` are
 // both accessed.
 func (s *viamServer) isRestartAllowed(ctx context.Context) (bool, error) {
-	if runtime.GOOS == "windows" {
-		// note: this throws 'unsupported protocol scheme', probably because checkURL is missing
-		return true, nil
-	}
 	for _, url := range []string{s.checkURL, s.checkURLAlt} {
 		s.logger.Debugf("starting restart allowed check for %s using %s", SubsysName, url)
 

--- a/utils/logger.go
+++ b/utils/logger.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -13,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
 	"go.viam.com/rdk/logging"
+	"golang.org/x/sys/windows/svc"
 )
 
 var (
@@ -124,6 +126,15 @@ func (l *MatchingLogger) Write(p []byte) (int, error) {
 		entry := parseLog(p).entry()
 		l.logger.Write(&logging.LogEntry{Entry: entry})
 	} else {
+		// windows background services have no STDIO, so we just drop the writes
+		if runtime.GOOS == "windows" {
+			if inService, err := svc.IsWindowsService(); err != nil {
+				return len(p), err
+			} else if inService {
+				return len(p), nil
+			}
+		}
+
 		// this case is already-structured logging from non-uploadAll; we print it but don't upload it.
 		return os.Stdout.Write(p)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -111,11 +111,8 @@ func DownloadFile(ctx context.Context, rawURL string, logger logging.Logger) (ou
 	}
 
 	logger.Infof("Starting download of %s", rawURL)
-
 	parsedPath := parsedURL.Path
-
 	outPath = filepath.Join(ViamDirs["cache"], path.Base(parsedPath))
-
 	if runtime.GOOS == "windows" && !strings.HasSuffix(outPath, ".exe") {
 		outPath += ".exe"
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -113,11 +113,12 @@ func DownloadFile(ctx context.Context, rawURL string, logger logging.Logger) (ou
 	logger.Infof("Starting download of %s", rawURL)
 
 	parsedPath := parsedURL.Path
-	if runtime.GOOS == "windows" && !strings.HasSuffix(parsedPath, ".exe") {
-		parsedPath += ".exe"
-	}
 
 	outPath = filepath.Join(ViamDirs["cache"], path.Base(parsedPath))
+
+	if runtime.GOOS == "windows" && !strings.HasSuffix(outPath, ".exe") {
+		outPath += ".exe"
+	}
 
 	//nolint:nestif
 	if parsedURL.Scheme == "file" {

--- a/utils/utils_linux.go
+++ b/utils/utils_linux.go
@@ -52,3 +52,7 @@ func checkPathOwner(uid int, info fs.FileInfo) error {
 
 // KillTree kills the process tree on windows (because other signaling doesn't work).
 func KillTree(pid int) error { return nil }
+
+func writePlatformOutput(p []byte) (int, error) {
+	return os.Stdout.Write(p)
+}

--- a/utils/utils_linux.go
+++ b/utils/utils_linux.go
@@ -56,3 +56,7 @@ func KillTree(pid int) error { return nil }
 func writePlatformOutput(p []byte) (int, error) {
 	return os.Stdout.Write(p)
 }
+
+func SendInterrupt(pid int) error {
+	return nil
+}

--- a/utils/utils_linux.go
+++ b/utils/utils_linux.go
@@ -9,7 +9,6 @@ import (
 	"syscall"
 
 	errw "github.com/pkg/errors"
-	"go.viam.com/rdk/logging"
 	"golang.org/x/sys/unix"
 )
 
@@ -17,12 +16,12 @@ func PlatformProcSettings(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 }
 
-// KillIfAvailable does SIGKILL if available for the platform.
-func KillIfAvailable(logger logging.Logger, cmd *exec.Cmd) {
-	err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-	if err != nil {
-		logger.Warn(err)
+// KillTree sends SIGKILL to the process group.
+func KillTree(pid int) error {
+	if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil {
+		return errw.Wrapf(err, "killing PID %d", pid)
 	}
+	return nil
 }
 
 func SyncFS(syncPath string) (errRet error) {
@@ -50,13 +49,13 @@ func checkPathOwner(uid int, info fs.FileInfo) error {
 	return nil
 }
 
-// KillTree kills the process tree on windows (because other signaling doesn't work).
-func KillTree(pid int) error { return nil }
-
 func writePlatformOutput(p []byte) (int, error) {
 	return os.Stdout.Write(p)
 }
 
-func SendInterrupt(pid int) error {
+func SignalForTermination(pid int) error {
+	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+		return errw.Wrapf(err, "signaling PID %d", pid)
+	}
 	return nil
 }

--- a/utils/utils_windows.go
+++ b/utils/utils_windows.go
@@ -11,6 +11,7 @@ import (
 
 	"go.viam.com/rdk/logging"
 	goutils "go.viam.com/utils"
+	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/eventlog"
 )
 
@@ -90,4 +91,13 @@ func KillTree(pid int) error {
 		goutils.UncheckedError(elog.Info(1, "KillTree finished"))
 	}
 	return nil
+}
+
+func writePlatformOutput(p []byte) (int, error) {
+	if inService, err := svc.IsWindowsService(); err != nil {
+		return len(p), err
+	} else if inService {
+		return len(p), nil
+	}
+	return os.Stdout.Write(p)
 }

--- a/utils/utils_windows.go
+++ b/utils/utils_windows.go
@@ -1,19 +1,16 @@
 package utils
 
 import (
-	"fmt"
 	"io/fs"
 	"os"
 	"os/exec"
 	"strconv"
-	"strings"
 	"syscall"
 
-	"go.viam.com/rdk/logging"
+	errw "github.com/pkg/errors"
 	goutils "go.viam.com/utils"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
-	"golang.org/x/sys/windows/svc/eventlog"
 )
 
 func PlatformProcSettings(cmd *exec.Cmd) {
@@ -22,7 +19,16 @@ func PlatformProcSettings(cmd *exec.Cmd) {
 	}
 }
 
-func KillIfAvailable(logger logging.Logger, cmd *exec.Cmd) {}
+// KillTree kills the process group.
+func KillTree(pid int) error {
+	//nolint:gosec
+	cmd := exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(pid))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return errw.Wrapf(err, "killing PID %d: %s", pid, out)
+	}
+	return nil
+}
 
 // platform-specific UID check.
 func checkPathOwner(_ int, _ fs.FileInfo) error {
@@ -45,61 +51,8 @@ func SyncFS(syncPath string) error {
 	return nil
 }
 
-func SendInterrupt(pid int) error {
+func SignalForTermination(pid int) error {
 	return windows.GenerateConsoleCtrlEvent(syscall.CTRL_BREAK_EVENT, uint32(pid)) //nolint:gosec
-}
-
-// KillTree kills the process tree on windows (because other signaling doesn't work).
-func KillTree(pid int) error {
-	elog, err := eventlog.Open("viam-agent")
-	if err != nil {
-		// Check error but continue since we want this to work
-		elog = nil
-	}
-
-	if pid == -1 {
-		pid = os.Getpid()
-	}
-
-	// Use a fixed command string to prevent injection
-	//nolint:gosec // WMIC.exe is a fixed command
-	cmd := exec.Command("WMIC.exe", "process", "where", fmt.Sprintf("ParentProcessId=%d", pid), "get", "ProcessId")
-	output, err := cmd.Output()
-	if err != nil {
-		return err
-	}
-	lines := strings.Split(string(output), "\r\n")
-	if elog != nil {
-		goutils.UncheckedError(elog.Info(1, fmt.Sprintf("KillTree stopping %d children of pid %d", len(lines), pid)))
-	}
-	for _, line := range lines[1:] {
-		if line == "" {
-			continue
-		}
-		var childPID int
-		_, err := fmt.Sscan(line, &childPID)
-		if err != nil {
-			if elog != nil {
-				goutils.UncheckedError(elog.Error(1, fmt.Sprintf("not a valid childProcess line %q, #%s", line, err)))
-			}
-			continue
-		}
-
-		//nolint:gosec // taskkill is a fixed command
-		cmd = exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(childPID))
-		err = cmd.Run()
-		if elog != nil {
-			if err != nil {
-				goutils.UncheckedError(elog.Error(1, fmt.Sprintf("error running taskkill pid %d: #%s", childPID, err)))
-			} else {
-				goutils.UncheckedError(elog.Info(1, fmt.Sprintf("killed pid %d", childPID)))
-			}
-		}
-	}
-	if elog != nil {
-		goutils.UncheckedError(elog.Info(1, "KillTree finished"))
-	}
-	return nil
 }
 
 func writePlatformOutput(p []byte) (int, error) {

--- a/utils/utils_windows.go
+++ b/utils/utils_windows.go
@@ -11,11 +11,16 @@ import (
 
 	"go.viam.com/rdk/logging"
 	goutils "go.viam.com/utils"
+	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/eventlog"
 )
 
-func PlatformProcSettings(cmd *exec.Cmd) {}
+func PlatformProcSettings(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}
 
 func KillIfAvailable(logger logging.Logger, cmd *exec.Cmd) {}
 
@@ -38,6 +43,10 @@ func SyncFS(syncPath string) error {
 		return err
 	}
 	return nil
+}
+
+func SendInterrupt(pid int) error {
+	return windows.GenerateConsoleCtrlEvent(syscall.CTRL_BREAK_EVENT, uint32(pid)) //nolint:gosec
 }
 
 // KillTree kills the process tree on windows (because other signaling doesn't work).

--- a/version_control.go
+++ b/version_control.go
@@ -159,9 +159,6 @@ func (c *VersionCache) Update(cfg *pb.UpdateInfo, binary string) error {
 	info.Version = newVersion
 	info.URL = cfg.GetUrl()
 	info.SymlinkPath = path.Join(utils.ViamDirs["bin"], cfg.GetFilename())
-	if runtime.GOOS == "windows" {
-		info.SymlinkPath += ".exe"
-	}
 	info.UnpackedSHA = cfg.GetSha256()
 
 	return c.save()


### PR DESCRIPTION
This fixes the startup and health checks for viam server by no longer writing to the (non-existant) STDOUT when in windows service mode. It also allocates a console, allowing interrupt signaling for graceful shutdown of viam-server. Lastly, it improves handling/adding the ".exe" suffix for windows. Appending it immediately upon reception from the cloud, rather than manipulating it multiple places later.