### PR TITLE
Change ViamDirs from map to struct

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -37,7 +37,7 @@ func InstallNewVersion(ctx context.Context, logger logging.Logger) (bool, error)
 		// windows doesn't have systemctl so we don't do a postinstall yet.
 		return true, nil
 	}
-	expectedPath := filepath.Join(utils.ViamDirs["bin"], SubsystemName)
+	expectedPath := filepath.Join(utils.ViamDirs.Bin, SubsystemName)
 
 	// Run the newly updated version to install systemd and other service files.
 	//nolint:gosec
@@ -67,12 +67,12 @@ func Install(logger logging.Logger) error {
 
 	// If this is a brand new install, we want to copy ourselves into the version
 	// cache and install a symlink.
-	expectedBinPath := filepath.Join(utils.ViamDirs["bin"], SubsystemName)
+	expectedBinPath := filepath.Join(utils.ViamDirs.Bin, SubsystemName)
 	arch := utils.GoArchToOSArch(runtime.GOARCH)
 	if arch == "" {
 		return fmt.Errorf("could not determine platform arch mapping for GOARCH %s", runtime.GOARCH)
 	}
-	expectedCachePath := filepath.Join(utils.ViamDirs["cache"], strings.Join([]string{SubsystemName, utils.Version, arch}, "-"))
+	expectedCachePath := filepath.Join(utils.ViamDirs.Cache, strings.Join([]string{SubsystemName, utils.Version, arch}, "-"))
 	curPath, err := os.Executable()
 	if err != nil {
 		return errw.Wrap(err, "getting path to self")
@@ -163,7 +163,7 @@ func Install(logger logging.Logger) error {
 
 	logger.Info("Install complete.")
 
-	return errors.Join(utils.SyncFS("/etc"), utils.SyncFS(serviceFilePath), utils.SyncFS(utils.ViamDirs["viam"]))
+	return errors.Join(utils.SyncFS("/etc"), utils.SyncFS(serviceFilePath), utils.SyncFS(utils.ViamDirs.Viam))
 }
 
 func inSystemdPath(path string, logger logging.Logger) bool {

--- a/cmd/viam-agent/main.go
+++ b/cmd/viam-agent/main.go
@@ -100,12 +100,12 @@ func commonMain() {
 
 	if runtime.GOOS != "windows" && !opts.DevMode {
 		// confirm that we're running from a proper install
-		if !strings.HasPrefix(os.Args[0], utils.ViamDirs["viam"]) {
+		if !strings.HasPrefix(os.Args[0], utils.ViamDirs.Viam) {
 			//nolint:forbidigo
 			fmt.Printf("viam-agent is intended to be run as a system service and installed in %s.\n"+
 				"Please install with '%s --install' and then start the service with 'systemctl start viam-agent'\n"+
 				"Note you may need to preface the above commands with 'sudo' if you are not currently root.\n",
-				utils.ViamDirs["viam"], os.Args[0])
+				utils.ViamDirs.Viam, os.Args[0])
 			return
 		}
 	}
@@ -239,7 +239,7 @@ func exitIfError(err error) {
 }
 
 func getLock() (lockfile.Lockfile, error) {
-	pidFile, err := lockfile.New(filepath.Join(utils.ViamDirs["tmp"], "viam-agent.pid"))
+	pidFile, err := lockfile.New(filepath.Join(utils.ViamDirs.Tmp, "viam-agent.pid"))
 	if err != nil {
 		return "", errors.Wrap(err, "init lockfile")
 	}

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -791,7 +791,7 @@ func (n *Networking) processUserInput(userInput userInput) bool {
 }
 
 func (n *Networking) checkForceProvisioning() bool {
-	touchFile := path.Join(utils.ViamDirs["etc"], "force_provisioning_mode")
+	touchFile := path.Join(utils.ViamDirs.Etc, "force_provisioning_mode")
 
 	// Check if the touch file exists
 	if _, err := os.Stat(touchFile); err == nil {

--- a/subsystems/networking/networkmanager_linux_test.go
+++ b/subsystems/networking/networkmanager_linux_test.go
@@ -80,7 +80,7 @@ func TestCheckForceProvisioning(t *testing.T) {
 			}
 
 			// Set up the touch file if needed
-			touchFilePath := path.Join(utils.ViamDirs["etc"], "force_provisioning_mode")
+			touchFilePath := path.Join(utils.ViamDirs.Etc, "force_provisioning_mode")
 			if tt.setupTouchFile {
 				utils.Touch(t, touchFilePath)
 			}

--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -79,7 +79,7 @@ func (s *viamServer) Start(ctx context.Context) error {
 		s.mu.Unlock()
 		return nil
 	}
-	binPath := path.Join(utils.ViamDirs["bin"], SubsysName)
+	binPath := path.Join(utils.ViamDirs.Bin, SubsysName)
 
 	if runtime.GOOS == "windows" {
 		binPath += ".exe"
@@ -101,7 +101,7 @@ func (s *viamServer) Start(ctx context.Context) error {
 	stderr := utils.NewMatchingLogger(s.logger, false, false, "viam-server.StdErr")
 	//nolint:gosec
 	s.cmd = exec.Command(binPath, "-config", utils.AppConfigFilePath)
-	s.cmd.Dir = utils.ViamDirs["viam"]
+	s.cmd.Dir = utils.ViamDirs.Viam
 	utils.PlatformProcSettings(s.cmd)
 	s.cmd.Stdout = stdio
 	s.cmd.Stderr = stderr

--- a/utils/config.go
+++ b/utils/config.go
@@ -250,7 +250,7 @@ func DefaultConfig() AgentConfig {
 }
 
 func SaveConfigToCache(cfg AgentConfig) error {
-	cachePath := filepath.Join(ViamDirs["cache"], configCacheFilename)
+	cachePath := filepath.Join(ViamDirs.Cache, configCacheFilename)
 
 	js, err := json.Marshal(cfg)
 	if err != nil {
@@ -262,7 +262,7 @@ func SaveConfigToCache(cfg AgentConfig) error {
 }
 
 func LoadConfigFromCache() (AgentConfig, error) {
-	cachePath := filepath.Join(ViamDirs["cache"], configCacheFilename)
+	cachePath := filepath.Join(ViamDirs.Cache, configCacheFilename)
 
 	cfg := AgentConfig{}
 

--- a/utils/testutils.go
+++ b/utils/testutils.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"go.viam.com/test"
@@ -16,12 +18,15 @@ func MockViamDirs(t *testing.T) {
 		ViamDirs = old
 	})
 	td := t.TempDir()
-	ViamDirs = map[string]string{
-		"viam": td,
+	ViamDirs = ViamDirsData{
+		Viam: td,
 	}
-	for _, subdir := range []string{"bin", "cache", "tmp", "etc"} {
-		ViamDirs[subdir] = filepath.Join(td, subdir)
-		err := os.Mkdir(ViamDirs[subdir], 0o750)
+	for _, subdir := range []string{"Bin", "Cache", "Tmp", "Etc"} {
+		refViamDirs := reflect.ValueOf(&ViamDirs)
+		field := refViamDirs.Elem().FieldByName(subdir)
+		val := filepath.Join(td, strings.ToLower(subdir))
+		field.Set(reflect.ValueOf(val))
+		err := os.Mkdir(field.Interface().(string), 0o750)
 		test.That(t, err, test.ShouldBeNil)
 	}
 }

--- a/version_control.go
+++ b/version_control.go
@@ -108,7 +108,7 @@ func (c *VersionCache) load() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	cacheFilePath := filepath.Join(utils.ViamDirs["cache"], versionCacheFilename)
+	cacheFilePath := filepath.Join(utils.ViamDirs.Cache, versionCacheFilename)
 	//nolint:gosec
 	cacheBytes, err := os.ReadFile(cacheFilePath)
 	if err != nil {
@@ -127,7 +127,7 @@ func (c *VersionCache) load() {
 
 // save should only be run when protected by mutex locks. Use SaveCache() for normal use.
 func (c *VersionCache) save() error {
-	cacheFilePath := filepath.Join(utils.ViamDirs["cache"], versionCacheFilename)
+	cacheFilePath := filepath.Join(utils.ViamDirs.Cache, versionCacheFilename)
 
 	cacheData, err := json.Marshal(c)
 	if err != nil {
@@ -172,7 +172,7 @@ func (c *VersionCache) Update(cfg *pb.UpdateInfo, binary string) error {
 
 	info.Version = newVersion
 	info.URL = cfg.GetUrl()
-	info.SymlinkPath = path.Join(utils.ViamDirs["bin"], cfg.GetFilename())
+	info.SymlinkPath = path.Join(utils.ViamDirs.Bin, cfg.GetFilename())
 	info.UnpackedSHA = cfg.GetSha256()
 
 	return c.save()
@@ -342,7 +342,7 @@ func (c *VersionCache) getProtectedFilesAndCleanVersions(ctx context.Context, ma
 			path += ".exe"
 		}
 
-		destPath, err := filepath.EvalSymlinks(filepath.Join(utils.ViamDirs["bin"], path))
+		destPath, err := filepath.EvalSymlinks(filepath.Join(utils.ViamDirs.Bin, path))
 		if err != nil {
 			c.logger.Warn(err)
 			continue
@@ -404,7 +404,7 @@ func (c *VersionCache) CleanCache(ctx context.Context) {
 	}
 
 	// actually remove files
-	for _, dir := range []string{utils.ViamDirs["cache"], utils.ViamDirs["tmp"]} {
+	for _, dir := range []string{utils.ViamDirs.Cache, utils.ViamDirs.Tmp} {
 		files, err := os.ReadDir(dir)
 		if err != nil {
 			c.logger.Error(err)


### PR DESCRIPTION
Agent uses a global map at `utils.ViamDirs` to track information about where it keeps files on disk. A map seems to have been chosen to allow iteration over the list of directories but comes with the tradeoff of not being discoverable by autocomplete and being vulnerable to an (admittedly unlikely) set of logic errors if a typo in a key makes it through testing and code review. This PR changes `utils.ViamDirs` to be a struct with members for each of the keys that were previously in the map. Reflection is used to continue supporting the one code path that relied on iterating over the map values and two tests that programmatically set the values to temporary test directories.