### PR TITLE
Handle FORCE correctly for viam.json overwrite check during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ uninstall_old_service() {
 fetch_config() {
 	if [ "$VIAM_API_KEY_ID" != "" ] && [ "$VIAM_API_KEY" != "" ] && [ "$VIAM_PART_ID" != "" ]; then
 
-		if [ -f /etc/viam.json ] && ! [ -z $FORCE ]; then
+		if [ -f /etc/viam.json ] && [ -z "$FORCE" ]; then
 			echo
 			echo "/etc/viam.json already exists."
 			echo


### PR DESCRIPTION
`install.sh` had a double negative in the logic gating a prompt asking the user if they want to overwrite `/etc/viam.json` if it exists:

```bash
if [ -f /etc/viam.json ] && ! [ -z $FORCE ]; then
```

This is saying "if `/etc/viam.json` exists and `$FORCE` is set (NOT empty)", then ask the user if they want to keep `/etc/viam.json` (otherwise just remove it).

I'm pretty sure we want the opposite behavior (if `$FORCE` is set, just remove the old credentials without asking, otherwise ask), which is what the script will do after changing the conditional to this:

```bash
if [ -f /etc/viam.json ] && [ -z "$FORCE" ]; then
```

Now, if `$FORCE` is set, we skip the check, otherwise we run it.

For what it's worth, this means that up until now we have always been removing existing `/etc/viam.json` files when installing agent without `$FORCE`.

The e2e install tests weren't catching this because they always pass `$FORCE` and usually install after uninstalling agent, so `/etc/viam.json` is usually not present during install.