### PR TITLE
APP-8440 move installer build to windows-2022

### DIFF
--- a/.github/workflows/build-windows-installer.yaml
+++ b/.github/workflows/build-windows-installer.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   validate:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
 
   build:
     needs: validate
-    runs-on: windows-2019
+    runs-on: windows-2022
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
## What changed
- changed `runs-on: windows-2019` to `windows-2022` in actions YML
## Why
Github is [deprecating the windows-2019 runner](https://github.com/actions/runner-images/issues/12045).
## Manual test
- actions run [here](https://github.com/viamrobotics/agent/actions/runs/15424388113)
- I tested that ^ build on an old OS version and it worked