### PR TITLE
Switch GNM to viamrobotics repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.23.8
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1
-	github.com/Otterverse/gonetworkmanager/v2 v2.2.2
 	github.com/gabriel-vasile/mimetype v1.4.9
 	github.com/godbus/dbus/v5 v5.1.1-0.20241109141230-b9236d654833
 	github.com/google/uuid v1.6.0
@@ -15,6 +14,7 @@ require (
 	github.com/sergeymakinen/go-systemdconf/v2 v2.0.2
 	github.com/tidwall/jsonc v0.3.2
 	github.com/ulikunitz/xz v0.5.14
+	github.com/viamrobotics/gonetworkmanager/v2 v2.2.3
 	go.uber.org/zap v1.27.0
 	go.viam.com/api v0.1.443
 	go.viam.com/rdk v0.73.0

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7r
 github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmUx/1V+TNhjQvM=
-github.com/Otterverse/gonetworkmanager/v2 v2.2.2 h1:dMB1cEH+NTgrh9PtQ6DmUL8vJxCQPwF3fXB1hsI9MIA=
-github.com/Otterverse/gonetworkmanager/v2 v2.2.2/go.mod h1:C4DIH4n0H6mdK8gMlGv8OTpJfKjmd0QJPWjq2O7s64w=
 github.com/PuerkitoBio/goquery v1.6.0/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
@@ -692,6 +690,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.16.0/go.mod h1:YOKImeEosDdBPnxc0gy7INqi3m1zK6A+xl6TwOBhHCA=
 github.com/valyala/quicktemplate v1.6.3/go.mod h1:fwPzK2fHuYEODzJ9pkw0ipCPNHZ2tD5KW4lOuSdPKzY=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
+github.com/viamrobotics/gonetworkmanager/v2 v2.2.3 h1:KDbNG6jk9tMg7ARJ5xK8gowzfpgLvc58lce90j1J46k=
+github.com/viamrobotics/gonetworkmanager/v2 v2.2.3/go.mod h1:lZ27pZxpPgNAVv9qs+rwcJdgZDYJVPfbluoPbYJr/Ac=
 github.com/viamrobotics/webrtc/v3 v3.99.10 h1:ykE14wm+HkqMD5Ozq4rvhzzfvnXAu14ak/HzA1OCzfY=
 github.com/viamrobotics/webrtc/v3 v3.99.10/go.mod h1:ziH7/S52IyYAeDdwUUl5ZTbuyKe47fWorAz+0z5w6NA=
 github.com/viamrobotics/zeroconf v1.0.12 h1:y0AaDnBmELvtKKzJlnRBivZ4KWYXWXyGv73SY16sXUw=

--- a/subsystems/networking/definitions_linux.go
+++ b/subsystems/networking/definitions_linux.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	gnm "github.com/Otterverse/gonetworkmanager/v2"
+	gnm "github.com/viamrobotics/gonetworkmanager/v2"
 	pb "go.viam.com/api/provisioning/v1"
 )
 

--- a/subsystems/networking/generators_linux.go
+++ b/subsystems/networking/generators_linux.go
@@ -7,10 +7,10 @@ import (
 	"strconv"
 	"strings"
 
-	gnm "github.com/Otterverse/gonetworkmanager/v2"
 	"github.com/google/uuid"
 	errw "github.com/pkg/errors"
 	"github.com/viamrobotics/agent/utils"
+	gnm "github.com/viamrobotics/gonetworkmanager/v2"
 )
 
 // This file contains the wifi/hotspot setting generation functions.

--- a/subsystems/networking/networking_linux.go
+++ b/subsystems/networking/networking_linux.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	semver "github.com/Masterminds/semver/v3"
-	gnm "github.com/Otterverse/gonetworkmanager/v2"
 	errw "github.com/pkg/errors"
 	"github.com/viamrobotics/agent/subsystems"
 	"github.com/viamrobotics/agent/utils"
+	gnm "github.com/viamrobotics/gonetworkmanager/v2"
 	pb "go.viam.com/api/provisioning/v1"
 	"go.viam.com/rdk/logging"
 	"google.golang.org/grpc"

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -15,9 +15,9 @@ import (
 	"strings"
 	"time"
 
-	gnm "github.com/Otterverse/gonetworkmanager/v2"
 	errw "github.com/pkg/errors"
 	"github.com/viamrobotics/agent/utils"
+	gnm "github.com/viamrobotics/gonetworkmanager/v2"
 	"go.viam.com/utils/rpc"
 )
 

--- a/subsystems/networking/networkstate_linux.go
+++ b/subsystems/networking/networkstate_linux.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"sync"
 
-	gnm "github.com/Otterverse/gonetworkmanager/v2"
+	gnm "github.com/viamrobotics/gonetworkmanager/v2"
 	"go.viam.com/rdk/logging"
 )
 

--- a/subsystems/networking/scanning_linux.go
+++ b/subsystems/networking/scanning_linux.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	gnm "github.com/Otterverse/gonetworkmanager/v2"
 	errw "github.com/pkg/errors"
+	gnm "github.com/viamrobotics/gonetworkmanager/v2"
 )
 
 var (

--- a/subsystems/networking/setup_linux.go
+++ b/subsystems/networking/setup_linux.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 	"time"
 
-	gnm "github.com/Otterverse/gonetworkmanager/v2"
 	errw "github.com/pkg/errors"
 	"github.com/viamrobotics/agent/utils"
+	gnm "github.com/viamrobotics/gonetworkmanager/v2"
 )
 
 var (


### PR DESCRIPTION
Moved my personal fork of the GoNetworkManager library to the Viam org. This updates the references in agent to use the new location.