### PR TITLE
Fix Windows MSI builds

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -172,7 +172,7 @@ jobs:
     - name: Build MSI
       shell: bash
       run: |
-        mv msi/viam-agent-*-windows-x86_64 msi/viam-agent-from-installer.exe
+        mv msi/viam-agent-${{ needs.build.outputs.version }}-windows-x86_64 msi/viam-agent-from-installer.exe
         dotnet tool restore
         dotnet build msi -c Release
         mv msi/bin/x64/Release/en-US/Package.msi "viam-agent-${{ needs.build.outputs.version }}-windows-x86_64.msi"


### PR DESCRIPTION
```
Run mv msi/viam-agent-*-windows-x86_64 msi/viam-agent-from-installer.exe
  mv msi/viam-agent-*-windows-x86_64 msi/viam-agent-from-installer.exe
  dotnet tool restore
  dotnet build msi -c Release
  mv msi/bin/x64/Release/en-US/Package.msi "viam-agent-v0.28.0-windows-x86_64.msi"
  shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail ***0***
  
mv: target 'msi/viam-agent-from-installer.exe' is not a directory
```
this is because we copy the windows binary to a separate stable.exe, so there are now two binaries in the dir (v0.28.0 and stable). Since now mv matches both, the `mv` commands attempts to move both files into a directory (instead of the intended action with is to rename)


**Test plan**

PR (this PR)
- [x] `Build MSI` succeeds; artifact name is `viam-agent-v<next>-pr.<num>.<sha>-windows-x86_64.msi`.
- [x] MSI lands in `gs://packages.viam.com/apps/viam-agent/prerelease/pr-<num>/`.

Post-merge (main)
- [x] `Build MSI` runs with a `v<next>-dev.<N>` version and produces `viam-agent-v<next>-dev.<N>-windows-x86_64.msi`.
- [x] Uploads to `gs://packages.viam.com/apps/viam-agent/prerelease/`.

Release (the path that was broken)
- [ ] On a release tag, the artifact contains both `viam-agent-vX.Y.Z-windows-x86_64` and `viam-agent-stable-windows-x86_64`; `Build MSI` no longer fails on the `mv` step.
- [ ] `viam-agent-vX.Y.Z-windows-x86_64.msi` lands in `gs://packages.viam.com/apps/viam-agent/`.
- [ ] `viam-agent-stable-windows-x86_64.msi` exists in the same bucket and is byte-identical to the versioned MSI (it's a publish-time `cp`).
- [ ] Installing the MSI on Windows lays down `viam-agent.exe` and starts the service (sanity check that the embedded binary is the versioned one, not the stable copy).