### PR TITLE
RSDK-11021 - Only log ssid truncated if it is user defined

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -392,6 +392,10 @@ func validateConfig(cfg AgentConfig) (AgentConfig, error) {
 			errw.New("network_configuration.hotspot_password should not be empty, please omit empty fields entirely"))
 	}
 
+	if len(cfg.NetworkConfiguration.HotspotSSID) > 32 {
+		errOut = errors.Join(errOut, errw.New("network_configuration.hotspot_ssid is being truncated to 32 characters"))
+	}
+
 	if cfg.NetworkConfiguration.HotspotSSID == "" {
 		hostname, err := os.Hostname()
 		if err != nil {
@@ -400,9 +404,9 @@ func validateConfig(cfg AgentConfig) (AgentConfig, error) {
 		}
 		cfg.NetworkConfiguration.HotspotSSID = cfg.NetworkConfiguration.HotspotPrefix + "-" + strings.ToLower(hostname)
 	}
+
 	if len(cfg.NetworkConfiguration.HotspotSSID) > 32 {
 		cfg.NetworkConfiguration.HotspotSSID = cfg.NetworkConfiguration.HotspotSSID[:32]
-		errOut = errors.Join(errOut, errw.New("network_configuration.hotspot_ssid is being truncated to 32 characters"))
 	}
 
 	var haveBadTimeout bool


### PR DESCRIPTION
side steps the whole only validate config if it is different from previous, but didn't think we needed to do that yet

the idea is that we would only warn if this is a deliberate choice that the user made, but also down to just remove the log entirely