### PR TITLE
[APP-7500] [RSDK-10333] Automatically restart agent when update available (and safe)

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -135,7 +135,7 @@ func Install(logger logging.Logger) error {
 		}
 	}
 
-	logger.Info("Install complete. Please (re)start the service with 'systemctl restart viam-agent' when ready.")
+	logger.Info("Install complete.")
 
 	return errors.Join(utils.SyncFS("/etc"), utils.SyncFS(serviceFilePath), utils.SyncFS(utils.ViamDirs["viam"]))
 }

--- a/cmd/viam-agent/main.go
+++ b/cmd/viam-agent/main.go
@@ -138,7 +138,7 @@ func commonMain() {
 	cfg = utils.ApplyCLIArgs(cfg)
 
 	// main manager structure
-	manager := agent.NewManager(ctx, globalLogger, cfg)
+	manager := agent.NewManager(ctx, globalLogger, cfg, globalCancel)
 
 	err = manager.LoadAppConfig()
 	//nolint:nestif
@@ -178,7 +178,7 @@ func commonMain() {
 		}
 	}
 
-	manager.StartBackgroundChecks(ctx, globalCancel)
+	manager.StartBackgroundChecks(ctx)
 	<-ctx.Done()
 	manager.CloseAll()
 }

--- a/cmd/viam-agent/main_linux.go
+++ b/cmd/viam-agent/main_linux.go
@@ -20,7 +20,7 @@ func main() {
 	commonMain()
 }
 
-func waitOnline(logger logging.Logger, timeoutCtx context.Context) {
+func waitOnline(_ logging.Logger, timeoutCtx context.Context) {
 	for {
 		cmd := exec.CommandContext(timeoutCtx, "systemctl", "is-active", "network-online.target")
 		_, err := cmd.CombinedOutput()

--- a/manager.go
+++ b/manager.go
@@ -199,9 +199,6 @@ func (m *Manager) SubsystemUpdates(ctx context.Context) {
 		if err != nil {
 			m.logger.Warnw("running install of new agent version", "error", err)
 		}
-	}
-
-	if needRestart {
 		m.viamAgentNeedsRestart = true
 	}
 

--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -137,7 +137,7 @@ func (s *viamServer) Start(ctx context.Context) error {
 		if s.cmd.ProcessState != nil {
 			s.lastExit = s.cmd.ProcessState.ExitCode()
 			if s.lastExit != 0 {
-				s.logger.Errorw("non-zero exit code", "exit code", s.lastExit)
+				s.logger.Error("non-zero exit code: %d", s.lastExit)
 			}
 		}
 		if s.shouldRun {


### PR DESCRIPTION
Note: This should merge after #108 and until then, will look like a larger set of changes.

This update makes viam-agent exit gracefully after it has installed a new update for itself (and optionally viam-server) when it's safe to do so. That is, when viam-server is disabled, or reports "safe to restart."

This also fixes a bug on windows preventing lockups or "self-exit" there from working as intended.