### PR TITLE
RSDK-13270: Annotate remaining bare errors in UpdateBinary path

### DIFF
--- a/version_control.go
+++ b/version_control.go
@@ -152,11 +152,11 @@ func (c *VersionCache) save() error {
 
 	cacheData, err := json.Marshal(c)
 	if err != nil {
-		return err
+		return errw.Wrap(err, "marshaling version cache")
 	}
 
 	_, err = utils.WriteFileIfNew(cacheFilePath, cacheData)
-	return err
+	return errw.Wrap(err, "writing updated version cache")
 }
 
 // Update processes data for the two binaries: agent itself, and viam-server.
@@ -311,7 +311,7 @@ func (c *VersionCache) UpdateBinary(ctx context.Context, binary string) (bool, e
 		// chmod with execute permissions if the file is executable
 		//nolint:gosec
 		if err := os.Chmod(verData.DlPath, 0o755); err != nil {
-			return needRestart, err
+			return needRestart, errw.Wrapf(err, "chmodding %s to 0o755", verData.DlPath)
 		}
 
 		actualSha, err := utils.GetFileSum(verData.DlPath)
@@ -373,7 +373,7 @@ func (c *VersionCache) UpdateBinary(ctx context.Context, binary string) (bool, e
 	// ensure the version we are switching to is indeed executable
 	//nolint:gosec
 	if err := os.Chmod(verData.UnpackedPath, 0o755); err != nil {
-		return needRestart, err
+		return needRestart, errw.Wrapf(err, "chmodding %s to 0o755", verData.UnpackedPath)
 	}
 
 	// symlink the extracted file to bin


### PR DESCRIPTION
Trying to get more info about a log line we saw on **Windows**: `warn    viam-agent  github.com/viamrobotics/agent/manager.go:228    The process cannot access the file because it is being used by another process.` in the `UpdateBinary` path:
https://github.com/viamrobotics/agent/blob/a119a3c681ecfc416c5d713b8d18fad479639076/manager.go#L226-L228

Almost all `return err` in are already annotated with `errw.Wrap(err, "more info")` with extra info including the paths that failed.

This PR annotates the remaining bare `return err` with more context.

As you can see, the error probably came from one of the `os.Chmod` calls, which has no effect on Windows (all `WriteFileIfNew` error exit paths are already annotated with the path).