### PR TITLE
Make agent try all local IPs for healthchecks

### DIFF
--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -456,7 +456,7 @@ func GetAllLocalIPv4s() ([]string, error) {
 
 				all = append(all, v.IP.String())
 			default:
-				return nil, fmt.Errorf("unknow address type: %T", v)
+				return nil, fmt.Errorf("unknown address type: %T", v)
 			}
 		}
 	}


### PR DESCRIPTION
This is kinda quick and dirty... should really dedupe isRestartAllowed() and HealthCheck() as they do a LOT of the same stuff. But for now, it solves the problem I believe.