### PR TITLE
RSDK-10951: Quickfix for more responsive UX on incorrect wifi password

### DIFF
--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -702,6 +702,7 @@ func (n *Networking) backgroundLoop(ctx context.Context, scanChan chan<- bool) {
 	}
 }
 
+// Process user input (viam.json and/or Wifi settings) and return true if everything succeeded without error, false otherwise.
 func (n *Networking) processUserInput(userInput userInput) bool {
 	if userInput.RawConfig != "" || userInput.PartID != "" {
 		n.logger.Info("Device config received")

--- a/subsystems/networking/networkstate_linux.go
+++ b/subsystems/networking/networkstate_linux.go
@@ -108,7 +108,7 @@ func (n *networkState) genNetKey(ifName, ssid string) string {
 }
 
 // LockingNetwork returns a pointer to a network, wrapped in a lockable struct, so updates are persisted
-// Users must lock the returned network before updates.
+// Users must lock the returned network before updates. Use Network() instead for a read-only copy.
 func (n *networkState) LockingNetwork(iface, ssid string) *lockingNetwork {
 	n.mu.Lock()
 	defer n.mu.Unlock()


### PR DESCRIPTION
Quickfix to bypass the internal hotspot restart timer in specific cases (namely, when user enters incorrect wifi password). Works well on my Raspberry Pi 4B with both the web portal and GRPC provisioning, but let me know if there are other odd devices or corner cases. I also invite others to help test.

Switching between networks on the OS side (disabling hotspot in order to try the newly entered wifi, and reactivating hotspot if it fails) takes some time, so this is likely about the fastest and most "responsive" I can see with this current design.

```
2025-06-25T20:33:14.834Z        INFO    viam-agent      networking/networkmanager_linux.go:204  Starting provisioning mode.
2025-06-25T20:33:14.835Z        INFO    viam-agent      networking/networkmanager_linux.go:501  Adding/updating settings for network viam-setup-10951@wlan0
2025-06-25T20:33:14.853Z        INFO    viam-agent      networking/networkmanager_linux.go:306  Activating connection: viam-setup-10951@wlan0
2025-06-25T20:33:18.861Z        INFO    viam-agent      networking/networkmanager_linux.go:356  Successfully activated connection: viam-setup-10951@wlan0
2025-06-25T20:33:18.861Z        INFO    viam-agent      networking/networkmanager_linux.go:247  Hotspot provisioning set up successfully.
2025-06-25T20:33:18.942Z        INFO    viam-agent      networking/bluetooth_linux.go:64        Bluetooth provisioning started.
(waiting for user input...)
2025-06-25T20:33:44.705Z        INFO    viam-agent      networking/networkmanager_linux.go:744  Wifi settings received for Viam-2G
2025-06-25T20:33:44.748Z        INFO    viam-agent      networking/networkmanager_linux.go:501  Adding/updating settings for network Viam-2G@wlan0
2025-06-25T20:33:46.786Z        INFO    viam-agent      networking/networkmanager_linux.go:258  Stopping provisioning mode.
2025-06-25T20:33:46.787Z        INFO    viam-agent      networking/networkmanager_linux.go:390  Deactivating connection: viam-setup-10951@wlan0
2025-06-25T20:33:46.809Z        INFO    viam-agent      networking/networkmanager_linux.go:397  Successfully deactivated connection: viam-setup-10951@wlan0
2025-06-25T20:33:46.809Z        INFO    viam-agent      networking/networkmanager_linux.go:280  Stopped hotspot provisioning mode.
-->2025-06-25T20:33:53.196Z        INFO    viam-agent      networking/networkmanager_linux.go:306  Activating connection: Viam-2G@wlan0
-->2025-06-25T20:34:06.213Z        WARN    viam-agent      networking/networkmanager_linux.go:620  bad or missing password
-->2025-06-25T20:34:06.213Z        INFO    viam-agent      networking/networkmanager_linux.go:204  Starting provisioning mode.
2025-06-25T20:34:06.213Z        INFO    viam-agent      networking/networkmanager_linux.go:501  Adding/updating settings for network viam-setup-10951@wlan0
2025-06-25T20:34:06.232Z        INFO    viam-agent      networking/networkmanager_linux.go:306  Activating connection: viam-setup-10951@wlan0
2025-06-25T20:34:10.246Z        INFO    viam-agent      networking/networkmanager_linux.go:356  Successfully activated connection: viam-setup-10951@wlan0
2025-06-25T20:34:10.247Z        INFO    viam-agent      networking/networkmanager_linux.go:247  Hotspot provisioning set up successfully.
2025-06-25T20:34:10.318Z        INFO    viam-agent      networking/bluetooth_linux.go:64        Bluetooth provisioning started.
(waiting for user input...)
2025-06-25T20:34:31.224Z        INFO    viam-agent      networking/networkmanager_linux.go:744  Wifi settings received for Viam-2G
2025-06-25T20:34:31.244Z        INFO    viam-agent      networking/networkmanager_linux.go:501  Adding/updating settings for network Viam-2G@wlan0
2025-06-25T20:34:33.284Z        INFO    viam-agent      networking/networkmanager_linux.go:258  Stopping provisioning mode.
2025-06-25T20:34:33.284Z        INFO    viam-agent      networking/networkmanager_linux.go:390  Deactivating connection: viam-setup-10951@wlan0
2025-06-25T20:34:33.295Z        INFO    viam-agent      networking/networkmanager_linux.go:397  Successfully deactivated connection: viam-setup-10951@wlan0
2025-06-25T20:34:33.296Z        INFO    viam-agent      networking/networkmanager_linux.go:280  Stopped hotspot provisioning mode.
2025-06-25T20:34:39.845Z        INFO    viam-agent      networking/networkmanager_linux.go:306  Activating connection: Viam-2G@wlan0
2025-06-25T20:34:43.863Z        INFO    viam-agent      networking/networkmanager_linux.go:356  Successfully activated connection: Viam-2G@wlan0
2025-06-25T20:34:43.977Z        INFO    viam-agent      networking/connstate_linux.go:39        Online: true
2025-06-25T20:34:43.983Z        INFO    viam-agent      networking/connstate_linux.go:65        Wifi Connected: true
```
