### PR TITLE
RSDK-11248 Add restart checking logic

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -382,7 +382,6 @@ func (m *Manager) SubsystemHealthChecks(ctx context.Context) {
 func (m *Manager) CheckIfNeedsRestart(ctx context.Context) (time.Duration, bool) {
 	m.logger.Debug("Checking cloud for forced restarts")
 	if m.cloudConfig == nil {
-		// No custom interval and no restart needed in the absence of cloud information.
 		m.logger.Warn("can't CheckIfNeedsRestart until successful config load")
 		return minimalNeedsRestartCheckInterval, false
 	}

--- a/manager.go
+++ b/manager.go
@@ -410,7 +410,7 @@ func (m *Manager) CheckIfNeedsRestart(ctx context.Context) (time.Duration, bool)
 		return minimalNeedsRestartCheckInterval, false
 	}
 
-	return res.RestartCheckInterval.AsDuration(), res.GetMustRestart()
+	return res.GetRestartCheckInterval().AsDuration(), res.GetMustRestart()
 }
 
 // CloseAll stops all subsystems and closes the cloud connection.

--- a/subsystems/networking/networking_linux.go
+++ b/subsystems/networking/networking_linux.go
@@ -425,3 +425,8 @@ func (n *Networking) writeWifiPowerSave(ctx context.Context) error {
 
 	return nil
 }
+
+// Property is a noop for the networking subsystem.
+func (n *Networking) Property(_ context.Context, _ string) bool {
+	return false
+}

--- a/subsystems/subsystems.go
+++ b/subsystems/subsystems.go
@@ -19,6 +19,9 @@ type Subsystem interface {
 
 	// HealthCheck reports if a subsystem is running correctly (it is restarted if not)
 	HealthCheck(ctx context.Context) error
+
+	// Property gets an arbitrary property about the running subystem.
+	Property(ctx context.Context, property string) bool
 }
 
 // Dummy is a fake subsystem for when a particular OS doesn't (yet) have support.
@@ -38,4 +41,8 @@ func (d *Dummy) Update(_ context.Context, _ utils.AgentConfig) bool {
 
 func (d *Dummy) HealthCheck(_ context.Context) error {
 	return nil
+}
+
+func (d *Dummy) Property(_ context.Context, _ string) bool {
+	return false
 }

--- a/subsystems/syscfg/syscfg_linux.go
+++ b/subsystems/syscfg/syscfg_linux.go
@@ -114,3 +114,8 @@ func (s *syscfg) HealthCheck(ctx context.Context) error {
 	}
 	return errors.New("healthcheck failed")
 }
+
+// Property is a noop for the syscfg subsystem.
+func (s *syscfg) Property(_ context.Context, _ string) bool {
+	return false
+}

