### PR TITLE
[RSDK-9293] Automatically prune cached binaries

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -272,6 +272,7 @@ func (m *Manager) SubsystemUpdates(ctx context.Context) {
 			m.logger.Warn(err)
 		}
 	}
+	m.cache.CleanCache(ctx)
 }
 
 // CheckUpdates retrieves an updated config from the cloud, and then passes it to SubsystemUpdates().
@@ -565,7 +566,7 @@ func fixWindowsPaths(resp *pb.DeviceAgentConfigResponse) {
 		return
 	}
 	if resp.GetAgentUpdateInfo() != nil && !strings.HasSuffix(resp.GetAgentUpdateInfo().GetFilename(), ".exe") {
-		resp.AgentUpdateInfo.Filename += ".exe"
+		resp.AgentUpdateInfo.Filename += ".exe" //nolint:goconst
 	}
 	if resp.GetViamServerUpdateInfo() != nil && !strings.HasSuffix(resp.GetViamServerUpdateInfo().GetFilename(), ".exe") {
 		resp.ViamServerUpdateInfo.Filename += ".exe"

--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -137,7 +137,7 @@ func (s *viamServer) Start(ctx context.Context) error {
 		if s.cmd.ProcessState != nil {
 			s.lastExit = s.cmd.ProcessState.ExitCode()
 			if s.lastExit != 0 {
-				s.logger.Error("non-zero exit code: %d", s.lastExit)
+				s.logger.Errorf("non-zero exit code: %d", s.lastExit)
 			}
 		}
 		if s.shouldRun {

--- a/version_control.go
+++ b/version_control.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -263,7 +264,7 @@ func (c *VersionCache) UpdateBinary(ctx context.Context, binary string) (bool, e
 				expectedMimes = []string{"application/vnd.microsoft.portable-executable"}
 			}
 
-			if !mimeIsAny(mtype, expectedMimes) {
+			if slices.ContainsFunc(expectedMimes, mtype.Is) {
 				data.brokenTarget = true
 				return needRestart, errw.Errorf("downloaded file is %s, not %s, skipping", mtype, strings.Join(expectedMimes, ", "))
 			}
@@ -305,14 +306,4 @@ func (c *VersionCache) UpdateBinary(ctx context.Context, binary string) (bool, e
 
 	// record the cache
 	return needRestart, c.save()
-}
-
-// returns true if mtype is any of expected strings.
-func mimeIsAny(mtype *mimetype.MIME, expected []string) bool {
-	for _, expectedType := range expected {
-		if mtype.Is(expectedType) {
-			return true
-		}
-	}
-	return false
 }

--- a/version_control.go
+++ b/version_control.go
@@ -323,16 +323,16 @@ func (c *VersionCache) CleanCache(ctx context.Context) {
 
 	// this can be set to the number of days to keep, ex: "VIAM_AGENT_FORCE_CLEAN=5"
 	forceVal := os.Getenv("VIAM_AGENT_FORCE_CLEAN")
-	minAgeDays, err := strconv.Atoi(forceVal)
+	maxAgeDays, err := strconv.Atoi(forceVal)
 	if err != nil {
-		minAgeDays = 30
+		maxAgeDays = 30
 	}
-	if minAgeDays < 1 {
-		minAgeDays = 1
+	if maxAgeDays < 1 {
+		maxAgeDays = 1
 	}
 
 	// only do this once every 24 hours
-	if time.Now().Before(c.LastCleaned.Add(time.Hour*24)) && os.Getenv("VIAM_AGENT_FORCE_CLEAN") == "" {
+	if time.Now().Before(c.LastCleaned.Add(time.Hour*24)) && forceVal == "" {
 		return
 	}
 	c.logger.Info("Starting cache cleanup")
@@ -366,7 +366,7 @@ func (c *VersionCache) CleanCache(ctx context.Context) {
 				ver == system.TargetVersion ||
 				ver == system.runningVersion ||
 				// protect the last 30 days worth of updates in case of rollbacks
-				info.Installed.After(time.Now().Add(time.Hour*-24*time.Duration(minAgeDays))) {
+				info.Installed.After(time.Now().Add(time.Hour*-24*time.Duration(maxAgeDays))) {
 				protectedFiles = append(protectedFiles, filepath.Base(info.UnpackedPath))
 				continue
 			}


### PR DESCRIPTION
Note: Should merge after #109 as this inherits those changes and looks like bigger change set until then

This adds a CleanCache() function which prunes the cache and removes any obsolete/stray files to recover disk space. It runs every 24 hours, but won't run within the first 15 minutes of startup to avoid adding load on machines that may have been offline for an extended period and have a lot of updates to get through.