### PR TITLE
RSDK-14088 Use separate Sublogger for NetAppender without net logs

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -204,8 +204,12 @@ func (m *Manager) CreateNetAppender() (*logging.NetAppender, error) {
 		m.logger.Warn("m.netAppender already exists, replacing")
 	}
 	var err error
-	loggerWithoutNet := m.logger.Sublogger("NetAppender-loggerWithoutNet")
-	m.netAppender, err = logging.NewNetAppender(m.cloudConfig, nil, true, loggerWithoutNet)
+	m.netAppender, err = logging.NewNetAppender(
+		m.cloudConfig,
+		nil,
+		true,
+		m.logger.Sublogger("NetAppender"),
+	)
 	return m.netAppender, err
 }
 

--- a/manager.go
+++ b/manager.go
@@ -204,7 +204,8 @@ func (m *Manager) CreateNetAppender() (*logging.NetAppender, error) {
 		m.logger.Warn("m.netAppender already exists, replacing")
 	}
 	var err error
-	m.netAppender, err = logging.NewNetAppender(m.cloudConfig, nil, true, m.logger)
+	loggerWithoutNet := m.logger.Sublogger("NetAppender-loggerWithoutNet")
+	m.netAppender, err = logging.NewNetAppender(m.cloudConfig, nil, true, loggerWithoutNet)
 	return m.netAppender, err
 }
 


### PR DESCRIPTION
RSDK-14088

## What

Uses "`viam-agent.NetAppender`" as the logger name for internal logs (i.e. logger used for complaining about inability to reach app) from the agent's `NetAppender` instance.

## Why

If we use a Sublogger here we can mark that Sublogger as diagnostic in app, so that logs like the following are diagnostic and don't flood users' `Logs` pages when a machine is having connectivity issues:

```
6/8/2026, 7:00:38 PM info viam-agent   logging/net_appender.go:326   error logging to network: rpc error: code = DeadlineExceeded desc = context deadline exceeded
```

Ideally, the `NetAppender` should be smarter about when it's submitting logs to app, but utilizing diagnostic logs lets us hide the noisy logs from users for now. If a machine is indeed offline, these logs are _not_ the main indicator of that state.

## Testing

Verified that a log like:

```
6/8/2026, 7:00:38 PM info viam-agent   logging/net_appender.go:326   error logging to network: rpc error: code = DeadlineExceeded desc = context deadline exceeded
```

is now output as:

```
6/10/2026, 10:00:01 AM info viam-agent.NetAppender   logging/net_appender.go:326   error logging to network: rpc error: code = DeadlineExceeded desc = context deadline exceeded
```
