### PR TITLE
RSDK-7895: Avoid having agent logging make assumptions about input patterns.

### DIFF
--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -97,8 +97,8 @@ func (s *viamServer) Start(ctx context.Context) error {
 		s.shouldRun = true
 	}
 
-	stdio := utils.NewMatchingLogger(s.logger, false, false)
-	stderr := utils.NewMatchingLogger(s.logger, false, false)
+	stdio := utils.NewMatchingLogger(s.logger, false, false, "viam-server.StdOut")
+	stderr := utils.NewMatchingLogger(s.logger, false, false, "viam-server.StdErr")
 	//nolint:gosec
 	s.cmd = exec.Command(binPath, "-config", utils.AppConfigFilePath)
 	s.cmd.Dir = utils.ViamDirs["viam"]

--- a/utils/logger_test.go
+++ b/utils/logger_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"go.uber.org/zap/zapcore"
+	"go.viam.com/rdk/logging"
 	"go.viam.com/test"
 )
 
@@ -41,4 +42,41 @@ func TestParseLog(t *testing.T) {
 		entry := parsed.entry()
 		test.That(t, entry.Message, test.ShouldResemble, "")
 	})
+}
+
+func TestUnstructuredLogger(t *testing.T) {
+	// We want to test the `MatchingLogger`. A `MatchingLogger` takes bytes (of raw log lines) and
+	// outputs those bytes:
+	// - Wrapped in a LogEntry envelop and written to the underlying logger or
+	// - Directly to stdout
+	//
+	// We set up an "observed" test logger to capture which logs get written to it.
+	logger, observedLogs := logging.NewObservedTestLogger(t)
+	// We use `false, false` such that "unstructured" logs:
+	// - are logged as warns (unimportant here)
+	// - And that "structured" logs are _not_ written to the underlying logger.
+	//
+	// Where "structured" logs are identified by starting with a `<YYYY>-<MM>-<DD>T` pattern.
+	matchingLogger := NewMatchingLogger(logger, false, false, "viam-server.StdOut")
+
+	// Write a normal structured log line to the `matchingLogger`. This will not be forwarded to the
+	// underlying observed logger.
+	matchingLogger.Write([]byte("2025-06-27T01:59:16.710Z	INFO	rdk	config/logging_level.go:38	Log\n"))
+	test.That(t, len(observedLogs.TakeAll()), test.ShouldEqual, 0)
+
+	// Write an unstructured log line. This is perhaps something that writes directly to the
+	// viam-server stdout without the help of a viam configured logger. Assert this log line is
+	// written to the underlying logger.
+	matchingLogger.Write([]byte("Candidate pair bandwidth log. Agent: 0x40018f0308 From: 127.0.0.1:51248 To:\n"))
+	test.That(t, len(observedLogs.TakeAll()), test.ShouldEqual, 1)
+
+	// As a `MatchingLogger` is attached directly to a process' stdout, there's no guarantee
+	// `MatchingLogger.Write([]byte)` is called exactly once per log line. Feed four log lines. Two
+	// "structured" and two "unstructured". Assert only two get forwarded to the underlying logger.
+	matchingLogger.Write([]byte(`2025-06-27T01:59:16.710Z	INFO	rdk	config/logging_level.go:38	Log
+Candidate pair bandwidth log. Agent: 0x40018f0308 From: 127.0.0.1:51248 To:
+2025-06-27T01:59:16.710Z	INFO	rdk	config/logging_level.go:38	Log
+Candidate pair bandwidth log. Agent: 0x40018f0308 From: 127.0.0.1:51248 To:
+`))
+	test.That(t, len(observedLogs.TakeAll()), test.ShouldEqual, 2)
 }


### PR DESCRIPTION
- Do _not_ assume there is only one newline per call to `Write`
  - But we continue to ssume that calls to `Write` will be on a newline boundary.
- Remove the "unstructured log" prefix. It's not necessary.
- Label the uploaded logs as coming from `viam-server.Stdout`.