### PR TITLE
[RSDK-11691] Agent Shutdown should not hang

### DIFF
--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -182,6 +182,7 @@ func (s *viamServer) Start(ctx context.Context) error {
 }
 
 func (s *viamServer) Stop(ctx context.Context) error {
+	time.Sleep(time.Minute*3 + time.Second*5)
 	s.startStopMu.Lock()
 	defer s.startStopMu.Unlock()
 

--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -182,7 +182,6 @@ func (s *viamServer) Start(ctx context.Context) error {
 }
 
 func (s *viamServer) Stop(ctx context.Context) error {
-	time.Sleep(time.Minute*3 + time.Second*5)
 	s.startStopMu.Lock()
 	defer s.startStopMu.Unlock()
 


### PR DESCRIPTION
### Description
[[RSDK-11691]](https://viam.atlassian.net/browse/RSDK-11691) Agent Shutdown should not hang

* Spawns goroutine which loops through subsystems and closes them
     * If all subsystems `Close`  successfully by `stopAllTimeout`, we `close()` the `ctx` as everything shut down as expected and proceed normally. 