### PR TITLE
[APP-8238] Convert all boolean values in config to new Tribool type

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 
 	errw "github.com/pkg/errors"
@@ -148,12 +149,7 @@ func inSystemdPath(path string, logger logging.Logger) bool {
 		return false
 	}
 	searchPaths := strings.Split(strings.TrimSpace(string(output)), ":")
-	for _, searchPath := range searchPaths {
-		if searchPath == path {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(searchPaths, path)
 }
 
 func getServiceFilePath(logger logging.Logger) (string, bool, error) {

--- a/cmd/viam-agent/main.go
+++ b/cmd/viam-agent/main.go
@@ -160,7 +160,7 @@ func commonMain() {
 	// wait until now when we (potentially) have a network logger to record this
 	globalLogger.Infof("Viam Agent Version: %s Git Revision: %s", utils.GetVersion(), utils.GetRevision())
 
-	if cfg.AdvancedSettings.WaitForUpdateCheck {
+	if cfg.AdvancedSettings.WaitForUpdateCheck.Get() {
 		// wait to be online
 		timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute)
 		defer cancel()

--- a/manager.go
+++ b/manager.go
@@ -546,11 +546,6 @@ func (m *Manager) GetConfig(ctx context.Context) (time.Duration, error) {
 		m.logger.Warn(errw.Wrap(err, "processing config"))
 	}
 
-	cfg, err = utils.ValidateConfig(cfg)
-	if err != nil {
-		m.logger.Warn(errw.Wrap(err, "processing config"))
-	}
-
 	if err := utils.SaveConfigToCache(cfg); err != nil {
 		m.logger.Warn(err)
 	}

--- a/subsystems/networking/bluetooth_linux.go
+++ b/subsystems/networking/bluetooth_linux.go
@@ -235,5 +235,5 @@ func (n *Networking) bluetoothEnabled() bool {
 	n.dataMu.Lock()
 	noBT := n.noBT
 	n.dataMu.Unlock()
-	return !noBT && !n.Config().DisableBTProvisioning
+	return !noBT && !n.Config().DisableBTProvisioning.Get()
 }

--- a/subsystems/networking/networking_linux.go
+++ b/subsystems/networking/networking_linux.go
@@ -171,7 +171,7 @@ func (n *Networking) init(ctx context.Context) error {
 
 	n.warnIfMultiplePrimaryNetworks()
 
-	if n.Config().TurnOnHotspotIfWifiHasNoInternet {
+	if n.Config().TurnOnHotspotIfWifiHasNoInternet.Get() {
 		n.logger.Info("Wifi internet checking enabled. Will try all connections for global internet connectivity.")
 	} else {
 		primarySSID := n.netState.PrimarySSID(n.Config().HotspotInterface)
@@ -225,7 +225,7 @@ func (n *Networking) Start(ctx context.Context) error {
 		n.logger.Warn(err)
 	}
 
-	if !n.Config().DisableBTProvisioning || !n.Config().DisableWifiProvisioning {
+	if !n.Config().DisableBTProvisioning.Get() || !n.Config().DisableWifiProvisioning.Get() {
 		cancelCtx, cancel := context.WithCancel(ctx)
 		n.cancel = cancel // This will loop indefinitely until context cancellation or serious error
 		n.monitorWorkers.Add(1)
@@ -312,7 +312,7 @@ func (n *Networking) HealthCheck(ctx context.Context) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
-	if n.noNM || (n.Config().DisableBTProvisioning && n.Config().DisableWifiProvisioning) {
+	if n.noNM || (n.Config().DisableBTProvisioning.Get() && n.Config().DisableWifiProvisioning.Get()) {
 		return nil
 	}
 
@@ -337,7 +337,7 @@ func (n *Networking) Nets() utils.AdditionalNetworks {
 }
 
 func (n *Networking) processAdditionalnetworks(ctx context.Context) {
-	if !n.Config().TurnOnHotspotIfWifiHasNoInternet && len(n.Nets()) > 0 {
+	if !n.Config().TurnOnHotspotIfWifiHasNoInternet.Get() && len(n.Nets()) > 0 {
 		n.logger.Warn("Additional networks configured, but internet checking is not enabled. Additional networks may be unused.")
 	}
 
@@ -358,8 +358,8 @@ func (n *Networking) processAdditionalnetworks(ctx context.Context) {
 // must be run inside dataMu lock.
 func (n *Networking) writeWifiPowerSave(ctx context.Context) error {
 	contents := wifiPowerSaveContentsDefault
-	if n.Config().WifiPowerSave != nil {
-		if *n.Config().WifiPowerSave {
+	if n.Config().WifiPowerSave.IsSet() {
+		if n.Config().WifiPowerSave.Get() {
 			contents = wifiPowerSaveContentsEnable
 		} else {
 			contents = wifiPowerSaveContentsDisable

--- a/subsystems/networking/setup_linux.go
+++ b/subsystems/networking/setup_linux.go
@@ -20,7 +20,7 @@ var (
 
 func (n *Networking) writeDNSMasq() error {
 	DNSMasqContents := DNSMasqContentsRedirect
-	if n.cfg.DisableCaptivePortalRedirect {
+	if n.cfg.DisableCaptivePortalRedirect.Get() {
 		DNSMasqContents = DNSMasqContentsSetupOnly
 	}
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -83,13 +83,10 @@ func (b Tribool) IsSet() bool {
 }
 
 func (b Tribool) MarshalJSON() ([]byte, error) {
-	switch b {
-	case 1:
+	if b == 1 {
 		return []byte("true"), nil
-	case -1:
-		return []byte("false"), nil
 	}
-	return nil, nil
+	return []byte("false"), nil
 }
 
 func (b *Tribool) UnmarshalJSON(data []byte) error {

--- a/utils/config_old.go
+++ b/utils/config_old.go
@@ -100,10 +100,19 @@ func LoadOldProvisioningConfig() (*NetworkConfiguration, error) {
 		DeviceRebootAfterOfflineMinutes:     oldCfg.DeviceRebootAfterOfflineMinutes,
 	}
 
-	nc.DisableCaptivePortalRedirect.Set(oldCfg.DisableDNSRedirect)
-	nc.TurnOnHotspotIfWifiHasNoInternet.Set(oldCfg.RoamingMode)
+	// explicit conversions to Tribool
+	if oldCfg.DisableDNSRedirect {
+		nc.DisableCaptivePortalRedirect = 1
+	}
+	if oldCfg.RoamingMode {
+		nc.TurnOnHotspotIfWifiHasNoInternet = 1
+	}
 	if oldCfg.WifiPowerSave != nil {
-		nc.WifiPowerSave.Set(*oldCfg.WifiPowerSave)
+		if *oldCfg.WifiPowerSave {
+			nc.WifiPowerSave = 1
+		} else {
+			nc.WifiPowerSave = -1
+		}
 	}
 	return nc, nil
 }

--- a/utils/config_old.go
+++ b/utils/config_old.go
@@ -87,19 +87,23 @@ func LoadOldProvisioningConfig() (*NetworkConfiguration, error) {
 		return nil, err
 	}
 
-	return &NetworkConfiguration{
+	nc := &NetworkConfiguration{
 		Manufacturer:                        oldCfg.Manufacturer,
 		Model:                               oldCfg.Model,
 		FragmentID:                          oldCfg.FragmentID,
 		HotspotInterface:                    oldCfg.HotspotInterface,
 		HotspotPrefix:                       oldCfg.HotspotPrefix,
 		HotspotPassword:                     oldCfg.HotspotPassword,
-		DisableCaptivePortalRedirect:        oldCfg.DisableDNSRedirect,
-		TurnOnHotspotIfWifiHasNoInternet:    oldCfg.RoamingMode,
-		WifiPowerSave:                       oldCfg.WifiPowerSave,
 		OfflineBeforeStartingHotspotMinutes: oldCfg.OfflineTimeout,
 		UserIdleMinutes:                     oldCfg.UserTimeout,
 		RetryConnectionTimeoutMinutes:       oldCfg.FallbackTimeout,
 		DeviceRebootAfterOfflineMinutes:     oldCfg.DeviceRebootAfterOfflineMinutes,
-	}, nil
+	}
+
+	nc.DisableCaptivePortalRedirect.Set(oldCfg.DisableDNSRedirect)
+	nc.TurnOnHotspotIfWifiHasNoInternet.Set(oldCfg.RoamingMode)
+	if oldCfg.WifiPowerSave != nil {
+		nc.WifiPowerSave.Set(*oldCfg.WifiPowerSave)
+	}
+	return nc, nil
 }

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -17,11 +17,7 @@ func TestConvertJson(t *testing.T) {
 	},
 	"advanced_settings": {
 		"debug": false,
-		"wait_for_update_check": false,
-		"viam_server_start_timeout_minutes": 10,
-		"disable_viam_server": false,
-		"disable_network_configuration": false,
-		"disable_system_configuration": false
+		"viam_server_start_timeout_minutes": 10
 	},
 	"network_configuration": {
 		"manufacturer": "viam",
@@ -33,7 +29,6 @@ func TestConvertJson(t *testing.T) {
 		"offline_before_starting_hotspot_minutes": 2,
 		"user_idle_minutes": 5,
 		"retry_connection_timeout_minutes": 10,
-		"turn_on_hotspot_if_wifi_has_no_internet": false,
 		"wifi_power_save": null
 	},
 	"additional_networks": {
@@ -81,6 +76,9 @@ func TestConvertJson(t *testing.T) {
 			PSK:  "cow",
 		},
 	}
+	// these are explicitly false, rather than the "unset" for missing fields
+	testConfig.AdvancedSettings.Debug = -1
+	testConfig.NetworkConfiguration.DisableCaptivePortalRedirect = -1
 
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, *newConfig, test.ShouldResemble, testConfig)


### PR DESCRIPTION
Due to the way Agent stacks configs (e.g. including built-in defaults, then processing viam-defaults.json, before finally using values from the cloud) booleans set to true at a lower level (viam-defaults) cannot be overridden with false at higher layers, as "false" is the same as unset due to json marshalling using "omitempty."

This adds a new Tribool type that allows for an explicitly "unset" value, subsequently allowing this kind of optional override.

Tested manually with various combinations of setting debug in viam-defaults, CLI (always takes precedence) and cloud. Appears to work, but as this touches a LOT of places, may not be urgent to get in.