### PR TITLE
[APP-8431] Bluetooth Improvments

### DIFF
--- a/subsystems/networking/bluetooth_characteristics_linux.go
+++ b/subsystems/networking/bluetooth_characteristics_linux.go
@@ -65,7 +65,7 @@ func newBTCharacteristics(logger logging.Logger, userInputData *userInputData, p
 		logger:        logger,
 		writables:     map[string]*bluetooth.Characteristic{},
 		userInputData: userInputData,
-		PSK: psk,
+		PSK:           psk,
 	}
 }
 

--- a/subsystems/networking/bluetooth_characteristics_linux.go
+++ b/subsystems/networking/bluetooth_characteristics_linux.go
@@ -1,6 +1,7 @@
 package networking
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
@@ -33,11 +34,16 @@ const (
 	fragmentKey              = "fragment_id"
 	errorsKey                = "errors"
 	cryptoKey                = "pub_key"
+	exitProvisioningKey      = "exit_provisioning"
+	agentVersionKey          = "agent_version"
 )
 
 var (
-	characteristicsWriteOnly = []string{ssidKey, pskKey, robotPartIDKey, robotPartSecretKey, appAddressKey}
-	characteristicsReadOnly  = []string{cryptoKey, statusKey, manufacturerKey, modelKey, fragmentKey, availableWiFiNetworksKey, errorsKey}
+	characteristicsWriteOnly = []string{ssidKey, pskKey, robotPartIDKey, robotPartSecretKey, appAddressKey, exitProvisioningKey}
+	characteristicsReadOnly  = []string{
+		cryptoKey, statusKey, manufacturerKey, modelKey,
+		fragmentKey, availableWiFiNetworksKey, errorsKey, agentVersionKey,
+	}
 )
 
 type btCharacteristics struct {
@@ -60,12 +66,12 @@ func newBTCharacteristics(logger logging.Logger, userInputData *userInputData) *
 	}
 }
 
