### PR TITLE
[RSDK-10815] [APP-8673] Bluetooth Tethering

### DIFF
--- a/cmd/provisioning-client/bluetooth.go
+++ b/cmd/provisioning-client/bluetooth.go
@@ -37,7 +37,7 @@ const (
 	cryptoKey                = "pub_key"
 	exitProvisioningKey      = "exit_provisioning"
 	agentVersionKey          = "agent_version"
-	tetherAddressKey         = "tether_address"
+	unlockPairingKey         = "unlock_pairing"
 )
 
 var pubKey *rsa.PublicKey
@@ -99,8 +99,8 @@ func btClient() error {
 		}
 	}
 
-	if opts.TetherAddr != "" {
-		if err := BTSetTetherAddress(chars); err != nil {
+	if opts.UnlockPairing {
+		if err := BTUnlockPairing(chars); err != nil {
 			return err
 		}
 	}
@@ -347,20 +347,20 @@ func BTSetWifiCreds(chars map[string]bluetooth.DeviceCharacteristic) error {
 	return nil
 }
 
-func BTSetTetherAddress(chars map[string]bluetooth.DeviceCharacteristic) error {
-	fmt.Println("writing tethering address...")
+func BTUnlockPairing(chars map[string]bluetooth.DeviceCharacteristic) error {
+	fmt.Println("writing unlock pairing request...")
 	if err := initCrypto(chars); err != nil {
 		return err
 	}
 
-	cryptAddr, err := encrypt([]byte(opts.TetherAddr))
+	cryptAddr, err := encrypt([]byte("1"))
 	if err != nil {
 		return err
 	}
 
-	_, err = chars[tetherAddressKey].WriteWithoutResponse(cryptAddr)
+	_, err = chars[unlockPairingKey].WriteWithoutResponse(cryptAddr)
 	if err != nil {
-		return errw.Wrap(err, "writing ssid")
+		return errw.Wrap(err, "writing unlock pairing request")
 	}
 
 	return nil
@@ -468,9 +468,9 @@ func getCharicteristicsMap(device *bluetooth.Device) (map[string]bluetooth.Devic
 		case getUUID(exitProvisioningKey):
 			key = exitProvisioningKey
 			charMap[exitProvisioningKey] = char
-		case getUUID(tetherAddressKey):
-			key = tetherAddressKey
-			charMap[tetherAddressKey] = char
+		case getUUID(unlockPairingKey):
+			key = unlockPairingKey
+			charMap[unlockPairingKey] = char
 
 		default:
 			fmt.Printf("Unknown characteristic discovered with UUID: %s", char.String())

--- a/cmd/provisioning-client/opts.go
+++ b/cmd/provisioning-client/opts.go
@@ -12,6 +12,8 @@ var opts struct {
 	BTScan   bool   `description:"Bluetooth Scan" long:"scan"`
 	BTFilter string `default:"viam-setup"         description:"Bluetooth Device Name Prefix" long:"filter" short:"f"`
 
+	TetherAddr string `description:"Bluetooth hardware address to trust for tethering" long:"tether" short:"t"`
+
 	Address string `description:"GRPC address/port to dial (ex: 'localhost:4772')" long:"address" short:"a"`
 
 	WifiSSID string `description:"SSID to set"           long:"wifi-ssid"`

--- a/cmd/provisioning-client/opts.go
+++ b/cmd/provisioning-client/opts.go
@@ -12,7 +12,7 @@ var opts struct {
 	BTScan   bool   `description:"Bluetooth Scan" long:"scan"`
 	BTFilter string `default:"viam-setup"         description:"Bluetooth Device Name Prefix" long:"filter" short:"f"`
 
-	TetherAddr string `description:"Bluetooth hardware address to trust for tethering" long:"tether" short:"t"`
+	UnlockPairing bool `description:"Unlock bluetooth pairing (for tethering)" long:"pairing" short:"p"`
 
 	Address string `description:"GRPC address/port to dial (ex: 'localhost:4772')" long:"address" short:"a"`
 

--- a/examples/agent-config.jsonc
+++ b/examples/agent-config.jsonc
@@ -32,7 +32,8 @@
 		"retry_connection_timeout_minutes": 10,
 		"device_reboot_after_offline_minutes": 0, // does nothing when set to zero
 		"disable_bt_provisioning": false,
-		"disable_wifi_provisioning": false
+		"disable_wifi_provisioning": false,
+		"bluetooth_trust_all": false // if true, accept all bluetooth pairing requests without requiring devices addr to be adding via provisioning
 	},
 	"additional_networks": {
 		"myNetwork1": {

--- a/examples/agent-config.jsonc
+++ b/examples/agent-config.jsonc
@@ -33,7 +33,7 @@
 		"device_reboot_after_offline_minutes": 0, // does nothing when set to zero
 		"disable_bt_provisioning": false,
 		"disable_wifi_provisioning": false,
-		"bluetooth_trust_all": false // if true, accept all bluetooth pairing requests without requiring devices addr to be adding via provisioning
+		"bluetooth_trust_all": false // if true, accept all bluetooth pairing requests without requiring dev address to be added via provisioning
 	},
 	"additional_networks": {
 		"myNetwork1": {

--- a/subsystems/networking/bluetooth_characteristics_linux.go
+++ b/subsystems/networking/bluetooth_characteristics_linux.go
@@ -37,11 +37,15 @@ const (
 	cryptoKey                = "pub_key"
 	exitProvisioningKey      = "exit_provisioning"
 	agentVersionKey          = "agent_version"
+	tetherAddress            = "tether_address"
 )
 
 var (
-	characteristicsWriteOnly = []string{ssidKey, pskKey, robotPartIDKey, robotPartSecretKey, appAddressKey, exitProvisioningKey}
-	characteristicsReadOnly  = []string{
+	characteristicsWriteOnly = []string{
+		ssidKey, pskKey, robotPartIDKey, robotPartSecretKey,
+		appAddressKey, exitProvisioningKey, tetherAddress,
+	}
+	characteristicsReadOnly = []string{
 		cryptoKey, statusKey, manufacturerKey, modelKey,
 		fragmentKey, availableWiFiNetworksKey, errorsKey, agentVersionKey,
 	}

--- a/subsystems/networking/bluetooth_linux.go
+++ b/subsystems/networking/bluetooth_linux.go
@@ -153,8 +153,7 @@ func (n *Networking) removeServices() error {
 	var ok bool
 	for id := range 10000 {
 		path := dbus.ObjectPath(fmt.Sprintf("/org/tinygo/bluetooth/service%d", id))
-		err := adapter.Call("org.bluez.GattManager1.UnregisterApplication", 0, path).Err
-		if err == nil {
+		if adapter.Call("org.bluez.GattManager1.UnregisterApplication", 0, path).Err == nil {
 			n.logger.Debugf("removed gatt service %s", path)
 			ok = true
 		}

--- a/subsystems/networking/bluetooth_linux.go
+++ b/subsystems/networking/bluetooth_linux.go
@@ -53,7 +53,9 @@ func (n *Networking) startProvisioningBluetooth(ctx context.Context) error {
 		n.logger.Warn("could not update BT networks characteristic")
 	}
 
-	// TODO RSDK-10815: Enable pairing and tethering
+	if err := n.enablePairing(n.Config().HotspotSSID); err != nil {
+		return err
+	}
 
 	// Start advertising the bluetooth service.
 	if err := n.btAdv.Start(); err != nil {
@@ -76,7 +78,9 @@ func (n *Networking) stopProvisioningBluetooth() error {
 	}
 	n.btAdv = nil
 
-	// TODO RSDK-10815: Enable pairing and tethering
+	if err := n.disablePairing(); err != nil {
+		return err
+	}
 
 	if err := n.removeServices(); err != nil {
 		return err

--- a/subsystems/networking/bluetooth_tethering_linux.go
+++ b/subsystems/networking/bluetooth_tethering_linux.go
@@ -1,0 +1,84 @@
+package networking
+
+import (
+	"fmt"
+	"time"
+
+	dbus "github.com/godbus/dbus/v5"
+	errw "github.com/pkg/errors"
+	"go.viam.com/rdk/logging"
+)
+
+type basicAgent struct {
+	conn   *dbus.Conn
+	logger logging.Logger
+}
+
+func (b *basicAgent) RequestAuthorization(device dbus.ObjectPath) *dbus.Error {
+	return nil
+	// b.logger.Infof("rejecting just-works bluetooth pair attempt for %s, please initiate pairing from your mobile device settings", device)
+	// return &dbus.Error{Name: "org.bluez.Error.Rejected"}
+}
+
+func (n *Networking) enablePairing(deviceName string) error {
+	conn, adapter, err := getBluetoothDBus()
+	if err != nil {
+		return err
+	}
+
+	err = adapter.SetProperty("org.bluez.Adapter1.Alias", dbus.MakeVariant(deviceName))
+	if err != nil {
+		return errw.Wrap(err, "setting bluetooth alias")
+	}
+
+	n.logger.Debug("setting bluetooth to discoverable")
+	err = adapter.SetProperty("org.bluez.Adapter1.Discoverable", dbus.MakeVariant(true))
+	if err != nil {
+		return errw.Wrap(err, "enabling bluetooth discovery")
+	}
+
+	discoveryTimeout := uint32(time.Duration(n.Config().RetryConnectionTimeoutMinutes * 2).Seconds())
+	err = adapter.SetProperty("org.bluez.Adapter1.DiscoverableTimeout", dbus.MakeVariant(discoveryTimeout))
+	if err != nil {
+		return errw.Wrap(err, "adjusting discovery timeout")
+	}
+
+	if err := conn.Export(&basicAgent{logger: n.logger, conn: conn}, BluezAgentPath, BluezAgent); err != nil {
+		return errw.Wrap(err, "exporting custom agent object")
+	}
+
+	obj := conn.Object(BluezDBusService, "/org/bluez")
+	call := obj.Call("org.bluez.AgentManager1.RegisterAgent", 0, dbus.ObjectPath(BluezAgentPath), "NoInputNoOutput")
+	if err := call.Err; err != nil {
+		return errw.Wrap(err, "registering custom agent")
+	}
+
+	call = obj.Call("org.bluez.AgentManager1.RequestDefaultAgent", 0, dbus.ObjectPath(BluezAgentPath))
+	if err := call.Err; err != nil {
+		return fmt.Errorf("failed to set default agent: %w", err)
+	}
+
+	n.logger.Debug("bluetooth pairing enabled")
+	return nil
+}
+
+func (n *Networking) disablePairing() error {
+	conn, adapter, err := getBluetoothDBus()
+	if err != nil {
+		return err
+	}
+
+	obj := conn.Object(BluezDBusService, "/org/bluez")
+	call := obj.Call("org.bluez.AgentManager1.UnregisterAgent", 0, dbus.ObjectPath(BluezAgentPath))
+	if err := call.Err; err != nil {
+		n.logger.Warnf("failed to unregister a bluez agent: %v", err)
+	}
+
+	n.logger.Debug("setting bluetooth to NOT discoverable")
+	err = adapter.SetProperty("org.bluez.Adapter1.Discoverable", dbus.MakeVariant(false))
+	if err != nil {
+		return errw.Wrap(err, "disabling bluetooth discovery")
+	}
+	n.logger.Debug("bluetooth pairing disabled")
+	return nil
+}

--- a/subsystems/networking/bluetooth_tethering_linux.go
+++ b/subsystems/networking/bluetooth_tethering_linux.go
@@ -138,8 +138,9 @@ func (b *pairingAgent) RequestAuthorization(devicePath dbus.ObjectPath) *dbus.Er
 			ret, err := remoteDev.GetProperty("org.bluez.Device1.Paired")
 			if err != nil {
 				b.logger.Warn(errw.Wrapf(err, "cannot get paired status for bluetooth device: %s (%s)", bdaddr, alias))
+			} else if ret.Value() != nil {
+				paired = ret.Value().(bool)
 			}
-			paired = ret.Value().(bool)
 		}
 
 		// We have to connect something to make service discovery happen (this is a workaround probably specific to Bluez/Linux)

--- a/subsystems/networking/bluetooth_tethering_linux.go
+++ b/subsystems/networking/bluetooth_tethering_linux.go
@@ -17,10 +17,11 @@ var errPairingRejected = &dbus.Error{Name: "org.bluez.Error.Rejected"}
 
 // this will be the bluetooth "agent" used for pairing requests.
 type basicAgent struct {
-	mu      sync.Mutex
-	conn    *dbus.Conn
-	logger  logging.Logger
-	trusted map[string]bool
+	mu       sync.Mutex
+	conn     *dbus.Conn
+	logger   logging.Logger
+	trusted  map[string]bool
+	trustAll bool
 
 	workers sync.WaitGroup
 	cancel  context.CancelFunc
@@ -80,7 +81,7 @@ func (b *basicAgent) RequestAuthorization(devicePath dbus.ObjectPath) *dbus.Erro
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	trusted, ok := b.trusted[bdaddr]
-	if !(ok && trusted) {
+	if !(ok && trusted) && !b.trustAll {
 		b.logger.Errorf("Bluetooth device pairing rejected for %s (%s), device address must be added via provisioning first.", bdaddr, alias)
 		return errPairingRejected
 	}

--- a/subsystems/networking/bluetooth_tethering_linux.go
+++ b/subsystems/networking/bluetooth_tethering_linux.go
@@ -2,6 +2,8 @@ package networking
 
 import (
 	"fmt"
+	"slices"
+	"sync"
 	"time"
 
 	dbus "github.com/godbus/dbus/v5"
@@ -9,20 +11,110 @@ import (
 	"go.viam.com/rdk/logging"
 )
 
+var errPairingRejected = &dbus.Error{Name: "org.bluez.Error.Rejected"}
+
 type basicAgent struct {
-	conn   *dbus.Conn
-	logger logging.Logger
+	mu      sync.Mutex
+	conn    *dbus.Conn
+	logger  logging.Logger
+	trusted []string
 }
 
-func (b *basicAgent) RequestAuthorization(device dbus.ObjectPath) *dbus.Error {
+func (b *basicAgent) Cancel() *dbus.Error {
+	b.logger.Debug("SMURF Cancel")
 	return nil
-	// b.logger.Infof("rejecting just-works bluetooth pair attempt for %s, please initiate pairing from your mobile device settings", device)
-	// return &dbus.Error{Name: "org.bluez.Error.Rejected"}
+}
+
+func (b *basicAgent) DisplayPasskey(devicePath dbus.ObjectPath, passkey, entered uint32) *dbus.Error {
+	b.logger.Debugf("SMURF DisplayPasskey %s", passkey)
+	return nil
+}
+
+func (b *basicAgent) DisplayPinCode(devicePath dbus.ObjectPath, pincode string) *dbus.Error {
+	b.logger.Debugf("SMURF DisplayPinCode %s", pincode)
+	return nil
+}
+
+func (b *basicAgent) RequestConfirmation(devicePath dbus.ObjectPath, passkey uint32) *dbus.Error {
+	b.logger.Debug("SMURF RequestConfirmation")
+	return b.RequestAuthorization(devicePath)
+}
+
+func (b *basicAgent) RequestAuthorization(devicePath dbus.ObjectPath) *dbus.Error {
+	b.logger.Debugf("SMURF RequestAuthorization %+v", devicePath)
+	conn, _, err := getBluetoothDBus()
+	if err != nil {
+		b.logger.Error(err)
+		return errPairingRejected
+	}
+
+	remoteDev := conn.Object(BluezDBusService, devicePath)
+
+	bdaddr, err := remoteDev.GetProperty("org.bluez.Device1.Address")
+	if err != nil {
+		b.logger.Error(err)
+		return errPairingRejected
+	}
+
+	// bdaddrStr := strings.Trim(bdaddr.String(), "\"")
+	bdaddrStr := bdaddr.Value().(string)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.logger.Infof("Bluetooth pairing request from: %s", bdaddrStr)
+	b.logger.Warnf("SMURF equal:%t, (%s), (%s)", bdaddrStr == b.trusted[0], bdaddrStr, b.trusted[0])
+
+	if !slices.Contains(b.trusted, bdaddrStr) {
+		b.logger.Errorf("Bluetooth device pairing rejected for %s, device address must be added via provisioning first.", bdaddrStr)
+		return errPairingRejected
+	}
+
+	if err := remoteDev.SetProperty("org.bluez.Device1.Trusted", true); err != nil {
+		b.logger.Error(errw.Wrapf(err, "trusting bluetooth device %s", bdaddrStr))
+	} else {
+		b.logger.Infof("Bluetooth device trusted: %s", bdaddrStr)
+	}
+
+	b.logger.Warnf("Bluetooth device paired: %s", bdaddrStr)
+
+	go func() {
+		b.logger.Warn("SMURF1")
+
+		var i int
+		for {
+			i++
+			ret, err := remoteDev.GetProperty("org.bluez.Device1.Paired")
+			if err != nil {
+				b.logger.Warn(errw.Wrapf(err, "cannot get paired status for bluetooth device %s", bdaddrStr))
+			}
+			if ret.Value().(bool) || i > 30 {
+				break
+			}
+			b.logger.Warnf("SMURF Value: %+v", ret.Value())
+			time.Sleep(time.Second * 1)
+		}
+		b.logger.Warn("SMURF2")
+		call := remoteDev.Call("org.bluez.Device1.ConnectProfile", 0, "00001115-0000-1000-8000-00805f9b34fb")
+		b.logger.Warn("SMURF3")
+		if err := call.Err; err != nil {
+			b.logger.Error(errw.Wrapf(err, "connecting bluetooth device %s", bdaddrStr))
+		}
+
+		b.logger.Infof("Connected bluetooth device for tethering: %s", bdaddrStr)
+	}()
+
+	return nil
 }
 
 func (n *Networking) enablePairing(deviceName string) error {
 	conn, adapter, err := getBluetoothDBus()
 	if err != nil {
+		return err
+	}
+
+	call := adapter.Call("org.bluez.Adapter1.StartDiscovery", 0)
+	if call.Err != nil {
 		return err
 	}
 
@@ -43,12 +135,13 @@ func (n *Networking) enablePairing(deviceName string) error {
 		return errw.Wrap(err, "adjusting discovery timeout")
 	}
 
-	if err := conn.Export(&basicAgent{logger: n.logger, conn: conn}, BluezAgentPath, BluezAgent); err != nil {
+	// SMURF remove trusted!
+	if err := conn.Export(&basicAgent{logger: n.logger, conn: conn, trusted: []string{"FC:41:16:BF:6D:98"}}, BluezAgentPath, BluezAgent); err != nil {
 		return errw.Wrap(err, "exporting custom agent object")
 	}
 
 	obj := conn.Object(BluezDBusService, "/org/bluez")
-	call := obj.Call("org.bluez.AgentManager1.RegisterAgent", 0, dbus.ObjectPath(BluezAgentPath), "NoInputNoOutput")
+	call = obj.Call("org.bluez.AgentManager1.RegisterAgent", 0, dbus.ObjectPath(BluezAgentPath), "DisplayYesNo")
 	if err := call.Err; err != nil {
 		return errw.Wrap(err, "registering custom agent")
 	}
@@ -68,8 +161,13 @@ func (n *Networking) disablePairing() error {
 		return err
 	}
 
+	call := adapter.Call("org.bluez.Adapter1.StopDiscovery", 0)
+	if call.Err != nil {
+		return err
+	}
+
 	obj := conn.Object(BluezDBusService, "/org/bluez")
-	call := obj.Call("org.bluez.AgentManager1.UnregisterAgent", 0, dbus.ObjectPath(BluezAgentPath))
+	call = obj.Call("org.bluez.AgentManager1.UnregisterAgent", 0, dbus.ObjectPath(BluezAgentPath))
 	if err := call.Err; err != nil {
 		n.logger.Warnf("failed to unregister a bluez agent: %v", err)
 	}

--- a/subsystems/networking/definitions.go
+++ b/subsystems/networking/definitions.go
@@ -10,7 +10,7 @@ const (
 	NetworkTypeHotspot   = "hotspot"
 	NetworkTypeBluetooth = "bluetooth"
 
-	HealthCheckTimeout = time.Minute
+	HealthCheckTimeout = time.Minute * 2
 )
 
 var NetworkTypesKnown = []string{NetworkTypeHotspot, NetworkTypeWifi, NetworkTypeWired, NetworkTypeBluetooth}

--- a/subsystems/networking/definitions.go
+++ b/subsystems/networking/definitions.go
@@ -10,5 +10,8 @@ const (
 	NetworkTypeHotspot   = "hotspot"
 	NetworkTypeBluetooth = "bluetooth"
 
-	HealthCheckTimeout = time.Minute * 2
+	HealthCheckTimeout      = time.Minute
+	BluetoothPairingTimeout = time.Second * 30
 )
+
+var NetworkTypesKnown = []string{NetworkTypeHotspot, NetworkTypeWifi, NetworkTypeWired, NetworkTypeBluetooth}

--- a/subsystems/networking/definitions.go
+++ b/subsystems/networking/definitions.go
@@ -10,8 +10,7 @@ const (
 	NetworkTypeHotspot   = "hotspot"
 	NetworkTypeBluetooth = "bluetooth"
 
-	HealthCheckTimeout      = time.Minute
-	BluetoothPairingTimeout = time.Second * 30
+	HealthCheckTimeout = time.Minute
 )
 
 var NetworkTypesKnown = []string{NetworkTypeHotspot, NetworkTypeWifi, NetworkTypeWired, NetworkTypeBluetooth}

--- a/subsystems/networking/definitions_linux.go
+++ b/subsystems/networking/definitions_linux.go
@@ -4,16 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
 
 	gnm "github.com/Otterverse/gonetworkmanager/v2"
 	pb "go.viam.com/api/provisioning/v1"
-	"go.viam.com/rdk/logging"
 )
 
 // This file contains type, const, and var definitions.
@@ -282,33 +279,7 @@ func (b *banner) Get() string {
 // bluetooth is "bluetooth@<ifname>" where ifname is the hardware address of the remote device, ex: "bluetooth@1A:2B:3C:11:22:33".
 type NetKey string
 
-const (
-	NetKeyUnknown    = NetKey("UNKNOWN")
-	HotspotInterface = "HotspotInterface"
-)
-
-func GenNetKey(netType, ifName, ssid string) NetKey {
-	switch netType {
-	case NetworkTypeHotspot:
-		fallthrough
-	case NetworkTypeWifi:
-		if ifName == "" {
-			ifName = HotspotInterface
-		}
-		return NetKey(fmt.Sprintf("%s@%s", ssid, ifName))
-	case NetworkTypeWired:
-		return NetKey(fmt.Sprintf("%s@%s", NetworkTypeWired, ifName))
-	case NetworkTypeBluetooth:
-		return NetKey(fmt.Sprintf("%s@%s", NetworkTypeBluetooth, ifName))
-	default:
-		logging.Global().Warnf("encountered unknown network type: %s, interface: %s, ssid: %s", netType, ifName, ssid)
-		_, file, no, ok := runtime.Caller(1)
-		if ok {
-			logging.Global().Warnf("called from %s#%d", file, no)
-		}
-		return NetKeyUnknown
-	}
-}
+const NetKeyUnknown = NetKey("UNKNOWN")
 
 func (n NetKey) Type() string {
 	if n == NetKeyUnknown {

--- a/subsystems/networking/generators_linux.go
+++ b/subsystems/networking/generators_linux.go
@@ -92,9 +92,9 @@ func generateNetworkSettings(id string, cfg utils.NetworkDefinition) (gnm.Connec
 
 	// Handle bluetooth
 	if cfg.Type == NetworkTypeBluetooth {
-		macAddr, err := net.ParseMAC(cfg.SSID)
+		macAddr, err := net.ParseMAC(cfg.BluetoothAddress)
 		if err != nil {
-			return nil, errw.Wrapf(err, "parsing bluetooth device address for %s", cfg.SSID)
+			return nil, errw.Wrapf(err, "parsing bluetooth device address for %s", cfg.BluetoothAddress)
 		}
 
 		settings[NetworkTypeBluetooth] = map[string]any{

--- a/subsystems/networking/generators_linux.go
+++ b/subsystems/networking/generators_linux.go
@@ -75,7 +75,7 @@ func generateNetworkSettings(id string, cfg utils.NetworkDefinition) (gnm.Connec
 		"autoconnect-priority": cfg.Priority,
 	}
 
-	if cfg.Interface != "" {
+	if cfg.Type != NetworkTypeBluetooth && cfg.Interface != "" && cfg.Interface != HotspotInterface {
 		settings["connection"]["interface-name"] = cfg.Interface
 	}
 
@@ -92,9 +92,9 @@ func generateNetworkSettings(id string, cfg utils.NetworkDefinition) (gnm.Connec
 
 	// Handle bluetooth
 	if cfg.Type == NetworkTypeBluetooth {
-		macAddr, err := net.ParseMAC(cfg.BluetoothAddress)
+		macAddr, err := net.ParseMAC(cfg.Interface)
 		if err != nil {
-			return nil, errw.Wrapf(err, "parsing bluetooth device address for %s", cfg.BluetoothAddress)
+			return nil, errw.Wrapf(err, "parsing bluetooth device address for %s", cfg.Interface)
 		}
 
 		settings[NetworkTypeBluetooth] = map[string]any{

--- a/subsystems/networking/generators_linux.go
+++ b/subsystems/networking/generators_linux.go
@@ -61,6 +61,8 @@ func generateNetworkSettings(id string, cfg utils.NetworkDefinition) (gnm.Connec
 		netType = "802-11-wireless"
 	case NetworkTypeWired:
 		netType = "802-3-ethernet"
+	case NetworkTypeBluetooth:
+		netType = NetworkTypeBluetooth
 	default:
 		return nil, errw.Errorf("unknown network type: %s", cfg.Type)
 	}
@@ -85,6 +87,19 @@ func generateNetworkSettings(id string, cfg utils.NetworkDefinition) (gnm.Connec
 		}
 		if cfg.PSK != "" {
 			settings["802-11-wireless-security"] = map[string]any{"key-mgmt": "wpa-psk", "psk": cfg.PSK}
+		}
+	}
+
+	// Handle bluetooth
+	if cfg.Type == NetworkTypeBluetooth {
+		macAddr, err := net.ParseMAC(cfg.SSID)
+		if err != nil {
+			return nil, errw.Wrapf(err, "parsing bluetooth device address for %s", cfg.SSID)
+		}
+
+		settings[NetworkTypeBluetooth] = map[string]any{
+			"type":   "panu",
+			"bdaddr": macAddr,
 		}
 	}
 

--- a/subsystems/networking/generators_linux.go
+++ b/subsystems/networking/generators_linux.go
@@ -15,7 +15,7 @@ import (
 
 // This file contains the wifi/hotspot setting generation functions.
 
-func generateHotspotSettings(id, ssid, psk, ifName string) gnm.ConnectionSettings {
+func generateHotspotSettings(id NetKey, psk string) gnm.ConnectionSettings {
 	IPAsUint32, err := generateAddress(PortalBindAddr)
 	if err != nil {
 		// BindAddr is a const, so should only ever fail if code itself is changed/broken
@@ -24,15 +24,15 @@ func generateHotspotSettings(id, ssid, psk, ifName string) gnm.ConnectionSetting
 
 	settings := gnm.ConnectionSettings{
 		"connection": map[string]any{
-			"id":             id,
+			"id":             string(id),
 			"uuid":           uuid.New().String(),
 			"type":           "802-11-wireless",
 			"autoconnect":    false,
-			"interface-name": ifName,
+			"interface-name": id.Interface(),
 		},
 		"802-11-wireless": map[string]any{
 			"mode": "ap",
-			"ssid": []byte(ssid),
+			"ssid": []byte(id.SSID()),
 		},
 		"802-11-wireless-security": map[string]any{
 			"key-mgmt": "wpa-psk",
@@ -49,14 +49,14 @@ func generateHotspotSettings(id, ssid, psk, ifName string) gnm.ConnectionSetting
 	return settings
 }
 
-func generateNetworkSettings(id string, cfg utils.NetworkDefinition) (gnm.ConnectionSettings, error) {
+func generateNetworkSettings(id NetKey, cfg utils.NetworkDefinition) (gnm.ConnectionSettings, error) {
 	settings := gnm.ConnectionSettings{}
 	if id == "" {
 		return nil, errw.New("id cannot be empty")
 	}
 
 	var netType string
-	switch cfg.Type {
+	switch id.Type() {
 	case NetworkTypeWifi:
 		netType = "802-11-wireless"
 	case NetworkTypeWired:
@@ -64,7 +64,7 @@ func generateNetworkSettings(id string, cfg utils.NetworkDefinition) (gnm.Connec
 	case NetworkTypeBluetooth:
 		netType = NetworkTypeBluetooth
 	default:
-		return nil, errw.Errorf("unknown network type: %s", cfg.Type)
+		return nil, errw.Errorf("unknown network type: %s", id.Type())
 	}
 
 	settings["connection"] = map[string]any{
@@ -75,15 +75,15 @@ func generateNetworkSettings(id string, cfg utils.NetworkDefinition) (gnm.Connec
 		"autoconnect-priority": cfg.Priority,
 	}
 
-	if cfg.Type != NetworkTypeBluetooth && cfg.Interface != "" && cfg.Interface != HotspotInterface {
-		settings["connection"]["interface-name"] = cfg.Interface
+	if id.Type() != NetworkTypeBluetooth && id.Interface() != "" {
+		settings["connection"]["interface-name"] = id.Interface()
 	}
 
 	// Handle Wifi
-	if cfg.Type == NetworkTypeWifi {
+	if id.Type() == NetworkTypeWifi {
 		settings["802-11-wireless"] = map[string]any{
 			"mode": "infrastructure",
-			"ssid": []byte(cfg.SSID),
+			"ssid": []byte(id.SSID()),
 		}
 		if cfg.PSK != "" {
 			settings["802-11-wireless-security"] = map[string]any{"key-mgmt": "wpa-psk", "psk": cfg.PSK}
@@ -91,10 +91,10 @@ func generateNetworkSettings(id string, cfg utils.NetworkDefinition) (gnm.Connec
 	}
 
 	// Handle bluetooth
-	if cfg.Type == NetworkTypeBluetooth {
-		macAddr, err := net.ParseMAC(cfg.Interface)
+	if id.Type() == NetworkTypeBluetooth {
+		macAddr, err := net.ParseMAC(id.Interface())
 		if err != nil {
-			return nil, errw.Wrapf(err, "parsing bluetooth device address for %s", cfg.Interface)
+			return nil, errw.Wrapf(err, "parsing bluetooth device address for %s", id.Interface())
 		}
 
 		settings[NetworkTypeBluetooth] = map[string]any{

--- a/subsystems/networking/grpc_linux.go
+++ b/subsystems/networking/grpc_linux.go
@@ -59,7 +59,7 @@ func (n *Networking) GetSmartMachineStatus(ctx context.Context,
 
 	lastSSID := n.netState.LastSSID(n.Config().HotspotInterface)
 	if lastSSID != "" {
-		lastNetwork := n.netState.Network(n.Config().HotspotInterface, lastSSID)
+		lastNetwork := n.netState.Network(GenNetKey(NetworkTypeWifi, n.Config().HotspotInterface, lastSSID))
 		lastNetworkInfo := lastNetwork.getInfo()
 		ret.LatestConnectionAttempt = NetworkInfoToProto(&lastNetworkInfo)
 	}
@@ -87,7 +87,7 @@ func (n *Networking) SetNetworkCredentials(ctx context.Context,
 
 	lastSSID := n.netState.LastSSID(n.Config().HotspotInterface)
 	if req.GetSsid() == lastSSID && lastSSID != "" {
-		lastNetwork := n.netState.LockingNetwork(n.Config().HotspotInterface, lastSSID)
+		lastNetwork := n.netState.LockingNetwork(GenNetKey(NetworkTypeWifi, n.Config().HotspotInterface, lastSSID))
 		lastNetwork.mu.Lock()
 		lastNetwork.lastError = nil
 		lastNetwork.mu.Unlock()
@@ -137,7 +137,9 @@ func (n *Networking) GetNetworkList(ctx context.Context,
 func (n *Networking) errListAsStrings() []string {
 	errList := []string{}
 
-	lastNetwork := n.netState.Network(n.Config().HotspotInterface, n.netState.LastSSID(n.Config().HotspotInterface))
+	lastNetwork := n.netState.Network(
+		GenNetKey(NetworkTypeWifi, n.Config().HotspotInterface, n.netState.LastSSID(n.Config().HotspotInterface)),
+	)
 
 	if lastNetwork.lastError != nil {
 		errList = append(errList, fmt.Sprintf("SSID: %s: %s", lastNetwork.ssid, lastNetwork.lastError))

--- a/subsystems/networking/grpc_linux.go
+++ b/subsystems/networking/grpc_linux.go
@@ -59,7 +59,7 @@ func (n *Networking) GetSmartMachineStatus(ctx context.Context,
 
 	lastSSID := n.netState.LastSSID(n.Config().HotspotInterface)
 	if lastSSID != "" {
-		lastNetwork := n.netState.Network(GenNetKey(NetworkTypeWifi, n.Config().HotspotInterface, lastSSID))
+		lastNetwork := n.netState.Network(n.netState.GenNetKey(NetworkTypeWifi, "", lastSSID))
 		lastNetworkInfo := lastNetwork.getInfo()
 		ret.LatestConnectionAttempt = NetworkInfoToProto(&lastNetworkInfo)
 	}
@@ -87,7 +87,7 @@ func (n *Networking) SetNetworkCredentials(ctx context.Context,
 
 	lastSSID := n.netState.LastSSID(n.Config().HotspotInterface)
 	if req.GetSsid() == lastSSID && lastSSID != "" {
-		lastNetwork := n.netState.LockingNetwork(GenNetKey(NetworkTypeWifi, n.Config().HotspotInterface, lastSSID))
+		lastNetwork := n.netState.LockingNetwork(n.netState.GenNetKey(NetworkTypeWifi, "", lastSSID))
 		lastNetwork.mu.Lock()
 		lastNetwork.lastError = nil
 		lastNetwork.mu.Unlock()
@@ -138,7 +138,7 @@ func (n *Networking) errListAsStrings() []string {
 	errList := []string{}
 
 	lastNetwork := n.netState.Network(
-		GenNetKey(NetworkTypeWifi, n.Config().HotspotInterface, n.netState.LastSSID(n.Config().HotspotInterface)),
+		n.netState.GenNetKey(NetworkTypeWifi, "", n.netState.LastSSID(n.Config().HotspotInterface)),
 	)
 
 	if lastNetwork.lastError != nil {

--- a/subsystems/networking/networking_linux.go
+++ b/subsystems/networking/networking_linux.go
@@ -387,7 +387,7 @@ func (n *Networking) processAdditionalnetworks(ctx context.Context) {
 			continue
 		}
 		if network.Interface != "" {
-			if err := n.activateConnection(ctx, GenNetKey(network.Type, network.Interface, network.SSID)); err != nil {
+			if err := n.activateConnection(ctx, n.netState.GenNetKey(network.Type, network.Interface, network.SSID)); err != nil {
 				n.logger.Warn(err)
 			}
 		}
@@ -419,7 +419,7 @@ func (n *Networking) writeWifiPowerSave(ctx context.Context) error {
 
 		ssid := n.netState.ActiveSSID(n.Config().HotspotInterface)
 		if n.connState.getConnected() && ssid != "" {
-			if err := n.activateConnection(ctx, GenNetKey(NetworkTypeWifi, HotspotInterface, ssid)); err != nil {
+			if err := n.activateConnection(ctx, n.netState.GenNetKey(NetworkTypeWifi, "", ssid)); err != nil {
 				return errw.Wrapf(err, "reactivating %s to enforce powersave setting", ssid)
 			}
 		}

--- a/subsystems/networking/networking_linux.go
+++ b/subsystems/networking/networking_linux.go
@@ -58,9 +58,10 @@ type Networking struct {
 	portalData *userInputData
 
 	// bluetooth
-	noBT   bool
-	btChar *btCharacteristics
-	btAdv  *bluetooth.Advertisement
+	noBT    bool
+	btChar  *btCharacteristics
+	btAdv   *bluetooth.Advertisement
+	btAgent *basicAgent
 
 	pb.UnimplementedProvisioningServiceServer
 }

--- a/subsystems/networking/networking_linux.go
+++ b/subsystems/networking/networking_linux.go
@@ -61,7 +61,7 @@ type Networking struct {
 	noBT    bool
 	btChar  *btCharacteristics
 	btAdv   *bluetooth.Advertisement
-	btAgent *basicAgent
+	btAgent *pairingAgent
 
 	pb.UnimplementedProvisioningServiceServer
 }
@@ -82,7 +82,7 @@ func NewSubsystem(ctx context.Context, logger logging.Logger, cfg utils.AgentCon
 		bgLoopHealth:   &health{},
 	}
 	subsys.portalData = &userInputData{connState: subsys.connState}
-	subsys.btAgent = &basicAgent{
+	subsys.btAgent = &pairingAgent{
 		logger:     logger,
 		networking: subsys,
 		trusted:    make(map[string]bool),

--- a/subsystems/networking/networking_linux.go
+++ b/subsystems/networking/networking_linux.go
@@ -88,7 +88,7 @@ func NewSubsystem(ctx context.Context, logger logging.Logger, cfg utils.AgentCon
 		trusted:    make(map[string]bool),
 		trustAll:   cfg.NetworkConfiguration.BluetoothTrustAll.Get(),
 	}
-	subsys.btChar = newBTCharacteristics(logger, subsys.portalData, cfg.NetworkConfiguration.HotspotPassword, subsys.btAgent.TrustDevice)
+	subsys.btChar = newBTCharacteristics(logger, subsys.portalData, cfg.NetworkConfiguration.HotspotPassword, subsys.btAgent.TrustAll)
 	return subsys
 }
 

--- a/subsystems/networking/networking_linux.go
+++ b/subsystems/networking/networking_linux.go
@@ -285,12 +285,6 @@ func (n *Networking) Stop(ctx context.Context) error {
 	}
 
 	n.logger.Infof("%s subsystem exiting", SubsysName)
-	if n.connState.getProvisioning() {
-		err := n.stopProvisioning()
-		if err != nil {
-			n.logger.Warn(err)
-		}
-	}
 	if n.cancel != nil {
 		n.cancel()
 	}

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -886,10 +886,11 @@ func (n *Networking) mainLoop(ctx context.Context) {
 				err := n.ActivateConnection(ctx, n.netState.GenNetKey(NetworkTypeWifi, "", userInputSSID))
 				if err != nil {
 					n.logger.Warn(errw.Wrapf(err, "Failed to connect to newly provided WiFi: %s", userInputSSID))
-					nwFound = n.tryCandidates(ctx) || n.tryBluetoothTether(ctx)
 				} else {
 					nwFound = true
 				}
+			} else {
+				nwFound = n.tryCandidates(ctx) || n.tryBluetoothTether(ctx)
 			}
 
 			if nwFound {

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -444,7 +444,7 @@ func (n *Networking) AddOrUpdateConnection(cfg utils.NetworkDefinition) (bool, e
 func (n *Networking) addOrUpdateConnection(cfg utils.NetworkDefinition) (bool, error) {
 	var changesMade bool
 
-	if cfg.Type != NetworkTypeWifi && cfg.Type != NetworkTypeHotspot && cfg.Type != NetworkTypeWired {
+	if cfg.Type != NetworkTypeWifi && cfg.Type != NetworkTypeHotspot && cfg.Type != NetworkTypeWired && cfg.Type != NetworkTypeBluetooth {
 		return changesMade, errw.Errorf("unspported network type %s, only %s, and %s currently supported",
 			cfg.Type, NetworkTypeWifi, NetworkTypeWired)
 	}

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -736,6 +736,11 @@ func (n *Networking) processUserInput(userInput userInput) bool {
 func (n *Networking) mainLoop(ctx context.Context) {
 	defer utils.Recover(n.logger, nil)
 	defer n.monitorWorkers.Done()
+	defer func() {
+		if err := n.stopProvisioning(); err != nil {
+			n.logger.Warn(err)
+		}
+	}()
 
 	scanChan := make(chan bool, 16)
 	inputChan := make(chan userInput, 10)

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -424,7 +424,11 @@ func (n *Networking) waitForConnect(ctx context.Context, nw *lockingNetwork, dev
 				return activeConnection, nil
 			case gnm.NmDeviceStateFailed:
 				if update.Reason == gnm.NmDeviceStateReasonNoSecrets {
-					return activeConnection, errw.Wrapf(ErrBadPassword, "activating connection: %s", n.netState.GenNetKey(nw.netType, nw.interfaceName, nw.ssid))
+					return activeConnection, errw.Wrapf(
+						ErrBadPassword,
+						"activating connection: %s",
+						n.netState.GenNetKey(nw.netType, nw.interfaceName, nw.ssid),
+					)
 				}
 				// custom error if it's some other reason for failure
 				return activeConnection, errw.Errorf("connection failed: %s", update.Reason)

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -424,7 +424,7 @@ func (n *Networking) waitForConnect(ctx context.Context, nw *lockingNetwork, dev
 				return activeConnection, nil
 			case gnm.NmDeviceStateFailed:
 				if update.Reason == gnm.NmDeviceStateReasonNoSecrets {
-					return activeConnection, ErrBadPassword
+					return activeConnection, errw.Wrapf(ErrBadPassword, "activating connection: %s", n.netState.GenNetKey(nw.netType, nw.interfaceName, nw.ssid))
 				}
 				// custom error if it's some other reason for failure
 				return activeConnection, errw.Errorf("connection failed: %s", update.Reason)

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -391,7 +391,7 @@ func (n *Networking) deactivateConnection(id NetKey) error {
 
 	n.logger.Infof("Successfully deactivated connection: %s", id)
 
-	// SMURF figure out what it means to be disconnected with bluetooth or multiple adapters
+	// TODO figure out what it means to be "disconnected" with bluetooth or multiple adapters
 	if id.Interface() == n.Config().HotspotInterface || id.Interface() == HotspotInterface {
 		n.connState.setConnected(false)
 	}

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -411,7 +411,7 @@ func (n *Networking) waitForConnect(ctx context.Context, nw *lockingNetwork, dev
 
 	activeConnection, err := n.nm.ActivateConnection(nw.conn, device, nil)
 	if err != nil {
-		return activeConnection, errw.Wrapf(err, "activating connection: %s", GenNetKey(nw.netType, nw.interfaceName, nw.ssid))
+		return activeConnection, errw.Wrapf(err, "activating connection: %s", n.netState.GenNetKey(nw.netType, nw.interfaceName, nw.ssid))
 	}
 
 	for {

--- a/subsystems/networking/networkstate_linux.go
+++ b/subsystems/networking/networkstate_linux.go
@@ -157,7 +157,6 @@ func (n *networkState) Networks() []network {
 }
 
 func (n *networkState) LastNetwork(netType, iface string) network {
-	// SMURF maybe shouldn't hardcode type
 	return n.Network(GenNetKey(netType, iface, n.LastSSID(iface)))
 }
 
@@ -318,4 +317,21 @@ func (n *networkState) Devices() map[string]gnm.Device {
 		allDevices[ifName] = dev
 	}
 	return allDevices
+}
+
+// GetNetworkDevice returns the appropriate network device for the given network type and interface.
+func (n *networkState) GetNetworkDevice(netType, interfaceName string) gnm.Device {
+	switch netType {
+	case NetworkTypeWifi:
+		return n.WifiDevice(interfaceName)
+	case NetworkTypeHotspot:
+		return n.WifiDevice(interfaceName)
+	case NetworkTypeBluetooth:
+		return n.BTDevice(interfaceName)
+	case NetworkTypeWired:
+		fallthrough
+	default:
+		// wired
+		return n.EthDevice(interfaceName)
+	}
 }

--- a/subsystems/networking/networkstate_linux.go
+++ b/subsystems/networking/networkstate_linux.go
@@ -1,7 +1,6 @@
 package networking
 
 import (
-	"fmt"
 	"sync"
 
 	gnm "github.com/Otterverse/gonetworkmanager/v2"
@@ -22,8 +21,8 @@ type networkState struct {
 	// key is ssid@interface for wifi, ex: TestNetwork@wlan0
 	// interface may be "any" for no interface set, ex: TestNetwork@any
 	// wired networks are just interface, ex: eth0
-	// generate with genNetKey(ifname, ssid)
-	network map[string]*lockingNetwork
+	// generate with GenNetKey(ifname, ssid)
+	network map[NetKey]*lockingNetwork
 
 	// key is interface name, ex: wlan0
 	primarySSID map[string]string
@@ -38,7 +37,7 @@ type networkState struct {
 func NewNetworkState(logger logging.Logger) *networkState {
 	return &networkState{
 		logger:      logger,
-		network:     make(map[string]*lockingNetwork),
+		network:     make(map[NetKey]*lockingNetwork),
 		activeSSID:  make(map[string]string),
 		primarySSID: make(map[string]string),
 		lastSSID:    make(map[string]string),
@@ -90,48 +89,21 @@ func (n *networkState) SetHotspotInterface(iface string) {
 	n.hotspotInterface = iface
 }
 
-func (n *networkState) GenNetKey(ifName, ssid string) string {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-	return n.genNetKey(ifName, ssid)
-}
-
-func (n *networkState) genNetKey(ifName, ssid string) string {
-	if ifName == "" && ssid != "" {
-		ifName = n.hotspotInterface
-	}
-
-	if ssid == "" {
-		return ifName
-	}
-	return fmt.Sprintf("%s@%s", ssid, ifName)
-}
-
-// LockingNetwork returns a pointer to a network, wrapped in a lockable struct, so updates are persisted
 // Users must lock the returned network before updates. Use Network() instead for a read-only copy.
-func (n *networkState) LockingNetwork(iface, ssid string) *lockingNetwork {
+func (n *networkState) LockingNetwork(id NetKey) *lockingNetwork {
 	n.mu.Lock()
 	defer n.mu.Unlock()
-
-	id := n.genNetKey(iface, ssid)
 
 	net, ok := n.network[id]
 	if !ok {
-		net = &lockingNetwork{}
-		n.network[id] = net
-
-		switch {
-		case iface == "bluetooth":
-			net.ssid = ssid
-			net.netType = NetworkTypeBluetooth
-		case ssid != "":
-			net.ssid = ssid
-			net.netType = NetworkTypeWifi
-		default:
-			net.netType = NetworkTypeWired
+		net = &lockingNetwork{
+			network: network{
+				netType:       id.Type(),
+				interfaceName: id.Interface(),
+				ssid:          id.SSID(),
+			},
 		}
-
-		net.interfaceName = iface
+		n.network[id] = net
 		n.logger.Debugf("found new network %s (%s)", id, net.netType)
 	}
 
@@ -139,10 +111,9 @@ func (n *networkState) LockingNetwork(iface, ssid string) *lockingNetwork {
 }
 
 // Network returns a copy-by-value of a network, which should be considered read-only, and doesn't need locking.
-func (n *networkState) Network(iface, ssid string) network {
+func (n *networkState) Network(id NetKey) network {
 	n.mu.Lock()
 	defer n.mu.Unlock()
-	id := n.genNetKey(iface, ssid)
 	ln, ok := n.network[id]
 	if !ok {
 		return network{}
@@ -152,8 +123,8 @@ func (n *networkState) Network(iface, ssid string) network {
 	return ln.network
 }
 
-func (n *networkState) SetNetwork(iface, ssid string, net network) {
-	ln := n.LockingNetwork(iface, ssid)
+func (n *networkState) SetNetwork(id NetKey, net network) {
+	ln := n.LockingNetwork(id)
 	ln.mu.Lock()
 	ln.network = net
 	ln.mu.Unlock()
@@ -185,8 +156,9 @@ func (n *networkState) Networks() []network {
 	return nets
 }
 
-func (n *networkState) LastNetwork(iface string) network {
-	return n.Network(iface, n.LastSSID(iface))
+func (n *networkState) LastNetwork(netType, iface string) network {
+	// SMURF maybe shouldn't hardcode type
+	return n.Network(GenNetKey(netType, iface, n.LastSSID(iface)))
 }
 
 func (n *networkState) PrimarySSID(iface string) string {

--- a/subsystems/networking/portal_linux.go
+++ b/subsystems/networking/portal_linux.go
@@ -191,7 +191,7 @@ func (n *Networking) portalSave(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	if ssid == n.netState.LastSSID(n.Config().HotspotInterface) && ssid != "" {
-		lastNetwork := n.netState.LockingNetwork(n.Config().HotspotInterface, ssid)
+		lastNetwork := n.netState.LockingNetwork(GenNetKey(NetworkTypeWifi, HotspotInterface, ssid))
 		lastNetwork.mu.Lock()
 		lastNetwork.lastError = nil
 		lastNetwork.mu.Unlock()

--- a/subsystems/networking/portal_linux.go
+++ b/subsystems/networking/portal_linux.go
@@ -191,7 +191,7 @@ func (n *Networking) portalSave(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	if ssid == n.netState.LastSSID(n.Config().HotspotInterface) && ssid != "" {
-		lastNetwork := n.netState.LockingNetwork(GenNetKey(NetworkTypeWifi, HotspotInterface, ssid))
+		lastNetwork := n.netState.LockingNetwork(n.netState.GenNetKey(NetworkTypeWifi, "", ssid))
 		lastNetwork.mu.Lock()
 		lastNetwork.lastError = nil
 		lastNetwork.mu.Unlock()

--- a/subsystems/networking/portal_linux.go
+++ b/subsystems/networking/portal_linux.go
@@ -82,11 +82,10 @@ func (n *Networking) stopPortal() error {
 		n.grpcServer = nil
 	}
 
-	var err error
 	if n.webServer != nil {
-		err = n.webServer.Close()
+		return n.webServer.Close()
 	}
-	return err
+	return nil
 }
 
 func (n *Networking) portalIndex(resp http.ResponseWriter, req *http.Request) {

--- a/subsystems/networking/scanning_linux.go
+++ b/subsystems/networking/scanning_linux.go
@@ -253,6 +253,9 @@ func (n *Networking) updateKnownConnections(ctx context.Context) error {
 		case NetworkTypeWifi:
 			fallthrough
 		case NetworkTypeBluetooth:
+			if n.btAgent != nil {
+				n.btAgent.TrustDevice(nw.ssid)
+			}
 			if n.netState.ActiveConn(nw.interfaceName) != nil && n.netState.ActiveSSID(ifName) == nw.ssid {
 				nw.connected = true
 			} else {

--- a/subsystems/networking/setup_linux.go
+++ b/subsystems/networking/setup_linux.go
@@ -116,7 +116,11 @@ func (n *Networking) initDevices() error {
 				n.logger.Infof("Using %s for hotspot/provisioning, will actively manage wifi only on this device.", ifName)
 			}
 		case gnm.NmDeviceTypeBt:
-			n.netState.SetBTDevice("bluetooth", device)
+			ifName, err := device.GetPropertyInterface()
+			if err != nil {
+				return err
+			}
+			n.netState.SetBTDevice(ifName, device)
 		default:
 			continue
 		}

--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -151,7 +151,7 @@ func (s *viamServer) Start(ctx context.Context) error {
 		s.running = false
 		s.logger.Infof("%s exited", SubsysName)
 		if err != nil {
-			s.logger.Errorw("error while getting process status", "error", err)
+			s.logger.Error(errw.Wrap(err, "error while getting process status"))
 		}
 		if s.cmd.ProcessState != nil {
 			s.lastExit = s.cmd.ProcessState.ExitCode()

--- a/utils/config.go
+++ b/utils/config.go
@@ -200,7 +200,7 @@ type NetworkConfiguration struct {
 type AdditionalNetworks map[string]NetworkDefinition
 
 type NetworkDefinition struct {
-	// "wifi", "wired"
+	// "wifi", "wired", "bluetooth"
 	Type string `json:"type,omitempty"`
 
 	// name of interface, ex: "wlan0", "eth0", "enp14s0", etc.
@@ -209,6 +209,9 @@ type NetworkDefinition struct {
 	// Wifi Settings
 	SSID string `json:"ssid,omitempty"`
 	PSK  string `json:"psk,omitempty"`
+
+	// Bluetooth device address for tethering connections, uppercase hex, ex: "A1:B2:C3:11:22:3F"
+	BluetoothAddress string `json:"bluetooth_address,omitempty"`
 
 	// Autoconnect Priority (primarily for wifi)
 	// higher values are preferred/tried first

--- a/utils/config.go
+++ b/utils/config.go
@@ -204,14 +204,12 @@ type NetworkDefinition struct {
 	Type string `json:"type,omitempty"`
 
 	// name of interface, ex: "wlan0", "eth0", "enp14s0", etc.
+	// for bluetooth tethering connections, uppercase hex, ex: "A1:B2:C3:11:22:3F"
 	Interface string `json:"interface,omitempty"`
 
 	// Wifi Settings
 	SSID string `json:"ssid,omitempty"`
 	PSK  string `json:"psk,omitempty"`
-
-	// Bluetooth device address for tethering connections, uppercase hex, ex: "A1:B2:C3:11:22:3F"
-	BluetoothAddress string `json:"bluetooth_address,omitempty"`
 
 	// Autoconnect Priority (primarily for wifi)
 	// higher values are preferred/tried first

--- a/utils/config.go
+++ b/utils/config.go
@@ -53,6 +53,7 @@ var (
 			HotspotSSID:                         "",
 			DisableBTProvisioning:               Tribool(0),
 			DisableWifiProvisioning:             Tribool(0),
+			BluetoothTrustAll:                   Tribool(0),
 		},
 		AdditionalNetworks{},
 	}
@@ -195,6 +196,9 @@ type NetworkConfiguration struct {
 	// Disable flags for provisioning types.
 	DisableBTProvisioning   Tribool `json:"disable_bt_provisioning,omitempty"`
 	DisableWifiProvisioning Tribool `json:"disable_wifi_provisioning,omitempty"`
+
+	// Accepts all BT pairing requests (for tethering) without requiring devices to be added via provisioning.
+	BluetoothTrustAll Tribool `json:"bluetooth_trust_all,omitempty"`
 }
 
 type AdditionalNetworks map[string]NetworkDefinition

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -29,7 +29,8 @@ func TestConvertJson(t *testing.T) {
 		"offline_before_starting_hotspot_minutes": 2,
 		"user_idle_minutes": 5,
 		"retry_connection_timeout_minutes": 10,
-		"wifi_power_save": null
+		"wifi_power_save": null,
+		"bluetooth_trust_all": false
 	},
 	"additional_networks": {
 		"network1": {
@@ -79,6 +80,7 @@ func TestConvertJson(t *testing.T) {
 	// these are explicitly false, rather than the "unset" for missing fields
 	testConfig.AdvancedSettings.Debug = -1
 	testConfig.NetworkConfiguration.DisableCaptivePortalRedirect = -1
+	testConfig.NetworkConfiguration.BluetoothTrustAll = -1
 
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, *newConfig, test.ShouldResemble, testConfig)


### PR DESCRIPTION
Should be feature complete!

UPDATE 07/22/2025: Rev4 is now built and released.

UPDATE 07/17/2025: Rev3 is now built and released. This fixes some bugs due to inconsistencies in network naming.

UPDATE 07/11/2025: Rev2 has moved to using the "unlock_pairing" characteristic, as iOS and android no longer expose the local BT Hardware Address to applications. Writing a "1" (string) to the characteristic temporarily enables pairing from any device, and lasts for the duration the device is in provisioning mode.

Test build here: http://packages.viam.com/temp/viam-agent-tethering.rev4-aarch64

Tethering works almost entirely based on pairing from the phone to the device, the only issue is establishing "trust" before the pairing, which can be established three ways:

~~1. The mobile app should write the phone's own bluetooth hardware address (ex: `DE:AD:BE:EF:CA:FE`) to the new `tether_address` ble characteristic to temporarily "trust" the phone for pairing.~~
2. The mobile app should write a "1" (string) to the new "unlock_pairing" characteristic to temporarily enable the acceptance of incoming pairing requests.
3. Previously configured tethering configs on the device store the bluetooth address, and will always be trusted in the future. E.g. if the phone is wiped/reset, or the device is removed via the phone's settings, it can be re-paired simply by pairing again as the hardware address is already trusted.
4. A new boolean configuration variable is available in the network settings portion of the config called `bluetooth_trust_all` and if set to true, no write for temporary trust is needed, and tethering can then be used completely without the mobile app. This setting can be reverted after pairing is complete (and the device is online) via the normal configuration in App. Note this (like most all other settings) can be set in `viam-defaults.json` as well as via cloud.

In any case, once trust is established, the phone needs to have bluetooth tethering enabled (on iOS, that's "personal hotspot>Allow others to join", on Android, "Network&Internet>Hotspot&Tethering>Bluetooth Tethering"), then pairing should be attempted from the phone's normal bluetooth pairing process. It typically takes 15 seconds or so to establish the tether, and if the devices is otherwise provisioned with machine credentials, it should exit provisioning mode and be online shortly.

Recommended testing configuration:
```json
{
  "agent": {
    "version_control": {
      "agent": "http://packages.viam.com/temp/viam-agent-tethering.rev4-aarch64"
    },
    "network_configuration": {
      "bluetooth_trust_all": true,
      "offline_before_starting_hotspot_minutes": 1
    }
  }
}
```