### PR TITLE
Pick up file:// viam-server rebuilds in place without duplicate cache copies

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -197,6 +197,17 @@ func GetLastModified(ctx context.Context, rawURL string, logger logging.Logger) 
 // DownloadFile downloads or copies a file into the cache directory and returns a path to the file.
 // If this is an http/s URL, you must check the checksum of the result; the partial logic does not check etags.
 func DownloadFile(ctx context.Context, rawURL string, logger logging.Logger) (string, error) {
+	return downloadFile(ctx, rawURL, "", logger)
+}
+
+// DownloadFileToPath behaves like DownloadFile but atomically replaces an existing known cache path
+// instead of allocating a fresh ".duplicate-NNN" slot. Use it when re-pulling the same target version
+// (e.g. a changed file:// source) so the cache filename and the symlink that points at it stay stable.
+func DownloadFileToPath(ctx context.Context, rawURL, knownPath string, logger logging.Logger) (string, error) {
+	return downloadFile(ctx, rawURL, knownPath, logger)
+}
+
+func downloadFile(ctx context.Context, rawURL, knownPath string, logger logging.Logger) (string, error) {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
 		return "", err
@@ -209,22 +220,28 @@ func DownloadFile(ctx context.Context, rawURL string, logger logging.Logger) (st
 	logger.Infof("Starting download of %s", rawURL)
 	parsedPath := parsedURL.Path
 
-	// don't want to accidentally overwrite anything in the cache directory by accident
-	// old agent versions used a different cache format, so it's possible we could be re-downloading ourself
+	// When re-pulling a known cache path, publish onto it (stable filename) so we don't accumulate
+	// ".duplicate-NNN" copies — see publishToCache for the per-platform swap. Otherwise allocate a fresh,
+	// non-colliding slot: old agent versions used a different cache format, so a blind write could clobber a
+	// binary we're re-downloading over ourself.
 	var outPath string
-	for n := range 100 {
-		var suffix string
-		if n > 0 {
-			suffix = fmt.Sprintf(".duplicate-%03d", n)
-		}
-		outPath = filepath.Join(ViamDirs.Cache, path.Base(parsedPath)+suffix)
-		if runtime.GOOS == "windows" && !strings.HasSuffix(outPath, ".exe") {
-			outPath += ".exe"
-		}
+	if knownPath != "" {
+		outPath = knownPath
+	} else {
+		for n := range 100 {
+			var suffix string
+			if n > 0 {
+				suffix = fmt.Sprintf(".duplicate-%03d", n)
+			}
+			outPath = filepath.Join(ViamDirs.Cache, path.Base(parsedPath)+suffix)
+			if runtime.GOOS == "windows" && !strings.HasSuffix(outPath, ".exe") {
+				outPath += ".exe"
+			}
 
-		_, err = os.Stat(outPath)
-		if errors.Is(err, fs.ErrNotExist) {
-			break
+			_, err = os.Stat(outPath)
+			if errors.Is(err, fs.ErrNotExist) {
+				break
+			}
 		}
 	}
 
@@ -234,7 +251,19 @@ func DownloadFile(ctx context.Context, rawURL string, logger logging.Logger) (st
 	case "file":
 		g := getter.FileGetter{Copy: true}
 		g.SetClient(getterClient)
-		if err := g.GetFile(outPath, parsedURL); err != nil {
+		if knownPath != "" {
+			// Re-pull: copy to a sibling staging file, then publish onto the stable name (see publishToCache).
+			staging := outPath + ".new"
+			if err := os.Remove(staging); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				return "", errw.Wrapf(err, "clearing stale staging file %s", staging)
+			}
+			if err := g.GetFile(staging, parsedURL); err != nil {
+				return "", errw.Wrap(err, "copying file")
+			}
+			if err := publishToCache(staging, outPath); err != nil {
+				return "", err
+			}
+		} else if err := g.GetFile(outPath, parsedURL); err != nil {
 			return "", errw.Wrap(err, "copying file")
 		}
 	case "http", "https":
@@ -281,7 +310,7 @@ func DownloadFile(ctx context.Context, rawURL string, logger logging.Logger) (st
 		}
 
 		logger.Debugw("moving successful download to outPath", "partialDest", partialDest)
-		if err := os.Rename(partialDest, outPath); err != nil {
+		if err := publishToCache(partialDest, outPath); err != nil {
 			return "", errw.Wrap(err, "moving successful download to outPath")
 		}
 		if err := os.RemoveAll(filepath.Dir(partialDest)); err != nil {
@@ -301,6 +330,78 @@ func DownloadFile(ctx context.Context, rawURL string, logger logging.Logger) (st
 	}
 
 	return outPath, nil
+}
+
+// publishToCache atomically moves a fully-written staging file onto destPath, keeping the cache filename
+// (and therefore the symlink target) stable so re-pulls don't accumulate ".duplicate-NNN" copies.
+//
+// On POSIX, rename over destPath is atomic even while viam-server executes the old bytes — the running
+// process keeps the old inode and the manager restarts it afterward. On Windows a running .exe can't be
+// overwritten, but it CAN be renamed, so we move the existing binary aside to ".old" first, then publish.
+// The ".old" leftover is cleared on the next publish (once the restarted process releases it) and by cache
+// cleanup as a backstop. If the swap fails mid-way we restore ".old" so the symlink never dangles.
+func publishToCache(stagingPath, destPath string) error {
+	return publishToCacheForOS(stagingPath, destPath, runtime.GOOS)
+}
+
+func publishToCacheForOS(stagingPath, destPath, goos string) error {
+	if goos == "windows" {
+		if _, err := os.Stat(destPath); err == nil {
+			old := destPath + ".old"
+			if rmErr := os.Remove(old); rmErr != nil && !errors.Is(rmErr, fs.ErrNotExist) {
+				return errw.Wrapf(rmErr, "removing stale %s", old)
+			}
+			if err := os.Rename(destPath, old); err != nil {
+				return errw.Wrapf(err, "moving running binary %s aside", destPath)
+			}
+			if err := os.Rename(stagingPath, destPath); err != nil {
+				return errors.Join(errw.Wrapf(err, "publishing %s", destPath), os.Rename(old, destPath))
+			}
+			return SyncFS(destPath)
+		}
+	}
+	if err := os.Rename(stagingPath, destPath); err != nil {
+		return err
+	}
+	return SyncFS(destPath)
+}
+
+// LocalSourcePath returns the filesystem path that a file:// URL points at.
+func LocalSourcePath(fileURL string) (string, error) {
+	parsed, err := url.Parse(fileURL)
+	if err != nil {
+		return "", err
+	}
+	return parsed.Path, nil
+}
+
+// ValidateLocalBinarySource rejects a file:// custom-binary source that resolves inside the agent-managed
+// cache/tmp dirs (or is the managed symlink, which resolves into the cache). Such a source aliases the
+// agent's own derived state: every re-pull rewrites it, bumping its mtime and triggering another re-pull
+// forever. The source must live outside the managed tree (e.g. /opt/viam-custom or a home dir).
+func ValidateLocalBinarySource(srcPath string) error {
+	real, err := filepath.EvalSymlinks(srcPath)
+	if err != nil {
+		return errw.Wrapf(err, "resolving file:// source %q", srcPath)
+	}
+	for _, managed := range []string{ViamDirs.Cache, ViamDirs.Tmp} {
+		// resolve the managed dir too: the cache path itself may contain symlinks (e.g. macOS /var ->
+		// /private/var), which would otherwise defeat the containment check.
+		if resolved, rErr := filepath.EvalSymlinks(managed); rErr == nil {
+			managed = resolved
+		}
+		rel, err := filepath.Rel(managed, real)
+		if err != nil {
+			continue
+		}
+		if rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))) {
+			return errw.Errorf(
+				"file:// source %q resolves to %q inside agent-managed dir %q; "+
+					"place the binary outside %q (e.g. /opt/viam-custom or a home dir)",
+				srcPath, real, managed, ViamDirs.Viam)
+		}
+	}
+	return nil
 }
 
 // Return an http client which can use SOCKS proxy from environment as gRPC proxy dialer.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -159,13 +159,26 @@ func InitPaths() error {
 	return nil
 }
 
-// GetLastModified retrieves the 'Last-Modified' header from a url via a HEAD request.
-// If there is any issue (e.g. not present, retreiving, parsing), it will return a default time.Time{}.
+// GetLastModified retrieves a change signal for a URL. For http/s it reads the 'Last-Modified' header
+// via a HEAD request; for file:// it uses the source file's mtime, so an in-place rebuild is picked up
+// without renaming the binary or editing config. If there is any issue (header absent, request/parse
+// failure, or a missing/unreadable file:// source) it returns a default time.Time{}, which callers
+// treat as "no detectable change" and keep running the current binary.
 func GetLastModified(ctx context.Context, rawURL string, logger logging.Logger) time.Time {
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {
 		logger.Infof("%v", err)
 		return time.Time{}
+	}
+	if parsedURL.Scheme == "file" {
+		srcPath := fileURLToPath(parsedURL)
+		stat, err := os.Stat(srcPath)
+		if err != nil {
+			// e.g. an unmounted build dir; keep running the current copy rather than churning.
+			logger.Infow("file:// source unavailable; treating as unchanged", "path", srcPath, "err", err)
+			return time.Time{}
+		}
+		return stat.ModTime()
 	}
 	client := socksClient(parsedURL.String(), logger)
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, parsedURL.String(), nil)
@@ -249,22 +262,25 @@ func downloadFile(ctx context.Context, rawURL, knownPath string, logger logging.
 	getterClient := &getter.Client{Ctx: ctx}
 	switch parsedURL.Scheme {
 	case "file":
+		// Reject sources that alias the agent's own managed tree (cache/tmp/symlink) — see
+		// ValidateLocalBinarySource. This is the chokepoint every file:// copy passes through.
+		if err := ValidateLocalBinarySource(fileURLToPath(parsedURL)); err != nil {
+			return "", err
+		}
 		g := getter.FileGetter{Copy: true}
 		g.SetClient(getterClient)
-		if knownPath != "" {
-			// Re-pull: copy to a sibling staging file, then publish onto the stable name (see publishToCache).
-			staging := outPath + ".new"
-			if err := os.Remove(staging); err != nil && !errors.Is(err, fs.ErrNotExist) {
-				return "", errw.Wrapf(err, "clearing stale staging file %s", staging)
-			}
-			if err := g.GetFile(staging, parsedURL); err != nil {
-				return "", errw.Wrap(err, "copying file")
-			}
-			if err := publishToCache(staging, outPath); err != nil {
-				return "", err
-			}
-		} else if err := g.GetFile(outPath, parsedURL); err != nil {
+		// Always copy to a sibling staging file, then publish onto outPath (see publishToCache). This keeps
+		// the cache filename (and the symlink target) stable across re-pulls and makes the swap atomic +
+		// fsync'd whether or not outPath already existed.
+		staging := outPath + ".new"
+		if err := os.Remove(staging); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return "", errw.Wrapf(err, "clearing stale staging file %s", staging)
+		}
+		if err := g.GetFile(staging, parsedURL); err != nil {
 			return "", errw.Wrap(err, "copying file")
+		}
+		if err := publishToCache(staging, outPath); err != nil {
+			return "", err
 		}
 	case "http", "https":
 		// note: we shrink the hash to avoid system path length limits
@@ -372,7 +388,19 @@ func LocalSourcePath(fileURL string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return parsed.Path, nil
+	return fileURLToPath(parsed), nil
+}
+
+// fileURLToPath converts a parsed file:// URL into a local filesystem path. On Windows, url.Parse
+// yields paths like "/C:/dir/bin.exe" (leading slash, forward slashes); strip and convert those so
+// os.Stat and friends see a real path rather than the URL form.
+func fileURLToPath(parsed *url.URL) string {
+	p := parsed.Path
+	if runtime.GOOS == "windows" {
+		p = strings.TrimPrefix(p, "/")
+		p = filepath.FromSlash(p)
+	}
+	return p
 }
 
 // ValidateLocalBinarySource rejects a file:// custom-binary source that resolves inside the agent-managed

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -168,6 +168,25 @@ func TestGetLastModified(t *testing.T) {
 	wg.Wait()
 }
 
+func TestGetLastModifiedFileURL(t *testing.T) {
+	logger := logging.NewTestLogger(t)
+	ctx := t.Context()
+
+	// a present file:// source reports its mtime
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "viam-server-debug")
+	test.That(t, os.WriteFile(srcFile, []byte("v1"), 0o644), test.ShouldBeNil)
+	stat, err := os.Stat(srcFile)
+	test.That(t, err, test.ShouldBeNil)
+
+	lm := GetLastModified(ctx, "file://"+srcFile, logger)
+	test.That(t, lm.Equal(stat.ModTime()), test.ShouldBeTrue)
+
+	// a missing file:// source reports the zero time ("no detectable change") rather than erroring
+	lm = GetLastModified(ctx, "file://"+filepath.Join(srcDir, "does-not-exist"), logger)
+	test.That(t, lm.IsZero(), test.ShouldBeTrue)
+}
+
 func TestDownloadFile(t *testing.T) {
 	MockAndCreateViamDirs(t)
 	logger := logging.NewTestLogger(t)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -420,6 +420,98 @@ func TestDownloadFile(t *testing.T) {
 	})
 }
 
+func TestDownloadFileToPath(t *testing.T) {
+	MockAndCreateViamDirs(t)
+	logger := logging.NewTestLogger(t)
+
+	t.Run("replaces in place without creating a duplicate", func(t *testing.T) {
+		srcDir := t.TempDir()
+		srcFile := filepath.Join(srcDir, "viam-server-debug")
+		test.That(t, os.WriteFile(srcFile, []byte("v1"), 0o644), test.ShouldBeNil)
+		fileURL := "file://" + srcFile
+
+		// initial install allocates the clean slot
+		knownPath, err := DownloadFile(t.Context(), fileURL, logger)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, strings.HasSuffix(knownPath, ".duplicate-001"), test.ShouldBeFalse)
+
+		// rebuild the source, then re-pull to the known path
+		test.That(t, os.WriteFile(srcFile, []byte("v2"), 0o644), test.ShouldBeNil)
+		gotPath, err := DownloadFileToPath(t.Context(), fileURL, knownPath, logger)
+		test.That(t, err, test.ShouldBeNil)
+
+		// same path, updated bytes, and no .duplicate-NNN sibling was created
+		test.That(t, gotPath, test.ShouldEqual, knownPath)
+		content, err := os.ReadFile(knownPath)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, string(content), test.ShouldEqual, "v2")
+		_, err = os.Stat(knownPath + ".duplicate-001")
+		test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+	})
+}
+
+func TestPublishToCacheWindows(t *testing.T) {
+	MockAndCreateViamDirs(t)
+
+	dest := filepath.Join(ViamDirs.Cache, "viam-server-debug.exe")
+	test.That(t, os.WriteFile(dest, []byte("v1"), 0o644), test.ShouldBeNil)
+
+	publish := func(content string) {
+		staging := dest + ".new"
+		test.That(t, os.WriteFile(staging, []byte(content), 0o644), test.ShouldBeNil)
+		test.That(t, publishToCacheForOS(staging, dest, "windows"), test.ShouldBeNil)
+	}
+
+	// first swap: existing binary is moved aside to .old, stable name gets the new bytes
+	publish("v2")
+	content, err := os.ReadFile(dest)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, string(content), test.ShouldEqual, "v2")
+	old, err := os.ReadFile(dest + ".old")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, string(old), test.ShouldEqual, "v1")
+	// stable name, never a .duplicate-NNN sibling
+	_, err = os.Stat(dest + ".duplicate-001")
+	test.That(t, os.IsNotExist(err), test.ShouldBeTrue)
+
+	// second swap: the prior .old is cleared and replaced, so leftovers stay bounded to one
+	publish("v3")
+	content, err = os.ReadFile(dest)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, string(content), test.ShouldEqual, "v3")
+	old, err = os.ReadFile(dest + ".old")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, string(old), test.ShouldEqual, "v2")
+}
+
+func TestValidateLocalBinarySource(t *testing.T) {
+	MockAndCreateViamDirs(t)
+
+	t.Run("accepts a source outside the managed tree", func(t *testing.T) {
+		src := filepath.Join(t.TempDir(), "viam-server-debug")
+		test.That(t, os.WriteFile(src, []byte("bin"), 0o644), test.ShouldBeNil)
+		test.That(t, ValidateLocalBinarySource(src), test.ShouldBeNil)
+	})
+
+	t.Run("rejects a source inside the cache dir", func(t *testing.T) {
+		src := filepath.Join(ViamDirs.Cache, "viam-server-debug")
+		test.That(t, os.WriteFile(src, []byte("bin"), 0o644), test.ShouldBeNil)
+		err := ValidateLocalBinarySource(src)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "agent-managed dir")
+	})
+
+	t.Run("rejects a symlink that resolves into the cache dir", func(t *testing.T) {
+		target := filepath.Join(ViamDirs.Cache, "viam-server-real")
+		test.That(t, os.WriteFile(target, []byte("bin"), 0o644), test.ShouldBeNil)
+		link := filepath.Join(ViamDirs.Bin, "viam-server")
+		test.That(t, ForceSymlink(target, link), test.ShouldBeNil)
+		err := ValidateLocalBinarySource(link)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "agent-managed dir")
+	})
+}
+
 // If either of the tests on ViamDirsData become outdated be sure there is at
 // least some test remaining on the ViamDirsData.Values method. As long as it
 // uses reflection it could break at runtime if we accidentally add a

