### PR TITLE
RSDK-11946 Specify GOOS for a[rm|md]64 targets in agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,11 @@ all: amd64 arm64 windows
 
 .PHONY: arm64
 arm64:
-	make GOARCH=arm64
+	make GOOS=linux GOARCH=arm64
 
 .PHONY: amd64
 amd64:
-	make GOARCH=amd64
+	make GOOS=linux GOARCH=amd64
 
 .PHONY: windows
 windows:


### PR DESCRIPTION
[RSDK-11946](https://viam.atlassian.net/browse/RSDK-11946)

Just calling `make arm64` on MacOS for agent results in a binary that has the wrong GOOS supplied for raspberry pis and cannot be executed (following log will be output by agent: `9/17/2025, 12:04:24 PM warn viam-agent   agent/manager.go:195   downloaded file is application/x-mach-binary, not application/x-elf, application/x-executable, skipping`). I’m assuming this is because most development on agent has been done from a Linux machine where GOOS was defaulting to linux. Explicitly specifying the GOOS in the target fixes the issue, and I do not think we need any target to build for MacOS at the moment.

[RSDK-11946]: https://viam.atlassian.net/browse/RSDK-11946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