### PR TITLE
Add PR-triggered dev releases via `dev-release` label

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -88,9 +88,11 @@ jobs:
     outputs:
       pr_urls: ${{ steps.pr_urls.outputs.urls }}
     env:
-      # Empty on non-PR events; dev-version.sh consumes this to stamp PR builds
-      # with the branch HEAD SHA (not the synthetic merge-commit SHA GitHub
-      # checks out for pull_request events).
+      # Empty on non-PR events; dev-version.sh consumes these to stamp PR
+      # builds as v<next>-pr.<pr-num>.<head-sha>. PR_HEAD_SHA is the branch
+      # HEAD (not the synthetic merge-commit SHA GitHub checks out for
+      # pull_request events).
+      PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -87,6 +87,11 @@ jobs:
     needs: test
     outputs:
       pr_urls: ${{ steps.pr_urls.outputs.urls }}
+    env:
+      # Empty on non-PR events; dev-version.sh consumes this to stamp PR builds
+      # with the branch HEAD SHA (not the synthetic merge-commit SHA GitHub
+      # checks out for pull_request events).
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -2,6 +2,7 @@ name: Test and Build
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
   workflow_call:
   push:
@@ -10,10 +11,19 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Lint, Test, Build
     runs-on: ubuntu-latest
+    # Skip rerun on unrelated label changes; still run when dev-release is
+    # added so the build job has a fresh test pass before uploading artifacts.
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      (github.event.action == 'labeled' && github.event.label.name == 'dev-release')
     steps:
     - uses: actions/checkout@v4
       with:
@@ -44,6 +54,10 @@ jobs:
   test-macos:
     name: Test on MacOS
     runs-on: macos-latest
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      (github.event.action == 'labeled' && github.event.label.name == 'dev-release')
     steps:
     - uses: actions/checkout@v4
       with:
@@ -57,8 +71,22 @@ jobs:
   build:
     name: Build and Upload
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
+    # Upload artifacts on: main pushes, releases, and PRs labeled `dev-release`
+    # (internal PRs only — fork PRs are blocked to keep secrets out of reach).
+    if: |
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'release' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        (
+          (github.event.action == 'labeled' && github.event.label.name == 'dev-release') ||
+          (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'dev-release'))
+        )
+      )
     needs: test
