### PR TITLE
Fallback if systemd-path or systemd-search-system-unit don't exist

### DIFF
--- a/utils/systemd/manager.go
+++ b/utils/systemd/manager.go
@@ -117,10 +117,7 @@ func (s *SystemdManager) getServiceFilePath(ctx context.Context, serviceFile str
 	// Check if the new, preferred path is present in the systemd search path and
 	// therefore a migration may need to be performed.
 	searchPaths, err := s.SystemdSearchPaths(ctx)
-	if err != nil {
-		return "", false, err
-	}
-	if !slices.Contains(searchPaths, s.dirs.serviceFileDir) {
+	if err != nil || !slices.Contains(searchPaths, s.dirs.serviceFileDir) {
 		s.logger.Warnf(
 			"Systemd does not have %s in its unit search path, installing directly to %s",
 			s.dirs.serviceFileDir,

--- a/utils/systemd/manager.go
+++ b/utils/systemd/manager.go
@@ -118,9 +118,10 @@ func (s *SystemdManager) getServiceFilePath(ctx context.Context, serviceFile str
 	// therefore a migration may need to be performed.
 	searchPaths, err := s.SystemdSearchPaths(ctx)
 	if err != nil {
-		s.logger.Warnf(
-			"Could not determine systemd unit search paths (%v); installing service file directly to %s",
-			err, s.dirs.fallbackFileDir,
+		s.logger.Warnw(
+			"Could not determine systemd unit search paths; installing to fallback path",
+			"err", err,
+			"installPath", oldFilePath,
 		)
 		return oldFilePath, false, nil
 	}

--- a/utils/systemd/manager.go
+++ b/utils/systemd/manager.go
@@ -122,7 +122,7 @@ func (s *SystemdManager) getServiceFilePath(ctx context.Context, serviceFile str
 			"Could not determine systemd unit search paths (%v); installing service file directly to %s",
 			err, s.dirs.fallbackFileDir,
 		)
-		return oldFilePath, false, nil //nolint:nilerr
+		return oldFilePath, false, nil
 	}
 	if !slices.Contains(searchPaths, s.dirs.serviceFileDir) {
 		s.logger.Warnf(

--- a/utils/systemd/manager.go
+++ b/utils/systemd/manager.go
@@ -117,7 +117,14 @@ func (s *SystemdManager) getServiceFilePath(ctx context.Context, serviceFile str
 	// Check if the new, preferred path is present in the systemd search path and
 	// therefore a migration may need to be performed.
 	searchPaths, err := s.SystemdSearchPaths(ctx)
-	if err != nil || !slices.Contains(searchPaths, s.dirs.serviceFileDir) {
+	if err != nil {
+		s.logger.Warnf(
+			"Could not determine systemd unit search paths (%v); installing service file directly to %s",
+			err, s.dirs.fallbackFileDir,
+		)
+		return oldFilePath, false, nil //nolint:nilerr
+	}
+	if !slices.Contains(searchPaths, s.dirs.serviceFileDir) {
 		s.logger.Warnf(
 			"Systemd does not have %s in its unit search path, installing directly to %s",
 			s.dirs.serviceFileDir,


### PR DESCRIPTION
@johnwalicki and I were helping a customer (Miele) install agent on a Linux machine running Ubuntu 20.04. The script exited fatally with this error message:  `running 'systemd-path systemd-search-system-unit' output: Path systemd-search-system-unit not known`:
<img width="2256" height="1504" alt="image" src="https://github.com/user-attachments/assets/17936fde-6e37-4a0b-98c7-5ed592f1ec74" />


It seems like they had an outdated version of `systemd` which doesn't recognize `systemd-search-system-unit` and we don't gracefully handle this scenario. We already have a fallback path (`/etc/systemd/system`) when we cannot find the default service path (`/usr/local/lib/systemd/system`), so this PR just makes it so we use that fallback path when `systemd-path` or `systemd-path systemd-search-system-unit` errors out instead of fatally exiting.