### PR TITLE
RSDK-11966 Log more obvious errors when update version info is malformed

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -604,12 +604,12 @@ func (m *Manager) GetConfig(ctx context.Context) (time.Duration, error) {
 	// Store update data in cache, actual binaries are updated later
 	err = m.cache.Update(resp.GetAgentUpdateInfo(), SubsystemName)
 	if err != nil {
-		m.logger.Warn(errw.Wrapf(err, "processing update data for %s", SubsystemName))
+		m.logger.Error(errw.Wrapf(err, "processing update data for %s", SubsystemName))
 	}
 
 	err = m.cache.Update(resp.GetViamServerUpdateInfo(), viamserver.SubsysName)
 	if err != nil {
-		m.logger.Warn(errw.Wrapf(err, "processing update data for %s", viamserver.SubsysName))
+		m.logger.Error(errw.Wrapf(err, "processing update data for %s", viamserver.SubsysName))
 	}
 
 	cfg, err := utils.StackConfigs(resp)


### PR DESCRIPTION
Before these changes, "" received as the version from app resulted in the following logs:
```

Before:
2025-09-19T18:53:01.620Z        WARN        viam-agent        agent/manager.go:196        version data not found for viam-agent
2025-09-19T18:53:01.620Z        WARN        viam-agent        agent/manager.go:218        version data not found for viam-server
2025-09-19T18:53:01.620Z        WARN        viam-agent        viamserver/viamserver.go:88        viam-server binary missing at /opt/viam/bin/viam-server, not starting
2025-09-19T18:53:01.620Z        WARN        viam-agent        viamserver/viamserver.go:88        viam-server binary missing at /opt/viam/bin/viam-server, not starting
```

After these changes:
```
2025-09-19T20:02:33.698Z        ERROR        viam-agent        agent/manager.go:607        processing update data for viam-agent: empty string given as version for viam-agent
2025-09-19T20:02:33.698Z        ERROR        viam-agent        agent/manager.go:612        processing update data for viam-server: empty string given as version for viam-server
2025-09-19T20:02:33.699Z        WARN        viam-agent        agent/manager.go:196        version data [empty string] not found for binary viam-agent
2025-09-19T20:02:33.700Z        WARN        viam-agent        agent/manager.go:218        version data [empty string] not found for binary viam-server
2025-09-19T20:02:33.700Z        WARN        viam-agent        viamserver/viamserver.go:88        viam-server binary missing at /opt/viam/bin/viam-server, not starting
2025-09-19T20:02:33.700Z        WARN        viam-agent        viamserver/viamserver.go:88        viam-server binary missing at /opt/viam/bin/viam-server, not starting
```
