### PR TITLE
RSDK-11678 Change FinalKillSignal to be SIGKILL

### DIFF
--- a/preinstall.sh
+++ b/preinstall.sh
@@ -24,7 +24,7 @@ User=root
 TimeoutSec=240
 ExecStart=/opt/viam/bin/viam-agent --config /etc/viam.json
 KillMode=mixed
-FinalKillSignal=SIGQUIT
+FinalKillSignal=SIGKILL
 
 [Install]
 WantedBy=multi-user.target

--- a/viam-agent.service
+++ b/viam-agent.service
@@ -12,7 +12,7 @@ User=root
 TimeoutSec=240
 ExecStart=/opt/viam/bin/viam-agent --config /etc/viam.json
 KillMode=mixed
-FinalKillSignal=SIGQUIT
+FinalKillSignal=SIGKILL
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
[RSDK-11678](https://viam.atlassian.net/browse/RSDK-11678)

When `viam-agent` is stopped with `systemd`, if any processes are still left running in the "unit" (`viam-server` or any modules), `systemd` will send SIGQUIT to them as a "final kill signal." SIGQUIT is a "nice" thing to send in the sense that the process can catch it and, by default in some language runtimes like Java and Golang, print out a core/goroutine dump/stack/trace. NetCode has recently run into issues where modules or even `viam-server` instances are _not_ responding to SIGQUIT. We don't know exactly why yet, but it's probably wiser to have `systemd` issue a full SIGKILL to any orphaned processes.

`viam-server` (and [soon](https://viam.atlassian.net/browse/RSDK-11691) `viam-agent`) also [prints out its own](https://github.com/viamrobotics/goutils/blob/4e8d3d10426c67064f82deab5a2d16f87723a075/runtime.go#L253-L262) goroutine dump in the event of slow shutdown.

[RSDK-11678]: https://viam.atlassian.net/browse/RSDK-11678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