### PR TITLE
Update hotspot IP settings to never be the default route

### DIFF
--- a/subsystems/networking/bluetooth_characteristics_linux.go
+++ b/subsystems/networking/bluetooth_characteristics_linux.go
@@ -144,7 +144,7 @@ func (b *btCharacteristics) initWriteOnlyCharacteristic(ctx context.Context, cNa
 			if cName == unlockPairingKey {
 				trustBool, err := strconv.ParseBool(plaintext)
 				if err != nil {
-					b.logger.Warn("invalid value received for pairing trust, expected boolean (0, 1, true, false), got: %s", plaintext)
+					b.logger.Warnf("invalid value received for pairing trust, expected boolean (0, 1, true, false), got: %s", plaintext)
 					return
 				}
 				b.trustFunc(trustBool)

--- a/subsystems/networking/generators_linux.go
+++ b/subsystems/networking/generators_linux.go
@@ -39,8 +39,9 @@ func generateHotspotSettings(id NetKey, psk string) gnm.ConnectionSettings {
 			"psk":      psk,
 		},
 		"ipv4": map[string]any{
-			"method":    "shared",
-			"addresses": [][]uint32{{IPAsUint32, 24, IPAsUint32}},
+			"method":        "shared",
+			"addresses":     [][]uint32{{IPAsUint32, 24, IPAsUint32}},
+			"never-default": true,
 		},
 		"ipv6": map[string]any{
 			"method": "disabled",

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -305,6 +305,7 @@ func (n *Networking) activateConnection(ctx context.Context, id NetKey) error {
 	}
 
 	n.logger.Infof("Activating connection: %s", id)
+	nw.lastTried = now
 
 	// Track the last WiFi network that attempted activation
 	if nw.netType == NetworkTypeWifi {
@@ -329,7 +330,6 @@ func (n *Networking) activateConnection(ctx context.Context, id NetKey) error {
 		}
 	}
 
-	nw.lastTried = now
 	activeConnection, err := n.waitForConnect(ctx, nw, netDev)
 	if err != nil {
 		nw.lastError = err


### PR DESCRIPTION
Test binary: http://packages.viam.com/temp/viam-agent-v0.21.0+tetherfixes.1-aarch64


This adds `ipv4.never-default=true` to the hotspot settings. This is needed because otherwise this is considered an active network, and if it can't reach the internet (which it typically never can) it causes NM connectivity checks to report it as "limited access." This was never a problem previously because we were never expecting to be online while in hotspot mode, but now with bluetooth tethering, that is possible.

This also has two VERY minor fixes, one for a typo Warn()>Warnf(), and another to mark a tried network slightly earlier in case of early return.