-func (b *btCharacteristics) initCharacteristics() []bluetooth.CharacteristicConfig {
+func (b *btCharacteristics) initCharacteristics(ctx context.Context) []bluetooth.CharacteristicConfig {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	var charList []bluetooth.CharacteristicConfig
 	for _, char := range characteristicsWriteOnly {
-		charList = append(charList, b.initWriteOnlyCharacteristic(char))
+		charList = append(charList, b.initWriteOnlyCharacteristic(ctx, char))
 	}
 
 	for _, char := range characteristicsReadOnly {
@@ -104,11 +110,12 @@ func (b *btCharacteristics) initDevInfo(cfg utils.NetworkConfiguration) error {
 		b.writeCharacteristic(manufacturerKey, []byte(cfg.Manufacturer)),
 		b.writeCharacteristic(modelKey, []byte(cfg.Model)),
 		b.writeCharacteristic(fragmentKey, []byte(cfg.FragmentID)),
+		b.writeCharacteristic(agentVersionKey, []byte(utils.GetVersion())),
 	)
 }
 
 // initWriteOnlyCharacteristic returns a bluetooth characteristic config.
-func (b *btCharacteristics) initWriteOnlyCharacteristic(cName string) bluetooth.CharacteristicConfig {
+func (b *btCharacteristics) initWriteOnlyCharacteristic(ctx context.Context, cName string) bluetooth.CharacteristicConfig {
 	// Generate predictable (v5) UUID from common namespace+cName
 	cUUID := bluetooth.NewUUID(uuid.NewSHA1(uuid.MustParse(uuidNamespace), []byte(cName)))
 
@@ -123,7 +130,7 @@ func (b *btCharacteristics) initWriteOnlyCharacteristic(cName string) bluetooth.
 			if err != nil {
 				b.logger.Error(fmt.Errorf("could not decrypt incoming value for %s: %w", cName, err))
 			}
-			b.recordInput(cName, string(plaintext))
+			b.recordInput(ctx, cName, string(plaintext))
 			b.logger.Debugf("Received %s: %s (cipher/plain sizes: %d/%d)", cName, plaintext, len(value), len(plaintext))
 		},
 	}
@@ -217,7 +224,7 @@ func (b *btCharacteristics) decrypt(ciphertext []byte) ([]byte, error) {
 	return rsa.DecryptOAEP(sha256.New(), nil, b.privKey, ciphertext, nil)
 }
 
-func (b *btCharacteristics) recordInput(cName, value string) {
+func (b *btCharacteristics) recordInput(ctx context.Context, cName, value string) {
 	b.userInputData.mu.Lock()
 	defer b.userInputData.mu.Unlock()
 
@@ -234,7 +241,7 @@ func (b *btCharacteristics) recordInput(cName, value string) {
 		b.userInputData.input.Secret = value
 	case appAddressKey:
 		b.userInputData.input.AppAddr = value
+	case exitProvisioningKey:
+		b.userInputData.sendInput(ctx)
 	}
-
-	b.userInputData.sendInput()
 }

--- a/subsystems/networking/bluetooth_linux.go
+++ b/subsystems/networking/bluetooth_linux.go
@@ -1,6 +1,7 @@
 package networking
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -20,7 +21,7 @@ const (
 )
 
 // startProvisioningBluetooth should only be called by 'StartProvisioning' (to ensure opMutex is acquired).
-func (n *Networking) startProvisioningBluetooth() error {
+func (n *Networking) startProvisioningBluetooth(ctx context.Context) error {
 	if !n.bluetoothEnabled() {
 		return nil
 	}
@@ -30,7 +31,7 @@ func (n *Networking) startProvisioningBluetooth() error {
 	n.btHealthy = false
 
 	// Create a bluetooth service comprised of the above configs.
-	if err := n.initializeBluetoothService(n.Config().HotspotSSID, n.btChar.initCharacteristics()); err != nil {
+	if err := n.initializeBluetoothService(n.Config().HotspotSSID, n.btChar.initCharacteristics(ctx)); err != nil {
 		n.noBT = true
 		return fmt.Errorf("failed to initialize bluetooth service: %w", err)
 	}

--- a/subsystems/networking/definitions_linux.go
+++ b/subsystems/networking/definitions_linux.go
@@ -165,34 +165,13 @@ type userInputData struct {
 }
 
 // must be called with u.mu already locked!
-func (u *userInputData) sendInput() {
-	inputSnapshot := *u.input
-
-	// send if we have a full/useful set of details, either complete wifi OR complete machine credentials
-	fullWifi := u.input.SSID != "" && u.input.PSK != ""
-	fullCreds := u.input.AppAddr != "" && u.input.PartID != "" && u.input.Secret != ""
-
-	if !fullWifi && !fullCreds {
-		return
-	}
-
-	// reset full set that we're about to send
-	if fullWifi {
-		u.input.SSID = ""
-		u.input.PSK = ""
-	}
-
-	if fullCreds {
-		u.input.PartID = ""
-		u.input.Secret = ""
-		u.input.AppAddr = ""
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+func (u *userInputData) sendInput(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	select {
-	case u.inputChan <- inputSnapshot:
+	case u.inputChan <- *u.input:
 		u.connState.resetLastInteraction()
+		u.input = &userInput{}
 	case <-ctx.Done():
 		u.connState.logger.Warn("user input not received by main loop after 60 seconds")
 	}

--- a/subsystems/networking/grpc_linux.go
+++ b/subsystems/networking/grpc_linux.go
@@ -51,6 +51,7 @@ func (n *Networking) GetSmartMachineStatus(ctx context.Context,
 		HasSmartMachineCredentials: n.connState.getConfigured(),
 		IsOnline:                   n.connState.getOnline(),
 		Errors:                     n.errListAsStrings(),
+		AgentVersion:               utils.GetVersion(),
 	}
 
 	lastSSID := n.netState.LastSSID(n.Config().HotspotInterface)
@@ -89,9 +90,12 @@ func (n *Networking) SetNetworkCredentials(ctx context.Context,
 		lastNetwork.mu.Unlock()
 	}
 
-	n.portalData.sendInput()
-
 	return &pb.SetNetworkCredentialsResponse{}, nil
+}
+
+func (n *Networking) ExitProvisioning(ctx context.Context, req *pb.ExitProvisioningRequest) (*pb.ExitProvisioningResponse, error) {
+	n.portalData.sendInput(ctx)
+	return &pb.ExitProvisioningResponse{}, nil
 }
 
 func (n *Networking) SetSmartMachineCredentials(ctx context.Context,
@@ -108,8 +112,6 @@ func (n *Networking) SetSmartMachineCredentials(ctx context.Context,
 	n.portalData.input.PartID = cloud.GetId()
 	n.portalData.input.Secret = cloud.GetSecret()
 	n.portalData.input.AppAddr = cloud.GetAppAddress()
-
-	n.portalData.sendInput()
 
 	return &pb.SetSmartMachineCredentialsResponse{}, nil
 }

--- a/subsystems/networking/networking_linux.go
+++ b/subsystems/networking/networking_linux.go
@@ -78,7 +78,7 @@ func NewSubsystem(ctx context.Context, logger logging.Logger, cfg utils.AgentCon
 		bgLoopHealth:   &health{},
 	}
 	subsys.portalData = &userInputData{connState: subsys.connState}
-	subsys.btChar = newBTCharacteristics(logger, subsys.portalData)
+	subsys.btChar = newBTCharacteristics(logger, subsys.portalData, cfg.NetworkConfiguration.HotspotPassword)
 	return subsys
 }
 

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -208,7 +208,7 @@ func (n *Networking) StartProvisioning(ctx context.Context, inputChan chan<- use
 	if hotspotErr != nil {
 		n.logger.Errorw("failed to start hotspot provisioning", "error", hotspotErr)
 	}
-	bluetoothErr := n.startProvisioningBluetooth()
+	bluetoothErr := n.startProvisioningBluetooth(ctx)
 	if bluetoothErr != nil {
 		n.logger.Errorw("failed to start bluetooth provisioning", "error", bluetoothErr)
 	}

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -707,7 +707,7 @@ func (n *Networking) mainLoop(ctx context.Context) {
 	defer n.monitorWorkers.Done()
 
 	scanChan := make(chan bool, 16)
-	inputChan := make(chan userInput, 1)
+	inputChan := make(chan userInput, 10)
 
 	n.monitorWorkers.Add(1)
 	go n.backgroundLoop(ctx, scanChan)

--- a/subsystems/networking/portal_linux.go
+++ b/subsystems/networking/portal_linux.go
@@ -193,5 +193,5 @@ func (n *Networking) portalSave(resp http.ResponseWriter, req *http.Request) {
 		lastNetwork.lastError = nil
 		lastNetwork.mu.Unlock()
 	}
-	n.portalData.sendInput()
+	n.portalData.sendInput(req.Context())
 }


### PR DESCRIPTION
This adds a new “ExitProvisioning()” grpc call, and “agent_version” field to MachineStatus(), along with equivalent characteristics for bluetooth. The new behavior is that provisioning clients (mobile app) must call ExitProvisioning() after they are done (instead of relying on heuristics like time-since-last-write and/or “guessing” when a group of writes is complete), causing the device to exit provisioning mode immediately, and attempt to resume normal operations.

This also adds a pre-shared key to the written characteristics. This PSK is the same as the hotspot password, and should be prepended to written charcteristics and separated with a colon, before encryption. Ex:

SSID = "myHotspotPassword:" + SSID

This is simple fix to close the security hole where a malicious actor could potentially claim another user's device (and thus gain access) by causing it to go offline (ex: through wifi jamming) and replacing the credentials with their own. A user can change/override the hotspot password from the cloud once they first activate a device to make it unique to them (instead of it always using the manufacturer set value in viam-defaults.json) when concerned about this.