### PR TITLE
fix Wrapf(nil) to remove nil in logs

### DIFF
--- a/subsystems/networking/bluetooth_tethering_linux.go
+++ b/subsystems/networking/bluetooth_tethering_linux.go
@@ -148,8 +148,8 @@ func (b *pairingAgent) RequestAuthorization(devicePath dbus.ObjectPath) *dbus.Er
 		// not consider pairing as "failed"
 		call := remoteDev.CallWithContext(ctx, "org.bluez.Device1.ConnectProfile", 0, "deadbeef-cafe-0000-0000-cafedeadbeef")
 		if call.Err.Error() != "br-connection-profile-unavailable" {
-			b.logger.Warn(errw.Wrapf(err, "temporarily connecting bluetooth device %s (%s) resulted in unexpected error: %s",
-				bdaddr, alias, call.Err.Error()))
+			b.logger.Warnf("temporarily connecting bluetooth device %s (%s) resulted in unexpected error: %s",
+				bdaddr, alias, call.Err.Error())
 		}
 
 		// every bluetooth device is new, so have to scan after a new pairing


### PR DESCRIPTION
## What changed
- `Warnf` directly instead of `Warn(errw.Wrapf())`
## Why
`err` will usually be nil here, it's from higher up in the function. When err is nil, this prints:
> 2025-09-05T00:01:29.180Z        WARN    viam-agent      networking/bluetooth_tethering_linux.go:151     <nil>

Mini example of wrapping nil if you want to repro:
```go
func main() {
	// err := errors.New("I am an error")
	logger := logging.NewLogger("logtest")
	logger.Warn(errw.Wrapf(nil, "I am text: %s, %s", "yup", nil))
}
// 2025-09-05T00:16:49.574Z	WARN	logtest	logtest/main.go:11	<nil>
```