### PR TITLE
[APP-8655] Force Provisioning Mode

### DIFF
--- a/subsystems/networking/connstate_linux.go
+++ b/subsystems/networking/connstate_linux.go
@@ -152,7 +152,8 @@ func (c *connectionState) getLastTested() time.Time {
 	return c.lastTested
 }
 
-func (c *connectionState) setForceProvisioning(force bool) {
+// setForceProvisioningTime records the current time if passed true, and resets the time to the zero-value otherwise.
+func (c *connectionState) setForceProvisioningTime(force bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if force {
@@ -162,7 +163,8 @@ func (c *connectionState) setForceProvisioning(force bool) {
 	}
 }
 
-func (c *connectionState) getForceProvisioning() time.Time {
+// getForceProvisioningTime returns the stored timestamp for forcing provisioning mode.
+func (c *connectionState) getForceProvisioningTime() time.Time {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.forceProvisioning

--- a/subsystems/networking/connstate_linux.go
+++ b/subsystems/networking/connstate_linux.go
@@ -24,6 +24,8 @@ type connectionState struct {
 
 	lastInteraction time.Time
 
+	forceProvisioning time.Time
+
 	logger logging.Logger
 }
 
@@ -148,4 +150,20 @@ func (c *connectionState) getLastTested() time.Time {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.lastTested
+}
+
+func (c *connectionState) setForceProvisioning(force bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if force {
+		c.forceProvisioning = time.Now()
+	} else {
+		c.forceProvisioning = time.Time{}
+	}
+}
+
+func (c *connectionState) getForceProvisioning() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.forceProvisioning
 }

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -761,6 +761,7 @@ func (n *Networking) checkForceProvisioning() bool {
 			n.logger.Infof("Force provisioning touch file %s found, will enter provisioning mode.", touchFile)
 		}
 		n.connState.setForceProvisioning(true)
+		return true
 	}
 
 	// Check if the force was triggered less recently than the retry connection timeout

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"reflect"
 	"slices"
 	"sort"
@@ -747,6 +748,25 @@ func (n *Networking) processUserInput(userInput userInput) bool {
 	return true
 }
 
+func (n *Networking) checkForceProvisioning() bool {
+	touchFile := path.Join(utils.ViamDirs["etc"], "force_provisioning_mode")
+
+	// Check if the touch file exists
+	if _, err := os.Stat(touchFile); err == nil {
+		// File exists, remove it and set force provisioning time
+		if err := os.Remove(touchFile); err != nil {
+			n.logger.Error(errw.Wrapf(err, "failed to remove %s, ignoring it to avoid getting stuck in provisioning mode", touchFile))
+			return false
+		} else {
+			n.logger.Infof("Force provisioning touch file %s found, will enter provisioning mode.", touchFile)
+		}
+		n.connState.setForceProvisioning(true)
+	}
+
+	// Check if the force was triggered less recently than the retry connection timeout
+	return time.Since(n.connState.getForceProvisioning()) < time.Duration(n.Config().RetryConnectionTimeoutMinutes)
+}
+
 func (n *Networking) mainLoop(ctx context.Context) {
 	defer utils.Recover(n.logger, nil)
 	defer n.monitorWorkers.Done()
@@ -795,6 +815,7 @@ func (n *Networking) mainLoop(ctx context.Context) {
 
 		n.mainLoopHealth.MarkGood()
 
+		forceProvisioning := n.checkForceProvisioning()
 		isOnline := n.connState.getOnline()
 		lastOnline := n.connState.getLastOnline()
 		isConnected := n.connState.getConnected()
@@ -855,13 +876,17 @@ func (n *Networking) mainLoop(ctx context.Context) {
 			shouldRebootSystem := n.Config().DeviceRebootAfterOfflineMinutes > 0 &&
 				lastConnectivity.Before(now.Add(time.Duration(n.Config().DeviceRebootAfterOfflineMinutes)*-1))
 
-			shouldExitPMode := allGood || haveCandidates || fallbackHit || shouldRebootSystem || userInputReceived
+			// only way for exit early when in forceProvisioning is userInput, otherwise the logic is any of the remaining conditions
+			shouldExitPMode := (!forceProvisioning || userInputReceived) &&
+				(allGood || haveCandidates || fallbackHit || shouldRebootSystem || userInputReceived)
 
 			n.logger.Debugf("inactive portal: %t, have candidates: %t, fallback timeout: %t (%s remaining)",
 				inactivePortal, haveCandidates, fallbackHit, fallbackRemaining)
 
 			if shouldExitPMode {
 				if userInputReceived {
+					// user theoretically finished their interaction, so reset the trigger timer
+					n.connState.setForceProvisioning(false)
 					// We could get to this point before the user receives our response (poor UX, but likely not critical)
 					// E.g. try to avoid "Not connected" web portal screen.
 					n.mainLoopHealth.Sleep(ctx, 3*time.Second)
@@ -924,7 +949,7 @@ func (n *Networking) mainLoop(ctx context.Context) {
 			now.After(pModeChange.Add(time.Duration(n.Config().OfflineBeforeStartingHotspotMinutes)))
 		// not in provisioning mode, so start it if not configured (/etc/viam.json)
 		// OR as long as we've been offline AND out of provisioning mode for at least OfflineTimeout (2 minute default)
-		if !isConfigured || hitOfflineTimeout || userInputReceived {
+		if !isConfigured || hitOfflineTimeout || userInputReceived || forceProvisioning {
 			if err := n.startProvisioning(ctx, inputChan); err != nil {
 				n.logger.Warn(err)
 			}

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -760,12 +760,12 @@ func (n *Networking) checkForceProvisioning() bool {
 		} else {
 			n.logger.Infof("Force provisioning touch file %s found, will enter provisioning mode.", touchFile)
 		}
-		n.connState.setForceProvisioning(true)
+		n.connState.setForceProvisioningTime(true)
 		return true
 	}
 
 	// Check if the force was triggered less recently than the retry connection timeout
-	return time.Since(n.connState.getForceProvisioning()) < time.Duration(n.Config().RetryConnectionTimeoutMinutes)
+	return time.Since(n.connState.getForceProvisioningTime()) < time.Duration(n.Config().RetryConnectionTimeoutMinutes)
 }
 
 func (n *Networking) mainLoop(ctx context.Context) {
@@ -887,7 +887,7 @@ func (n *Networking) mainLoop(ctx context.Context) {
 			if shouldExitPMode {
 				if userInputReceived {
 					// user theoretically finished their interaction, so reset the trigger timer
-					n.connState.setForceProvisioning(false)
+					n.connState.setForceProvisioningTime(false)
 					// We could get to this point before the user receives our response (poor UX, but likely not critical)
 					// E.g. try to avoid "Not connected" web portal screen.
 					n.mainLoopHealth.Sleep(ctx, 3*time.Second)

--- a/subsystems/networking/networkmanager_linux_test.go
+++ b/subsystems/networking/networkmanager_linux_test.go
@@ -102,13 +102,13 @@ func TestCheckForceProvisioning(t *testing.T) {
 			// Verify the force provisioning state
 			if tt.setupTouchFile {
 				// When touch file exists, force provisioning should be set to current time
-				forceProvisioningTime := n.connState.getForceProvisioning()
+				forceProvisioningTime := n.connState.getForceProvisioningTime()
 				test.That(t, forceProvisioningTime.IsZero(), test.ShouldBeFalse)
 				// Should be set to a recent time (within last 10 seconds)
 				test.That(t, time.Since(forceProvisioningTime), test.ShouldBeLessThan, time.Second*10)
 			} else {
 				// When no touch file exists, force provisioning should remain unchanged
-				forceProvisioningTime := n.connState.getForceProvisioning()
+				forceProvisioningTime := n.connState.getForceProvisioningTime()
 				if tt.setupForceProvisioning.IsZero() {
 					test.That(t, forceProvisioningTime.IsZero(), test.ShouldBeTrue)
 				} else {

--- a/subsystems/networking/networkmanager_linux_test.go
+++ b/subsystems/networking/networkmanager_linux_test.go
@@ -1,0 +1,120 @@
+package networking
+
+import (
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/viamrobotics/agent/utils"
+	"go.viam.com/rdk/logging"
+	"go.viam.com/test"
+)
+
+func TestCheckForceProvisioning(t *testing.T) {
+	// Mock ViamDirs to use temporary directory for testing
+	utils.MockViamDirs(t)
+
+	tests := []struct {
+		name                   string
+		setupTouchFile         bool
+		setupForceProvisioning time.Time
+		retryTimeoutMinutes    int
+		expectedResult         bool
+	}{
+		{
+			name:                   "touch file exists - should trigger force provisioning",
+			setupTouchFile:         true,
+			setupForceProvisioning: time.Time{}, // zero time
+			retryTimeoutMinutes:    10,
+			expectedResult:         true,
+		},
+		{
+			name:                   "touch file exists - force provisioning was set recently",
+			setupTouchFile:         true,
+			setupForceProvisioning: time.Now().Add(-time.Minute * 5), // 5 minutes ago
+			retryTimeoutMinutes:    10,
+			expectedResult:         true, // still within timeout
+		},
+		{
+			name:                   "touch file exists - old force provisioning timeout expired",
+			setupTouchFile:         true,
+			setupForceProvisioning: time.Now().Add(-time.Minute * 15), // 15 minutes ago
+			retryTimeoutMinutes:    10,
+			expectedResult:         true, // touch file exists, so always returns true
+		},
+		{
+			name:                   "no touch file - force provisioning not set",
+			setupTouchFile:         false,
+			setupForceProvisioning: time.Time{}, // zero time
+			retryTimeoutMinutes:    10,
+			expectedResult:         false,
+		},
+		{
+			name:                   "no touch file - force provisioning was set recently",
+			setupTouchFile:         false,
+			setupForceProvisioning: time.Now().Add(-time.Minute * 5), // 5 minutes ago
+			retryTimeoutMinutes:    10,
+			expectedResult:         true, // still within timeout
+		},
+		{
+			name:                   "no touch file - force provisioning timeout expired",
+			setupTouchFile:         false,
+			setupForceProvisioning: time.Now().Add(-time.Minute * 15), // 15 minutes ago
+			retryTimeoutMinutes:    10,
+			expectedResult:         false, // timeout expired
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fresh networking instance for each test
+			n := &Networking{
+				logger: logging.NewTestLogger(t),
+				connState: &connectionState{
+					forceProvisioning: tt.setupForceProvisioning,
+				},
+				cfg: utils.NetworkConfiguration{
+					RetryConnectionTimeoutMinutes: utils.Timeout(time.Duration(tt.retryTimeoutMinutes) * time.Minute),
+				},
+			}
+
+			// Set up the touch file if needed
+			touchFilePath := path.Join(utils.ViamDirs["etc"], "force_provisioning_mode")
+			if tt.setupTouchFile {
+				utils.Touch(t, touchFilePath)
+			}
+
+			// Call the function under test
+			result := n.checkForceProvisioning()
+
+			// Verify the result
+			test.That(t, result, test.ShouldEqual, tt.expectedResult)
+
+			// Verify the touch file was removed if it existed
+			if tt.setupTouchFile {
+				// Touch file should be removed after processing
+				_, err := os.Stat(touchFilePath)
+				test.That(t, err, test.ShouldNotBeNil)
+				test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+			}
+
+			// Verify the force provisioning state
+			if tt.setupTouchFile {
+				// When touch file exists, force provisioning should be set to current time
+				forceProvisioningTime := n.connState.getForceProvisioning()
+				test.That(t, forceProvisioningTime.IsZero(), test.ShouldBeFalse)
+				// Should be set to a recent time (within last 10 seconds)
+				test.That(t, time.Since(forceProvisioningTime), test.ShouldBeLessThan, time.Second*10)
+			} else {
+				// When no touch file exists, force provisioning should remain unchanged
+				forceProvisioningTime := n.connState.getForceProvisioning()
+				if tt.setupForceProvisioning.IsZero() {
+					test.That(t, forceProvisioningTime.IsZero(), test.ShouldBeTrue)
+				} else {
+					test.That(t, forceProvisioningTime, test.ShouldEqual, tt.setupForceProvisioning)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This looks for a touchfile at `/opt/viam/etc/force_provisioning_mode` and if found, enters provisioning mode until a user submits data (and calls ExitProvisioning()) OR the normal `retry_connection_timeout_minutes` limit (default 10 minutes) expires.

This is meant to be used by external scripts that could be tied to a "pair" button or similar.