### PR TITLE
[APP-8892] Fix lock contention around healthchecks and wifi activation

### DIFF
--- a/subsystems/networking/bluetooth_linux.go
+++ b/subsystems/networking/bluetooth_linux.go
@@ -163,8 +163,8 @@ func (n *Networking) removeServices() error {
 }
 
 func (n *Networking) bluetoothEnabled() bool {
-	n.dataMu.Lock()
+	n.dataMu.RLock()
 	noBT := n.noBT
-	n.dataMu.Unlock()
+	n.dataMu.RUnlock()
 	return !noBT && !n.Config().DisableBTProvisioning.Get()
 }

--- a/subsystems/networking/definitions.go
+++ b/subsystems/networking/definitions.go
@@ -10,5 +10,5 @@ const (
 	NetworkTypeHotspot   = "hotspot"
 	NetworkTypeBluetooth = "bluetooth"
 
-	HealthCheckTimeout = time.Minute
+	HealthCheckTimeout = time.Minute * 2
 )

--- a/subsystems/networking/grpc_linux.go
+++ b/subsystems/networking/grpc_linux.go
@@ -20,7 +20,9 @@ func (n *Networking) startGRPC(bindAddr string, bindPort int) error {
 		return errw.Wrapf(err, "listening on: %s", bind)
 	}
 
+	n.dataMu.Lock()
 	n.grpcServer = grpc.NewServer(grpc.WaitForHandlers(true))
+	n.dataMu.Unlock()
 	pb.RegisterProvisioningServiceServer(n.grpcServer, n)
 
 	n.portalData.workers.Add(1)

--- a/version_control.go
+++ b/version_control.go
@@ -144,9 +144,10 @@ func (c *VersionCache) Update(cfg *pb.UpdateInfo, binary string) error {
 	defer c.mu.Unlock()
 
 	var data *Versions
-	if binary == SubsystemName {
+	switch binary {
+	case SubsystemName:
 		data = c.ViamAgent
-	} else if binary == viamserver.SubsysName {
+	case viamserver.SubsysName:
 		data = c.ViamServer
 	}
 	newVersion := cfg.GetVersion()


### PR DESCRIPTION
This primarily restructures a lot of mutex locks, but also improves the network connection state change monitoring during activation by subscribing to changes before triggering activation, in order to not miss events that could possibly slip through when activation was very quick or the agent process isn't getting enough cpu share.

Healthchecks now continue to work normally even if ActivateConnection() is blocking.