--- a/subsystems/viamserver/restart_properties.go
+++ b/subsystems/viamserver/restart_properties.go
@@ -1,0 +1,238 @@
+package viamserver
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"runtime"
+	"time"
+
+	errw "github.com/pkg/errors"
+	goutils "go.viam.com/utils"
+)
+
+type (
+	// RestartPropertyGetter is a limited interface through which agent can access
+	// information about viamserver related to restarting.
+	RestartPropertyGetter interface {
+		// RestartAllowed checks whether viamserver is safe to restart.
+		RestartAllowed(ctx context.Context) bool
+		// DoesNotHandlesNeedsRestart checks whether viamserver does not itself check for the
+		// need to restart against app.
+		DoesNotHandleNeedsRestart(ctx context.Context) bool
+	}
+
+	// RestartStatusResponse is the http/json response from viamserver's /restart_status URL.
+	RestartStatusResponse struct {
+		// RestartAllowed represents whether this instance of the viamserver can be
+		// safely restarted.
+		RestartAllowed bool `json:"restart_allowed"`
+		// DoesNotHandleNeedsRestart represents whether this instance of the viamserver does
+		// not check for the need to restart against app itself and, thus, needs agent to do so.
+		// Newer versions of viamserver (>= v0.9x.0) will report true for this value, while
+		// older versions won't report it at all, and agent should let viamserver handle
+		// NeedsRestart logic.
+		DoesNotHandleNeedsRestart bool `json:"does_not_handle_needs_restart,omitempty"`
+	}
+
+	// restartProperty is a property related to restarting about which agent can query
+	// viamserver.
+	restartProperty string
+)
+
+const (
+	restartPropertyRestartAllowed            restartProperty = "restart allowed"
+	restartPropertyDoesNotHandleNeedsRestart                 = "does not handle need restart"
+
+	restartURLSuffix = "/restart_status"
+
+	checkRestartPropertyTimeout = 10 * time.Second
+)
+
+// Creates test URLs for property checks. Must be called with s.mu locked.
+func (s *viamServer) makeTestURLs() ([]string, error) {
+	port := "8080"
+	mainURL, err := url.Parse(s.checkURL)
+	if err != nil {
+		s.logger.Warnf("cannot determine port for restart allowed check, using default of 8080")
+	} else {
+		port = mainURL.Port()
+		s.logger.Debugf("using port %s for restart allowed check", port)
+	}
+
+	ips, err := getAllLocalIPv4s()
+	if err != nil {
+		return []string{}, err
+	}
+
+	urls := []string{s.checkURL, s.checkURLAlt}
+	for _, ip := range ips {
+		urls = append(urls, fmt.Sprintf("https://%s:%s", ip, port))
+	}
+
+	return urls, nil
+}
+
+// Gets all local IPV4s. Copied from goutils, but loopback checks are removed, as we DO
+// want loopback adapters. Used in creating test URLS.
+func getAllLocalIPv4s() ([]string, error) {
+	allInterfaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	all := []string{}
+
+	for _, i := range allInterfaces {
+		addrs, err := i.Addrs()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, addr := range addrs {
+			switch v := addr.(type) {
+			case *net.IPNet:
+				_, bits := v.Mask.Size()
+				if bits != 32 {
+					// this is what limits to ipv4
+					continue
+				}
+
+				all = append(all, v.IP.String())
+			default:
+				return nil, fmt.Errorf("unknown address type: %T", v)
+			}
+		}
+	}
+
+	return all, nil
+}
+
+// Returns the value of the requested restart property (false if not determined) and any
+// encountered errors. Must be called with s.mu held, as makeTestURLs is called.
+func (s *viamServer) checkRestartProperty(ctx context.Context, rp restartProperty) (bool, error) {
+	urls, err := s.makeTestURLs()
+	if err != nil {
+		return false, err
+	}
+
+	errorChan := make(chan error, len(urls))
+	propertyValueChan := make(chan bool, len(urls))
+	timeoutCtx, cancelFunc := context.WithTimeout(ctx, checkRestartPropertyTimeout)
+	defer cancelFunc()
+
+	for _, url := range urls {
+		go func() {
+			s.logger.Debugf("Starting %s check for %s using %s", rp, SubsysName, url)
+
+			restartURL := url + restartURLSuffix
+
+			req, err := http.NewRequestWithContext(timeoutCtx, http.MethodGet, restartURL, nil)
+			if err != nil {
+				errorChan <- errw.Wrapf(err, "creating HTTP request for %s check for %s via %s",
+					rp, SubsysName, restartURL)
+				return
+			}
+
+			// Disabling the cert verification because it doesn't work in offline mode (when
+			// connecting to localhost).
+			//nolint:gosec
+			client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				errorChan <- errw.Wrapf(err, "sending HTTP request for %s check for %s via %s",
+					rp, SubsysName, restartURL)
+				return
+			}
+			defer func() {
+				goutils.UncheckedError(resp.Body.Close())
+			}()
+
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				// Interacting with older viam-server instances will result in a non-successful
+				// HTTP response status code, as the /restart_status endpoint will not be
+				// available. Report false (default) as the feature value and continue to next
+				// test URL in this case.
+				propertyValueChan <- false
+				return
+			}
+
+			var restartStatusResponse RestartStatusResponse
+			if err = json.NewDecoder(resp.Body).Decode(&restartStatusResponse); err != nil {
+				errorChan <- errw.Wrapf(err, "decoding HTTP response for %s check for %s via %s",
+					rp, SubsysName, restartURL)
+				return
+			}
+
+			switch rp {
+			case restartPropertyRestartAllowed:
+				propertyValueChan <- restartStatusResponse.RestartAllowed
+			case restartPropertyDoesNotHandleNeedsRestart:
+				propertyValueChan <- restartStatusResponse.DoesNotHandleNeedsRestart
+			}
+
+			errorChan <- nil
+		}()
+	}
+
+	var combinedErr error
+	for err := range errorChan {
+		combinedErr = errors.Join(combinedErr, err)
+	}
+
+	// We assume below that the first test URL through which we encountered the feature's
+	// value represents the actual value.
+	return <-propertyValueChan, combinedErr
+}
+
+// RestartAllowed checks whether viamserver is safe to restart.
+func (s *viamServer) RestartAllowed(ctx context.Context) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.running || runtime.GOOS == "windows" {
+		// Assume viamserver is "safe to restart" if not running at all or on Windows.
+		return true
+	}
+
+	restartAllowed, err := s.checkRestartProperty(ctx, restartPropertyRestartAllowed)
+	if err != nil {
+		// Log any errors encountered while checking whether restart was allowed. Do not log
+		// whether viamserver has or has not reported allowance of a restart in this case, as
+		// we don't know, and will just assume it's unsafe to restart.
+		s.logger.Warn(err)
+		return restartAllowed
+	}
+	if restartAllowed {
+		s.logger.Infof("Will restart %s to run new version, as it has reported allowance of a restart", SubsysName)
+	} else {
+		s.logger.Infof("Will not restart %s version to run new version, as it has not reported allowance of a restart", SubsysName)
+	}
+	return restartAllowed
+}
+
+// DoesNotHandlesNeedsRestart checks whether viamserver does not itself check for the need
+// to restart against app.
+func (s *viamServer) DoesNotHandleNeedsRestart(ctx context.Context) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.running {
+		// Assume agent can handle the restart if viamserver isn't running.
+		return true
+	}
+
+	doesNotHandleNeedsRestart, err := s.checkRestartProperty(ctx,
+		restartPropertyDoesNotHandleNeedsRestart)
+	if err != nil {
+		// Log any errors encountered while checking whether needs restart is handled.
+		s.logger.Warn(err)
+	}
+	return doesNotHandleNeedsRestart
+}

