### PR TITLE
RSDK-11835: Prevent redundant self update after initial install

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -51,16 +51,6 @@ func InstallNewVersion(ctx context.Context, logger logging.Logger) (bool, error)
 	return true, nil
 }
 
-func goarchToOsArch(goarch string) string {
-	switch goarch {
-	case "arm64":
-		return "aarch64"
-	case "amd64":
-		return "x86_64"
-	}
-	return ""
-}
-
 // Install is directly executed from main() when --install is passed.
 func Install(logger logging.Logger) error {
 	// Check for systemd
@@ -78,7 +68,7 @@ func Install(logger logging.Logger) error {
 	// If this is a brand new install, we want to copy ourselves into the version
 	// cache and install a symlink.
 	expectedBinPath := filepath.Join(utils.ViamDirs["bin"], SubsystemName)
-	arch := goarchToOsArch(runtime.GOARCH)
+	arch := utils.GoarchToOSArch(runtime.GOARCH)
 	if arch == "" {
 		return fmt.Errorf("could not determine platform arch mapping for GOARCH %s", runtime.GOARCH)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -601,3 +601,16 @@ func AtomicCopy(dst, src string) error {
 	}
 	return nil
 }
+
+// GoArchToOSArch translates CPU architecture IDs used by Go such as "arm64" to
+// architucture IDs used by operating systems and their package managers, such
+// as "aarch64". It returns an empty string for unknown architectures.
+func GoarchToOSArch(goarch string) string {
+	switch goarch {
+	case "arm64":
+		return "aarch64"
+	case "amd64":
+		return "x86_64"
+	}
+	return ""
+}


### PR DESCRIPTION
This fixes an issue where the agent will always perform a self update after initial install by re-downloading it's binary and restarting. This happened because the install process run by `viam-agent --install` just symlinks itself to `/opt/viam/bin/viam-agent` and sets up the systemd unit. In order to  recognize an install as valid the agent expects to see certain values in the version cache, which was not created, and the symlink for the agent pointing to a specific directory, which was not true. This resolves these issues by updating the install process to copy the binary into the expected location at `/opt/viam/cache`, symlink to that copy, and write out a minimal version cache to disk. The rest of the version information is merged in when it is fetched from app on first agent run. Testing was done manually with a binary that was slightly modified to ignore the hash mismatch.