### PR TITLE
[APP-16363] Sign viam-agent Windows binary

### DIFF
--- a/.github/workflows/build-windows-installer.yaml
+++ b/.github/workflows/build-windows-installer.yaml
@@ -75,7 +75,7 @@ jobs:
             --storetype GOOGLECLOUD `
             --keystore "projects/engineering-tools-310515/locations/global/keyRings/release_signing_key" `
             --storepass "${{ steps.gcp-auth.outputs.access_token }}" `
-            --alias "ev-code-signing-key/cryptoKeyVersions/1" `
+            --alias "ev-code-signing-key/cryptoKeyVersions/2" `
             --certfile cert.pem viam-agent-installer.exe
           rm cert.pem
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -134,7 +134,6 @@ jobs:
             --tsaurl http://timestamp.digicert.com \
             "$f"
         done
-        rm cert.pem jsign.jar
     - name: Generate manifest
       run: make manifest
     - uses: google-github-actions/auth@v2

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -104,10 +104,8 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
-
     - name: Build
       run: make all
-
     - id: 'gcp-signing-auth'
       uses: 'google-github-actions/auth@v2'
       with:
@@ -115,13 +113,11 @@ jobs:
         project_id: 'engineering-tools-310515'
         workload_identity_provider: 'projects/385154741571/locations/global/workloadIdentityPools/ev-signing-id/providers/github-repos-viam-and-labs'
         service_account: 'ev-code-signing@engineering-tools-310515.iam.gserviceaccount.com'
-
     - id: 'gcp-signing-secrets'
       uses: 'google-github-actions/get-secretmanager-secrets@v2'
       with:
         secrets: |-
           public_key:projects/385154741571/secrets/ev-code-signing-public-key
-
     - name: Sign Windows binaries
       run: |
         curl -L -o jsign.jar https://github.com/ebourg/jsign/releases/download/7.1/jsign-7.1.jar
@@ -139,10 +135,8 @@ jobs:
             "$f"
         done
         rm cert.pem jsign.jar
-
     - name: Generate manifest
       run: make manifest
-
     - uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -107,14 +107,14 @@ jobs:
     - name: Build
       run: make all
     - id: 'gcp-signing-auth'
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         token_format: 'access_token'
         project_id: 'engineering-tools-310515'
         workload_identity_provider: 'projects/385154741571/locations/global/workloadIdentityPools/ev-signing-id/providers/github-repos-viam-and-labs'
         service_account: 'ev-code-signing@engineering-tools-310515.iam.gserviceaccount.com'
     - id: 'gcp-signing-secrets'
-      uses: 'google-github-actions/get-secretmanager-secrets@v2'
+      uses: 'google-github-actions/get-secretmanager-secrets@v3'
       with:
         secrets: |-
           public_key:projects/385154741571/secrets/ev-code-signing-public-key

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -85,9 +85,6 @@ jobs:
         )
       )
     needs: test
-    # id-token: write enables Workload Identity Federation for the Windows binary
-    # signing step. contents: read is required by checkout since adding any
-    # permissions block drops the defaults.
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -108,9 +105,6 @@ jobs:
       with:
         go-version-file: go.mod
 
-    # Build all binaries first, then sign the Windows ones, then generate the
-    # subsystem manifest so its SHA256 reflects the SIGNED binary. Signing after
-    # manifest generation would leave the manifest pointing at the unsigned hash.
     - name: Build
       run: make all
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -85,6 +85,12 @@ jobs:
         )
       )
     needs: test
+    # id-token: write enables Workload Identity Federation for the Windows binary
+    # signing step. contents: read is required by checkout since adding any
+    # permissions block drops the defaults.
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     outputs:
       pr_urls: ${{ steps.pr_urls.outputs.urls }}
     env:
@@ -101,8 +107,48 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
+
+    # Build all binaries first, then sign the Windows ones, then generate the
+    # subsystem manifest so its SHA256 reflects the SIGNED binary. Signing after
+    # manifest generation would leave the manifest pointing at the unsigned hash.
     - name: Build
-      run: make all manifest
+      run: make all
+
+    - id: 'gcp-signing-auth'
+      uses: 'google-github-actions/auth@v2'
+      with:
+        token_format: 'access_token'
+        project_id: 'engineering-tools-310515'
+        workload_identity_provider: 'projects/385154741571/locations/global/workloadIdentityPools/ev-signing-id/providers/github-repos-viam-and-labs'
+        service_account: 'ev-code-signing@engineering-tools-310515.iam.gserviceaccount.com'
+
+    - id: 'gcp-signing-secrets'
+      uses: 'google-github-actions/get-secretmanager-secrets@v2'
+      with:
+        secrets: |-
+          public_key:projects/385154741571/secrets/ev-code-signing-public-key
+
+    - name: Sign Windows binaries
+      run: |
+        curl -L -o jsign.jar https://github.com/ebourg/jsign/releases/download/7.1/jsign-7.1.jar
+        echo "${{ steps.gcp-signing-secrets.outputs.public_key }}" > cert.pem
+        # Loop signs the versioned binary and (on releases) the viam-agent-stable-windows-x86_64 copy.
+        for f in bin/viam-agent-*-windows-x86_64; do
+          java -jar jsign.jar \
+            --name "Viam Agent" \
+            --storetype GOOGLECLOUD \
+            --keystore "projects/engineering-tools-310515/locations/global/keyRings/release_signing_key" \
+            --storepass "${{ steps.gcp-signing-auth.outputs.access_token }}" \
+            --alias "ev-code-signing-key/cryptoKeyVersions/2" \
+            --certfile cert.pem \
+            --tsaurl http://timestamp.digicert.com \
+            "$f"
+        done
+        rm cert.pem jsign.jar
+
+    - name: Generate manifest
+      run: make manifest
+
     - uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ secrets.GCP_CREDENTIALS }}


### PR DESCRIPTION
## Summary

[APP-16363](https://viam.atlassian.net/browse/APP-16363) sign windows agent and viam-server

Companion to [viamrobotics/rdk#6020](https://github.com/viamrobotics/rdk/pull/6020). `bin/viam-agent-*-windows-x86_64` built by `make all` is currently unsigned, which can cause Windows Defender to flag it as untrusted on download. This PR signs it with the existing Viam EV code-signing cert (same one `viam_vnc` and the existing `build-windows-installer.yaml` use).

- `.github/workflows/build-windows-installer.yaml`: bump KMS key version `/1` → `/2`. The cert in Secret Manager was rotated in 2026-03 to bind to v2; the installer workflow was still pinned to v1 and has been broken since (2026-04-03 run failed with "private key doesn't match the certificate").

Changes to `.github/workflows/workflow.yaml`'s `build` job:
- Split `make all manifest` into `make all` → sign step → `make manifest` so the subsystem manifest's SHA256 reflects the signed binary.
- Add WIF-based auth scoped to the signing step. 
- Fetch the EV cert from Secret Manager, download `jsign-7.1.jar`, and loop over `bin/viam-agent-*-windows-x86_64` so both the versioned binary and the `viam-agent-stable-windows-x86_64` copy created by the Makefile on release builds get signed.

## Test plan

The `build` job triggers on `dev-release`-labeled PRs (from internal branches), so signing will be exercised on this PR itself once it's a non-draft branch on `viamrobotics/agent`.

- [x] Apply the `dev-release` label, confirm the `Sign Windows binaries` step runs cleanly and the dev-release comment posts a URL for the signed binary.
- [x] Download the signed `viam-agent-*-windows-x86_64` and verify: `osslsigncode verify` on Linux, or Properties → Digital Signatures on Windows shows "Viam Agent".

[APP-16363]: https://viam.atlassian.net/browse/APP-16363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