### PR TITLE
stopProvisioning: always flip provisioning flag, even on cleanup error

### DIFF
--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -314,11 +314,12 @@ func (n *Subsystem) stopProvisioning() error {
 		n.stopProvisioningHotspot(),
 		n.stopProvisioningBluetooth(),
 	)
-	if err != nil {
-		return err
-	}
+	// Always flip the provisioning flag, even if cleanup returned an error.
+	// Resources are already torn down at this point; leaving the flag set
+	// makes connState inaccurate with reality and blocks the agent from
+	// re-entering or exiting provisioning correctly until the next restart.
 	n.connState.setProvisioning(false)
-	return nil
+	return err
 }
 
 func (n *Subsystem) stopProvisioningHotspot() error {


### PR DESCRIPTION
A transient failure in stopProvisioningHotspot or stopProvisioningBluetooth would skip setProvisioning(false), leaving connState reporting "still provisioning" while resources were already torn down. The agent then could not re-enter or exit provisioning correctly until restart.

The joined error is still returned to callers, which already log it.

Follow up to an edge case I noticed while working on  https://github.com/viamrobotics/agent/pull/230