### PR TITLE
deprovision.sh script

### DIFF
--- a/etc/deprovision.sh
+++ b/etc/deprovision.sh
@@ -5,7 +5,7 @@
 
 set -eux
 
-sudo service viam-agent stop
+sudo systemctl stop viam-agent
 
 if [ -z "$BLUETOOTH_MAC" ]; then
     echo '$BLUETOOTH_MAC not set, skipping bluetooth cleanup'
@@ -20,5 +20,4 @@ else
 fi
 
 sudo rm -fv /etc/viam.json
-sudo service viam-agent start
-
+sudo systemctl start viam-agent


### PR DESCRIPTION
## What changed
- add `etc/deprovision.sh` script which removes viam.json and bluetooth settings
## Why
As we automate bt testing across multiple phones, this lets us reuse a pi without physically removing the SD card