### PR TITLE
fix Build and Upload CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ etc/
 gha-creds-*.json
 viam-agent-windows-installer*.exe
 *.pem
+jsign.jar
 
 # Config file containing secrets used for serial console tests
 agent-test.toml


### PR DESCRIPTION
https://github.com/viamrobotics/agent/actions/runs/26464229631/job/77920716413

`Generate manifest` fails because `Sign Windows Binaries` dirties the working tree by adding `jsign.jar`

With this change: https://github.com/viamrobotics/agent/actions/runs/26464988792/job/77923331484