### PR TITLE
Skip healthchecks on windows

### DIFF
--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -237,6 +237,9 @@ func (s *viamServer) HealthCheck(ctx context.Context) error {
 	if s.checkURL == "" {
 		return errw.Errorf("can't find listening URL for %s", SubsysName)
 	}
+	if runtime.GOOS == "windows" {
+		return nil
+	}
 
 	urls, err := s.makeTestURLs()
 	if err != nil {
@@ -375,7 +378,7 @@ func (s *viamServer) SafeToRestart(ctx context.Context) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if !s.running {
+	if !s.running || runtime.GOOS == "windows" {
 		return true
 	}
 


### PR DESCRIPTION
Hard code return values for windows to workaround issue with windows suspend/resume.