### PR TITLE
Do not let mise set GOROOT in CI

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -33,6 +33,12 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
+    # Mise and actions/setup-go break the build when mise pulls an old go
+    # toolchain from the cache and setup-go installs the latests stable.
+    # Manually unset GOROOT here so the latests version installed through
+    # setup-go works.
+    - name: Clear mise GOROOT
+      run: "echo 'GOROOT=' >> $GITHUB_ENV"
     - name: Lint
       run: |
         make lint

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -18,6 +18,8 @@ jobs:
   test:
     name: Lint, Test, Build
     runs-on: ubuntu-latest
+    env:
+      MISE_GO_SET_GOROOT: false
     # Skip rerun on unrelated label changes; still run when dev-release is
     # added so the build job has a fresh test pass before uploading artifacts.
     if: |
@@ -33,12 +35,6 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
-    # Mise and actions/setup-go break the build when mise pulls an old go
-    # toolchain from the cache and setup-go installs the latests stable.
-    # Manually unset GOROOT here so the latests version installed through
-    # setup-go works.
-    - name: Clear mise GOROOT
-      run: "echo 'GOROOT=' >> $GITHUB_ENV"
     - name: Lint
       run: |
         make lint


### PR DESCRIPTION
This fixes an issue where the go binary installed with `setup-go` would run but with a `GOROOT` pointing to the version installed by mise. This broke the build when they chose different versions. I would like to remove `setup-go` but the mise action's caching behavior currently doesn't allow for updating to the latest version of a tool that still satisfies the project's version constaints on a cache hit