--- a/subsystems/viamserver/restart_properties.go
+++ b/subsystems/viamserver/restart_properties.go
@@ -47,7 +47,7 @@ type (
 
 const (
 	restartPropertyRestartAllowed            restartProperty = "restart allowed"
-	restartPropertyDoesNotHandleNeedsRestart                 = "does not handle need restart"
+	restartPropertyDoesNotHandleNeedsRestart restartProperty = "does not handle need restart"
 
 	restartURLSuffix = "/restart_status"
 

--- a/utils/utils_unix.go
+++ b/utils/utils_unix.go
@@ -41,6 +41,13 @@ func SignalForTermination(pid int) error {
 	return nil
 }
 
+func SignalForQuit(pid int) error {
+	if err := syscall.Kill(pid, syscall.SIGQUIT); err != nil {
+		return errw.Wrapf(err, "signaling PID %d", pid)
+	}
+	return nil
+}
+
 // KillTree sends SIGKILL to the process group.
 func KillTree(pid int) error {
 	if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil {

--- a/utils/utils_windows.go
+++ b/utils/utils_windows.go
@@ -55,6 +55,11 @@ func SignalForTermination(pid int) error {
 	return windows.GenerateConsoleCtrlEvent(syscall.CTRL_BREAK_EVENT, uint32(pid)) //nolint:gosec
 }
 
+// SignalForQuit is the same as SignalForTermination on Windows for now.
+func SignalForQuit(pid int) error {
+	return SignalForTermination(pid)
+}
+
 func writePlatformOutput(p []byte) (int, error) {
 	if inService, err := svc.IsWindowsService(); err != nil {
 		return len(p), err

--- a/version_control.go
+++ b/version_control.go
@@ -216,8 +216,8 @@ func (c *VersionCache) UpdateBinary(ctx context.Context, binary string) (bool, e
 	shasum, err := utils.GetFileSum(verData.UnpackedPath)
 	if err == nil {
 		goodBytes = bytes.Equal(shasum, verData.UnpackedSHA)
-	} else {
-		c.logger.Warn(err)
+	} else if verData.UnpackedPath != "" { // custom file:// URLs with have an empty unpacked path; no need to warn
+		c.logger.Warnw("Could not calculate shasum", "path", verData.UnpackedPath, "error", err)
 	}
 
 	if data.TargetVersion == data.CurrentVersion {


### PR DESCRIPTION
[RSDK-11248](https://viam.atlassian.net/browse/RSDK-11248)

Adds similar restart checking logic to the logic removed in https://github.com/viamrobotics/rdk/pull/5324; the logic now restarts `viam-agent` and all its other subsystems along with `viam-server`. Refactors hits of `restart_status` to be more generic (can query multiple restart "properties"). Adds a `Property` method to the `Subsystem` interface.

## Testing

I've done a decent amount of manual testing but still want to do more to ensure I haven't broken the "restart allowed" logic nor the behavior of restarts on Windows.

Note that I'm leveraging a `does_not_handle_needs_restart` JSON property exposed on the `restart_status` endpoint introduced in the associated RDK PR. The expected behavior right now is:

|                 | Old viam-agent                             | New viam-agent                             |
|-----------------|--------------------------------------------|--------------------------------------------|
| Old viam-server | viam-server should handle restart checking | viam-server should handle restart checking |
| New viam-server | neither will handle restart checking       | viam-agent should handle restart checking  |
