### PR TITLE
RSDK-11890 Avoid immediate HealthCheck timeout when Start takes longer than 15s

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -349,14 +349,13 @@ func (m *Manager) SubsystemHealthChecks(ctx context.Context) {
 			}
 		}
 
-		ctxTimeout, cancelFunc := context.WithTimeout(ctx, time.Second*15)
-		defer cancelFunc()
-
 		// Start should return near-instantly if already started.
 		if err := entry.sub.Start(ctx); err != nil {
 			m.logger.Warn(err)
 		}
 
+		ctxTimeout, cancelFunc := context.WithTimeout(ctx, time.Second*15)
+		defer cancelFunc()
 		if err := entry.sub.HealthCheck(ctxTimeout); err != nil {
 			if ctx.Err() != nil {
 				return


### PR DESCRIPTION
[RSDK-11890](https://viam.atlassian.net/browse/RSDK-11890)

I do not think this bug was fully responsible for the ~3.5 mins it took for `viam-server` to come online in the case that NetworkManager had no active connection. That was [RSDK-11947](https://viam.atlassian.net/browse/RSDK-11947) (PR forthcoming). It did, however, exacerbate the situation by cutting off the networking subsystem early from completing its attempt to activate an available WiFi connection.

[RSDK-11947]: https://viam.atlassian.net/browse/RSDK-11947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RSDK-11890]: https://viam.atlassian.net/browse/RSDK-11890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