### PR TITLE
ignore 'not started' error from bluetooth Stop()

### DIFF
--- a/subsystems/networking/bluetooth_linux.go
+++ b/subsystems/networking/bluetooth_linux.go
@@ -73,8 +73,14 @@ func (n *Networking) stopProvisioningBluetooth() error {
 		n.logger.Warnf("bluetooth already stopped")
 		return nil
 	}
+	// 'not started' is unexported but comes from here
+	// https://github.com/tinygo-org/bluetooth/blob/5c615298c3e4400150c44da3636f3d3b10967e3c/gap_linux.go#L48
 	if err := n.btAdv.Stop(); err != nil {
-		return fmt.Errorf("failed to stop BT advertising: %w", err)
+		if err.Error() == "bluetooth: advertisement is not started" {
+			n.logger.Warnf("ignoring %q from Stop()", err)
+		} else {
+			return fmt.Errorf("failed to stop BT advertising: %w", err)
+		}
 	}
 	n.btAdv = nil
 


### PR DESCRIPTION
## What changed
- in stopProvisioningBluetooth, skip the 'advertisement is not started' error in btAdv.Stop()
## Why
I got one of these in logs:

> Sep 10 22:43:40 aw-pi-modreg viam-agent[1213]: 2025-09-10T21:43:40.428Z        WARN        viam-agent        networking/networkmanager_linux.go:896        failed to stop BT advertising: bluetooth: advertisement is not started

I'm not sure how to recreate it. I think it happened after I did something like this:

```bash
sudo service viam-agent stop
bluetoothctl remove $BLUETOOTH_MAC || echo "didn't remove bluetooth device"
sudo nmcli c delete bluetooth@$BLUETOOTH_MAC || echo "didn't remove nmcli network"
sudo rm -fv /etc/viam.json
sudo service viam-agent start
```

Will try to recreate but I suspect this isn't deterministic. Your call whether it makes sense to merge this without a repro.