### PR TITLE
[APP-8900] Make downloads avoid accidental overwrites, add tests

### DIFF
--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,10 +1,18 @@
 package utils
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	"go.viam.com/rdk/logging"
 	"go.viam.com/test"
 )
 
@@ -93,4 +101,199 @@ func TestWriteFileIfNew(t *testing.T) {
 	written, err = WriteFileIfNew(path, []byte("other contents"))
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, written, test.ShouldBeTrue)
+}
+
+func TestDownloadFile(t *testing.T) {
+	MockViamDirs(t)
+	logger := logging.NewTestLogger(t)
+
+	t.Run("file:// URL happy path", func(t *testing.T) {
+		// Create a test file to download
+		testContent := "test file content"
+		testFile := filepath.Join(t.TempDir(), "testfile.txt")
+		err := os.WriteFile(testFile, []byte(testContent), 0o644)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Download the file
+		fileURL := "file://" + testFile
+		downloadedPath, err := DownloadFile(context.Background(), fileURL, logger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, downloadedPath, test.ShouldNotBeEmpty)
+
+		// Verify the content
+		content, err := os.ReadFile(downloadedPath)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, string(content), test.ShouldEqual, testContent)
+	})
+
+	t.Run("https:// URL happy path", func(t *testing.T) {
+		// Create a test server
+		testContent := "https test content"
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(testContent))
+		}))
+		defer server.Close()
+
+		// Download the file
+		downloadedPath, err := DownloadFile(context.Background(), server.URL, logger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, downloadedPath, test.ShouldNotBeEmpty)
+
+		// Verify the content
+		content, err := os.ReadFile(downloadedPath)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, string(content), test.ShouldEqual, testContent)
+	})
+
+	t.Run("does not overwrite existing files", func(t *testing.T) {
+		// Create a test file to download
+		testContent := "original content"
+		testFile := filepath.Join(t.TempDir(), "duplicate.txt")
+		err := os.WriteFile(testFile, []byte(testContent), 0o644)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Create an existing file in cache with same name
+		existingPath := filepath.Join(ViamDirs["cache"], "duplicate.txt")
+		err = os.WriteFile(existingPath, []byte("existing content"), 0o644)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Download the file - should create a new file with suffix
+		fileURL := "file://" + testFile
+		downloadedPath, err := DownloadFile(context.Background(), fileURL, logger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, downloadedPath, test.ShouldNotEqual, existingPath)
+		test.That(t, strings.HasSuffix(downloadedPath, ".duplicate-001"), test.ShouldBeTrue)
+
+		// Verify original file is unchanged
+		content, err := os.ReadFile(existingPath)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, string(content), test.ShouldEqual, "existing content")
+
+		// Verify new file has correct content
+		content, err = os.ReadFile(downloadedPath)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, string(content), test.ShouldEqual, testContent)
+	})
+
+	t.Run("handles multiple duplicates", func(t *testing.T) {
+		// Create a test file to download
+		testContent := "test content"
+		testFile := filepath.Join(t.TempDir(), "multidupe.txt")
+		err := os.WriteFile(testFile, []byte(testContent), 0o644)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Create multiple existing files
+		for i := range 3 {
+			var suffix string
+			if i > 0 {
+				suffix = fmt.Sprintf(".duplicate-%03d", i)
+			}
+			existingPath := filepath.Join(ViamDirs["cache"], "multidupe.txt"+suffix)
+			err = os.WriteFile(existingPath, []byte(fmt.Sprintf("existing content %d", i)), 0o644)
+			test.That(t, err, test.ShouldBeNil)
+		}
+
+		// Download the file - should create file with .duplicate-003 suffix
+		fileURL := "file://" + testFile
+		downloadedPath, err := DownloadFile(context.Background(), fileURL, logger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, strings.HasSuffix(downloadedPath, ".duplicate-003"), test.ShouldBeTrue)
+
+		// Verify new file has correct content
+		content, err := os.ReadFile(downloadedPath)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, string(content), test.ShouldEqual, testContent)
+	})
+
+	t.Run("returns error for invalid URL", func(t *testing.T) {
+		_, err := DownloadFile(context.Background(), "invalid://url", logger)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "unsupported url scheme")
+	})
+
+	t.Run("returns error for non-existent file:// URL", func(t *testing.T) {
+		_, err := DownloadFile(context.Background(), "file:///nonexistent/file.txt", logger)
+		test.That(t, err, test.ShouldNotBeNil)
+	})
+
+	t.Run("returns error for HTTP 404", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		_, err := DownloadFile(context.Background(), server.URL, logger)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "got response '404 Not Found'")
+	})
+
+	t.Run("returns error for HTTP 500", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		_, err := DownloadFile(context.Background(), server.URL, logger)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "got response '500 Internal Server Error'")
+	})
+
+	t.Run("handles context cancellation", func(t *testing.T) {
+		// Create a slow server
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(100 * time.Millisecond)
+			w.Write([]byte("content"))
+		}))
+		defer server.Close()
+
+		// Create a context that cancels immediately
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := DownloadFile(ctx, server.URL, logger)
+		test.That(t, err, test.ShouldNotBeNil)
+	})
+
+	t.Run("handles network errors", func(t *testing.T) {
+		// Try to download from a non-existent server
+		_, err := DownloadFile(context.Background(), "https://nonexistent.example.com/file.txt", logger)
+		test.That(t, err, test.ShouldNotBeNil)
+	})
+
+	t.Run("handles incomplete downloads", func(t *testing.T) {
+		// Create a server that closes connection early
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("partial content"))
+			// Close the connection abruptly
+			if h, ok := w.(http.Hijacker); ok {
+				if conn, _, err := h.Hijack(); err == nil {
+					conn.Close()
+				}
+			}
+		}))
+		defer server.Close()
+
+		_, err := DownloadFile(context.Background(), server.URL, logger)
+		test.That(t, err, test.ShouldNotBeNil)
+	})
+
+	t.Run("handles files with special characters in name", func(t *testing.T) {
+		// Create a test file with special characters
+		testContent := "special chars content"
+		testFile := filepath.Join(t.TempDir(), "file with spaces & symbols.txt")
+		err := os.WriteFile(testFile, []byte(testContent), 0o644)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Download the file
+		fileURL := "file://" + testFile
+		downloadedPath, err := DownloadFile(context.Background(), fileURL, logger)
+		test.That(t, err, test.ShouldBeNil)
+
+		// Verify the content
+		content, err := os.ReadFile(downloadedPath)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, string(content), test.ShouldEqual, testContent)
+	})
 }


### PR DESCRIPTION
The cache (json) format used by Agent changed a few major versions ago. Jumping from an old version to the current version CAN result in the running agent binary not being in the cache file, and thus when a download for it is attempted, it can over overwrite the running file. If this is interrupted before the process is complete (e.g. the machine is restarted or there's a network outage for a while) it can leave the agent binary in a broken state, and it cannot start back up.

This PR fixes that by returning early from DownloadFile() if the actual io.Copy() fails (previously this wasn't caught until AFTER the temp file was renamed to replace the binary.) Additional code is also added to modify the output path name if a duplicate is detected. Lastly, tests are added for this.

As part of testing, this uncovered a race condition in the progress bar library, so a workaround with our own locking is implemented as well.