### PR TITLE
RSDK-13768 Improve Windows ConsoleLogger performance

### DIFF
--- a/utils/utils_windows.go
+++ b/utils/utils_windows.go
@@ -14,7 +14,6 @@ import (
 	errw "github.com/pkg/errors"
 	goutils "go.viam.com/utils"
 	"golang.org/x/sys/windows"
-	"golang.org/x/sys/windows/svc"
 )
 
 func PlatformProcSettings(cmd *exec.Cmd) {
@@ -144,9 +143,11 @@ func SignalForTermination(pid int) error {
 }
 
 func writePlatformOutput(p []byte) (int, error) {
-	if inService, err := svc.IsWindowsService(); err != nil {
-		return len(p), err
-	} else if inService {
+	// IsRunningLocally is set to true if the agent is not running as a Windows service.
+	// This check blanks out console logs if we are running as a service, since they're not needed,
+	// but it passes them through if we're running locally so they can be viewed (in the user's terminal,
+	// for example)
+	if !IsRunningLocally {
 		return len(p), nil
 	}
 	return os.Stdout.Write(p)


### PR DESCRIPTION
On Windows, when viam-agent spawns viam-server, the stdout from viam-server gets piped back to viam-agent through the `ConsoleAppender` path.

When viam-agent is running standalone, it will pass these logs through so the user can read them (in the terminal where viam-agent is running).

When viam-agent is running as a Windows service, it will throw out the logs piped from viam-server since there's no terminal to print them to.

viam-agent uses `svc.IsWindowsService()` to check whether it's running as a service, but it was making this expensive syscall in `utils.writePlatformOutput` which meant that the syscall was running for each log line.

On launch we already check `svc.IsWindowsService()` and store the result:

```go
func main() {
	if inService, err := svc.IsWindowsService(); err != nil {
		panic(err)
	} else if !inService {
		globalLogger.Info("no service detected -- running as normal process")
		utils.IsRunningLocally = true
		commonMain()
		return
	}
```

Since this value will never change at runtime, I just updated `writePlatformOutput` to use it instead:

```go
func writePlatformOutput(p []byte) (int, error) {
	if !IsRunningLocally {
		return len(p), nil
	}
	return os.Stdout.Write(p)
}
```

I tested this change on my Windows 10 VM and it dramatically reduced the incidence of "slow logs" (logs taking over 100ms).

I also ran the agent binary as standalone and confirmed that it was still passing through logs from viam-server (the logs looked the same whether or not my change was in).