--- a/version_control.go
+++ b/version_control.go
@@ -245,7 +245,30 @@ func (c *VersionCache) UpdateBinary(ctx context.Context, binary string) (bool, e
 	prevLastModified := verData.LastModified
 	var lastModified time.Time
 	var lastModifiedChanged bool
-	if isCustomURL && !isFileURL && time.Since(verData.LastModifiedCheck) > lastModifiedCheckFrequency {
+	switch {
+	case isCustomURL && isFileURL:
+		// file:// has no HTTP Last-Modified header, so use the source file's mtime as the change signal.
+		// This lets an in-place rebuild (same URL) be picked up without renaming the binary or editing config.
+		srcPath, err := utils.LocalSourcePath(verData.URL)
+		if err != nil {
+			data.brokenTarget = true
+			return needRestart, errw.Wrap(err, "parsing file:// source")
+		}
+		if stat, statErr := os.Stat(srcPath); statErr != nil {
+			// source temporarily missing (e.g. an unmounted build dir); keep running the current copy.
+			c.logger.Warnw("file:// source unavailable; keeping current binary", "path", srcPath, "error", statErr)
+		} else {
+			if err := utils.ValidateLocalBinarySource(srcPath); err != nil {
+				data.brokenTarget = true
+				return needRestart, err
+			}
+			lastModified = stat.ModTime()
+			lastModifiedChanged = !verData.LastModified.IsZero() && lastModified.After(verData.LastModified)
+			if lastModified.After(verData.LastModified) {
+				verData.LastModified = lastModified
+			}
+		}
+	case isCustomURL && time.Since(verData.LastModifiedCheck) > lastModifiedCheckFrequency:
 		lastModified = utils.GetLastModified(ctx, verData.URL, c.logger)
 		// don't mark changed if we're just storing lastModified for the first time
 		lastModifiedChanged = !verData.LastModified.IsZero() && lastModified.After(verData.LastModified)
@@ -299,8 +322,14 @@ func (c *VersionCache) UpdateBinary(ctx context.Context, binary string) (bool, e
 				"expected", hex.EncodeToString(verData.UnpackedSHA), "actual", hex.EncodeToString(shasum),
 				"url", verData.URL)
 		}
-		// download and record the sha of the download itself
-		verData.DlPath, err = utils.DownloadFile(ctx, verData.URL, c.logger)
+		// download and record the sha of the download itself. When re-pulling the same target version
+		// (e.g. a changed file:// source), replace the existing cache file in place so we don't accumulate
+		// ".duplicate-NNN" copies and so the symlink keeps pointing at a stable filename.
+		if verData.UnpackedPath != "" {
+			verData.DlPath, err = utils.DownloadFileToPath(ctx, verData.URL, verData.UnpackedPath, c.logger)
+		} else {
+			verData.DlPath, err = utils.DownloadFile(ctx, verData.URL, c.logger)
+		}
 		if err != nil {
 			if isCustomURL {
 				data.brokenTarget = true

--- a/version_control.go
+++ b/version_control.go
@@ -245,38 +245,37 @@ func (c *VersionCache) UpdateBinary(ctx context.Context, binary string) (bool, e
 	prevLastModified := verData.LastModified
 	var lastModified time.Time
 	var lastModifiedChanged bool
-	switch {
-	case isCustomURL && isFileURL:
-		// file:// has no HTTP Last-Modified header, so use the source file's mtime as the change signal.
-		// This lets an in-place rebuild (same URL) be picked up without renaming the binary or editing config.
-		srcPath, err := utils.LocalSourcePath(verData.URL)
-		if err != nil {
-			data.brokenTarget = true
-			return needRestart, errw.Wrap(err, "parsing file:// source")
-		}
-		if stat, statErr := os.Stat(srcPath); statErr != nil {
-			// source temporarily missing (e.g. an unmounted build dir); keep running the current copy.
-			c.logger.Warnw("file:// source unavailable; keeping current binary", "path", srcPath, "error", statErr)
-		} else {
-			if err := utils.ValidateLocalBinarySource(srcPath); err != nil {
-				data.brokenTarget = true
-				return needRestart, err
-			}
-			lastModified = stat.ModTime()
-			lastModifiedChanged = !verData.LastModified.IsZero() && lastModified.After(verData.LastModified)
-			if lastModified.After(verData.LastModified) {
-				verData.LastModified = lastModified
-			}
-		}
-	case isCustomURL && time.Since(verData.LastModifiedCheck) > lastModifiedCheckFrequency:
+	// file:// has no HTTP Last-Modified header; GetLastModified returns the source file's mtime instead, so
+	// an in-place rebuild flows through the same change-detection path as a remote re-publish. A local stat
+	// is cheap, so there's no point throttling it — pick rebuilds up on the very next reconcile.
+	lastModifiedCheckFreq := lastModifiedCheckFrequency
+	if isFileURL {
+		lastModifiedCheckFreq = 0
+	}
+	if isCustomURL && time.Since(verData.LastModifiedCheck) > lastModifiedCheckFreq {
 		lastModified = utils.GetLastModified(ctx, verData.URL, c.logger)
 		// don't mark changed if we're just storing lastModified for the first time
 		lastModifiedChanged = !verData.LastModified.IsZero() && lastModified.After(verData.LastModified)
-		// don't allow LastModified to move backwards (mostly likely in case server is misconfigured)
-		if lastModified.After(verData.LastModified) {
+		// For http we advance the stored timestamp eagerly (a HEAD is costly to repeat). For file:// we defer
+		// the advance until the change is confirmed/applied below, so a failed re-pull is retried next cycle
+		// instead of being suppressed by an already-advanced timestamp.
+		if !isFileURL && lastModified.After(verData.LastModified) {
 			verData.LastModified = lastModified
 		}
 		verData.LastModifiedCheck = time.Now()
+	}
+
+	// mtime is a cheap but weak trigger: rebuilds that preserve mtime won't trip it, and tools like `cp -p`
+	// or restore-from-cache can bump mtime without changing bytes. So for file:// confirm the content
+	// actually differs (vs the SHA we recorded for the cached copy) before paying for a re-pull + restart.
+	if isFileURL && lastModifiedChanged {
+		if srcPath, err := utils.LocalSourcePath(verData.URL); err == nil {
+			if srcSum, sumErr := utils.GetFileSum(srcPath); sumErr == nil && bytes.Equal(srcSum, verData.UnpackedSHA) {
+				c.logger.Debugw("file:// mtime changed but content is identical; skipping re-pull", "path", srcPath)
+				lastModifiedChanged = false
+				verData.LastModified = lastModified // record the new mtime so we stop re-hashing until it bumps again
+			}
+		}
 	}
 
 	if data.TargetVersion == data.CurrentVersion {
@@ -386,6 +385,13 @@ func (c *VersionCache) UpdateBinary(ctx context.Context, binary string) (bool, e
 				verData.UnpackedPath,
 				base64.StdEncoding.EncodeToString(verData.UnpackedSHA),
 			)
+		}
+
+		// Now that the re-pull succeeded, record the source mtime we acted on. Deferring the advance to here
+		// (rather than in the change-detection block above) means a failed download leaves the stored mtime
+		// unchanged, so the next reconcile retries instead of treating the change as already handled.
+		if isFileURL && !lastModified.IsZero() {
+			verData.LastModified = lastModified
 		}
 	}
 

--- a/version_control_test.go
+++ b/version_control_test.go
@@ -81,6 +81,43 @@ func TestUpdateBinary(t *testing.T) {
 			testExists(t, filepath.Join(utils.ViamDirs.Cache, "source-binary-"+vi2.Version))
 		})
 
+		t.Run("custom-file-mtime-bump-same-content-no-restart", func(t *testing.T) {
+			// A customURL+file:// rebuild that bumps mtime but produces identical bytes (e.g. `cp -p`,
+			// restore-from-cache) must NOT trigger a re-pull + restart: the source-hash gate confirms the
+			// content actually changed before acting. A real content change still restarts.
+			td := t.TempDir()
+			src := filepath.Join(td, "source-binary-mtime")
+			elf := []byte{0x7f, 'E', 'L', 'F', 'v', '1'}
+			test.That(t, os.WriteFile(src, elf, 0o755), test.ShouldBeNil)
+
+			viM := vi
+			viM.URL = "file://" + src
+			viM.Version = "customURL+" + viM.URL
+			viM.UnpackedSHA = nil // let the install compute and record the source sha
+			vc.ViamServer.Versions[viM.Version] = &viM
+			vc.ViamServer.TargetVersion = viM.Version
+
+			// install
+			needsRestart, err := vc.UpdateBinary(t.Context(), viamserver.SubsysName)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, needsRestart, test.ShouldBeTrue)
+
+			// bump only the mtime, keep the bytes identical -> no restart
+			future := time.Now().Add(time.Hour)
+			test.That(t, os.Chtimes(src, future, future), test.ShouldBeNil)
+			needsRestart, err = vc.UpdateBinary(t.Context(), viamserver.SubsysName)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, needsRestart, test.ShouldBeFalse)
+
+			// now actually change the bytes -> restart
+			evenLater := future.Add(time.Hour)
+			test.That(t, os.WriteFile(src, []byte{0x7f, 'E', 'L', 'F', 'v', '2'}, 0o755), test.ShouldBeNil)
+			test.That(t, os.Chtimes(src, evenLater, evenLater), test.ShouldBeNil)
+			needsRestart, err = vc.UpdateBinary(t.Context(), viamserver.SubsysName)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, needsRestart, test.ShouldBeTrue)
+		})
+
 		t.Run("checksum-wrong-at-top-should-redownload", func(t *testing.T) {
 			// case where checksum is wrong at the top of UpdateBinary
 			// (I think we get here by having a binary not tracked in cache)


### PR DESCRIPTION
## What

Makes a `file://` custom `version_control.viam_server` URL behave as a real local-iteration loop: drop a rebuilt binary at the source path and the agent picks it up on the next reconcile, on a stable cache filename, with no `duplicate-NNN` churn.

## Why

The agent treats the configured URL as desired state and the cache + `bin/viam-server` symlink as derived state, reconciling each cycle. For `file://` URLs this had two rough edges:

- **No change detection** — `file://` skipped the Last-Modified poll entirely, so a rebuilt binary was only picked up by changing the URL string (and waiting for the target version to flip).
- **Duplicate churn** — a re-pull can't overwrite the in-use cache file, so it allocated `viam-server.duplicate-NNN` and re-pointed the symlink at it, often running a binary the user didn't intend.

## Changes

- **Detect file:// source changes via the source file's mtime**, reusing the existing Last-Modified re-pull path. In-place rebuilds are picked up next reconcile with no config edit. (No 2-minute throttle — it's a cheap `stat`.)
- **Replace on the stable cache filename** instead of minting `duplicate-NNN`:
  - POSIX: atomic `rename` over the running binary (live process keeps the old inode).
  - Windows: a running `.exe` can't be overwritten but can be renamed, so the existing binary is moved aside to `.old` and the new bytes take the stable name; the symlink target never changes. The `.old` is cleared on the next publish and by cache cleanup.
- **Guard file:// sources inside the agent-managed `cache`/`tmp` dirs** (or the managed symlink), which would otherwise alias derived state and re-pull forever.

## Tests

- In-place replace creates no duplicate sibling (`TestDownloadFileToPath`).
- Windows rename-aside swap keeps the stable name and bounds leftovers to one `.old` (`TestPublishToCacheWindows`, OS injected so it runs in CI).
- Source guard accepts external paths and rejects cache-dir / symlink-into-cache sources (`TestValidateLocalBinarySource`).

## Notes / open questions

- Draft for early feedback.
- Pickup latency is the reconcile interval (not instant); an fsnotify watcher could make it instant if wanted.
- The Windows path leaves a transient `.old` (POSIX leaves nothing); bounded to one and reaped by cleanup.
- `UpdateBinary` is already `//nolint:gocognit`; happy to extract the file:// detection block into a helper if reviewers prefer.