+    outputs:
+      pr_urls: ${{ steps.pr_urls.outputs.urls }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -78,7 +106,48 @@ jobs:
         gsutil -h "Cache-Control:no-cache" cp bin/viam-agent-* install.sh uninstall.sh preinstall.sh gs://packages.viam.com/apps/viam-agent/
         gsutil cp etc/viam-agent-*.json gs://packages.viam.com/apps/viam-subsystems/
     - name: Upload binaries to GCS (Prerelease)
-      if: github.event_name != 'release'
+      if: github.event_name != 'release' && github.event_name != 'pull_request'
       run: |
         gsutil -h "Cache-Control:no-cache" cp bin/viam-agent-* gs://packages.viam.com/apps/viam-agent/prerelease/
         gsutil cp etc/viam-agent-*.json gs://packages.viam.com/apps/viam-subsystems/
+    - name: Upload binaries to GCS (PR dev release)
+      if: github.event_name == 'pull_request'
+      run: |
+        PR_PATH="gs://packages.viam.com/apps/viam-agent/prerelease/pr-${{ github.event.pull_request.number }}"
+        gsutil -h "Cache-Control:no-cache" cp bin/viam-agent-* "$PR_PATH/"
+        gsutil cp etc/viam-agent-*.json "$PR_PATH/"
+    - name: Collect PR dev release URLs
+      id: pr_urls
+      if: github.event_name == 'pull_request'
+      run: |
+        BASE="https://storage.googleapis.com/packages.viam.com/apps/viam-agent/prerelease/pr-${{ github.event.pull_request.number }}"
+        {
+          echo "urls<<EOF"
+          for f in bin/viam-agent-*; do
+            name=$(basename "$f")
+            echo "- [\`${name}\`](${BASE}/${name})"
+          done
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+
+  pr-dev-release-comment:
+    name: Post PR dev release URLs
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+    steps:
+    - name: Post or update sticky PR comment
+      # marocchino/sticky-pull-request-comment@v3.0.4
+      uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
+      with:
+        header: dev-release-urls
+        message: |
+          ## Dev release artifacts
+
+          Built from `${{ github.event.pull_request.head.sha }}`.
+
+          ${{ needs.build.outputs.pr_urls }}
+
+          Remove the `dev-release` label to stop further dev release builds.

--- a/dev-version.sh
+++ b/dev-version.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# dev-version.sh -- this generates filenames like 'viam-agent-v0.15.1-dev.4-x86_64' for prereleases.
+# dev-version.sh -- generates version labels for prereleases.
+#   main/manual CI builds: 'viam-agent-v0.15.1-dev.4-<arch>' (commits past last tag)
+#   PR dev-release builds: 'viam-agent-v0.15.1-pr.<head-sha>-<arch>' (unique per commit)
 # To test locally, comment out the `git status` stanza and do:
 # `GITHUB_REF_NAME=main ./dev-setup.sh` (to just see the version)
 # `GITHUB_REF_NAME=main make all` (for an actual build)
@@ -38,6 +40,11 @@ NEXT_VERSION=$(echo "$BASE_VERSION" | awk -F. '{$3+=1}1' OFS=.)
 # Set TAG_VERSION based on commits since last tag
 if [ "$COMMITS_SINCE_TAG" -eq 0 ]; then
 	TAG_VERSION="$BASE_VERSION"
+elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+	# PR builds use the head commit SHA for unambiguous provenance across
+	# simultaneous PRs branched from the same base. PR_HEAD_SHA is plumbed
+	# from github.event.pull_request.head.sha; fall back to HEAD for local use.
+	TAG_VERSION="${NEXT_VERSION}-pr.${PR_HEAD_SHA:-$(git rev-parse HEAD)}"
 else
 	TAG_VERSION="${NEXT_VERSION}-dev.${COMMITS_SINCE_TAG}"
 fi

--- a/dev-version.sh
+++ b/dev-version.sh
@@ -20,8 +20,9 @@ if [ -z "$GITHUB_REF_NAME" ]; then
 	GITHUB_REF_NAME=$(git rev-parse --abbrev-ref HEAD)
 fi
 
-# If we're not on main, we have no (automated) version to create
-if [ "$GITHUB_REF_NAME" != "main" ]; then
+# Outside of CI, only main gets an automated version (avoids local branch
+# builds producing CI-looking version labels).
+if [ -z "$GITHUB_ACTIONS" ] && [ "$GITHUB_REF_NAME" != "main" ]; then
 	exit 0
 fi
 

--- a/dev-version.sh
+++ b/dev-version.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # dev-version.sh -- generates version labels for prereleases.
 #   main/manual CI builds: 'viam-agent-v0.15.1-dev.4-<arch>' (commits past last tag)
-#   PR dev-release builds: 'viam-agent-v0.15.1-pr.<head-sha>-<arch>' (unique per commit)
+#   PR dev-release builds: 'viam-agent-v0.15.1-pr.<pr-num>.<head-sha>-<arch>'
+#     (PR number scopes, SHA pinpoints the commit)
 # To test locally, comment out the `git status` stanza and do:
 # `GITHUB_REF_NAME=main ./dev-setup.sh` (to just see the version)
 # `GITHUB_REF_NAME=main make all` (for an actual build)
@@ -41,10 +42,10 @@ NEXT_VERSION=$(echo "$BASE_VERSION" | awk -F. '{$3+=1}1' OFS=.)
 if [ "$COMMITS_SINCE_TAG" -eq 0 ]; then
 	TAG_VERSION="$BASE_VERSION"
 elif [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-	# PR builds use the head commit SHA for unambiguous provenance across
-	# simultaneous PRs branched from the same base. PR_HEAD_SHA is plumbed
-	# from github.event.pull_request.head.sha; fall back to HEAD for local use.
-	TAG_VERSION="${NEXT_VERSION}-pr.${PR_HEAD_SHA:-$(git rev-parse HEAD)}"
+	# PR builds embed both PR number and head SHA. PR_NUMBER and PR_HEAD_SHA
+	# are plumbed from the workflow (github.event.pull_request.{number,head.sha});
+	# PR_HEAD_SHA falls back to HEAD for local simulation.
+	TAG_VERSION="${NEXT_VERSION}-pr.${PR_NUMBER:-unknown}.${PR_HEAD_SHA:-$(git rev-parse HEAD)}"
 else
 	TAG_VERSION="${NEXT_VERSION}-dev.${COMMITS_SINCE_TAG}"
 fi


### PR DESCRIPTION
## Summary

Applying the `dev-release` label to an internal PR builds agent binaries and uploads them to `gs://packages.viam.com/apps/viam-agent/prerelease/pr-<num>/`. A sticky comment on the PR carries the download URLs, updated in place on each rebuild. Removing the label stops further builds. Fork PRs are blocked from upload.

**Version scheme:** PR builds use `v<next>-pr.<pr-num>.<head-sha>` (PR number scopes, SHA pinpoints the commit). Main's dev stream is unchanged (`v<next>-dev.<N>`).

**Prerequisite:** the `dev-release` label must exist in the repo before first use:
```
gh label create dev-release --description "Upload dev release artifacts on each push"
```

## Test plan

- [x] Apply `dev-release` on a throwaway PR; sticky comment appears with 4 arch URLs
- [x] Push a new commit; comment updates in place, new SHA in filenames
- [x] Remove label; subsequent pushes produce no build

🤖 Generated with [Claude Code](https://claude.com/claude-code)