### PR TITLE
Avoid returning early from checkConnections() loop.

### DIFF
--- a/subsystems/networking/networking_linux.go
+++ b/subsystems/networking/networking_linux.go
@@ -201,9 +201,7 @@ func (n *Networking) init(ctx context.Context) error {
 		}
 	}
 
-	if err := n.checkConnections(); err != nil {
-		n.logger.Warn(err)
-	}
+	n.checkConnections()
 
 	// Is there a configured wifi network? If so, set last times to now so we use normal timeouts.
 	// Otherwise, hotspot will start immediately if not connected, while wifi network might still be booting.

--- a/subsystems/networking/networkstate_linux.go
+++ b/subsystems/networking/networkstate_linux.go
@@ -365,3 +365,22 @@ func (n *networkState) GenNetKey(netType, ifName, ssid string) NetKey {
 		return NetKeyUnknown
 	}
 }
+
+// RemoveDevice removes a device from all device maps and cleans up associated state.
+func (n *networkState) RemoveDevice(ifName string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	// Remove from all device maps
+	delete(n.wifiDevice, ifName)
+	delete(n.ethDevice, ifName)
+	delete(n.btDevice, ifName)
+
+	// Clean up associated state
+	delete(n.activeConn, ifName)
+	delete(n.activeSSID, ifName)
+	delete(n.lastSSID, ifName)
+	delete(n.primarySSID, ifName)
+
+	n.logger.Debugf("removed device %s from network state", ifName)
+}


### PR DESCRIPTION
If other/virtual NetworkManager devices "go away" (which can happen with DBUS) the loop could exit early and not find the device(s) we care about. This should avoid that, and merely log a warning instead, and remove the "dead" device.