### PR TITLE
RSDK-14125 Deduplicate agent logs

### DIFF
--- a/cmd/viam-agent/main.go
+++ b/cmd/viam-agent/main.go
@@ -210,7 +210,7 @@ func commonMain() {
 	cfg = utils.ApplyCLIArgs(cfg)
 
 	// main manager structure
-	manager := agent.NewManager(ctx, globalLogger, cfg, globalCancel)
+	manager := agent.NewManager(ctx, globalLogger, registry, cfg, globalCancel)
 
 	err = manager.LoadAppConfig()
 	//nolint:nestif

--- a/manager.go
+++ b/manager.go
@@ -65,6 +65,7 @@ type Manager struct {
 	cloudConfig *logging.CloudConfig
 
 	logger      logging.Logger
+	registry    *logging.Registry
 	netAppender *logging.NetAppender
 
 	cfgMu sync.RWMutex
@@ -87,9 +88,16 @@ type Manager struct {
 }
 
 // NewManager returns a new Manager.
-func NewManager(ctx context.Context, logger logging.Logger, cfg utils.AgentConfig, globalCancel context.CancelFunc) *Manager {
+func NewManager(
+	ctx context.Context,
+	logger logging.Logger,
+	registry *logging.Registry,
+	cfg utils.AgentConfig,
+	globalCancel context.CancelFunc,
+) *Manager {
 	manager := &Manager{
 		logger:       logger,
+		registry:     registry,
 		cfg:          cfg,
 		globalCancel: globalCancel,
 
@@ -135,6 +143,7 @@ func NewManager(ctx context.Context, logger logging.Logger, cfg utils.AgentConfi
 	}
 
 	manager.setDebug(cfg.AdvancedSettings.Debug.Get())
+	manager.applyLogDeduplication(cfg)
 	manager.sysConfig = syscfg.New(
 		ctx,
 		logger,
@@ -395,6 +404,29 @@ func (m *Manager) setDebug(debug bool) {
 		m.logger.SetLevel(logging.DEBUG)
 	} else {
 		m.logger.SetLevel(logging.INFO)
+	}
+}
+
+// applyLogDeduplication enables or disables noisy-log deduplication on the logger
+// registry based on the agent config, mirroring how the rdk does it. Deduplication is
+// enabled by default and only disabled when disable_log_deduplication is set.
+//
+// Note that the config value is a "disable" while the registry value is an "enable".
+// This is by design to make configuration easier for users and predicates easier for
+// developers respectively. Due to this, the conditional below to check for a diff looks
+// odd (== instead of !=).
+func (m *Manager) applyLogDeduplication(cfg utils.AgentConfig) {
+	if m.registry == nil {
+		return
+	}
+	disable := cfg.AdvancedSettings.GetDisableLogDeduplication()
+	if disable == m.registry.DeduplicateLogs.Load() {
+		state := "enabled"
+		if disable {
+			state = "disabled"
+		}
+		m.registry.DeduplicateLogs.Store(!disable)
+		m.logger.Infof("Noisy log deduplication is now %s", state)
 	}
 }
 
@@ -803,6 +835,7 @@ func (m *Manager) GetConfig(ctx context.Context) (time.Duration, error) {
 
 	cfg := utils.ApplyCLIArgs(cfgFromCloud)
 	m.setDebug(cfg.AdvancedSettings.Debug.Get())
+	m.applyLogDeduplication(cfg)
 
 	m.cfgMu.Lock()
 	defer m.cfgMu.Unlock()

--- a/manager.go
+++ b/manager.go
@@ -414,18 +414,19 @@ func (m *Manager) setDebug(debug bool) {
 // Note that the config value is a "disable" while the registry value is an "enable".
 // This is by design to make configuration easier for users and predicates easier for
 // developers respectively. Due to this, the conditional below to check for a diff looks
-// odd (== instead of !=).
+// odd.
 func (m *Manager) applyLogDeduplication(cfg utils.AgentConfig) {
 	if m.registry == nil {
 		return
 	}
-	disable := cfg.AdvancedSettings.GetDisableLogDeduplication()
-	if disable == m.registry.DeduplicateLogs.Load() {
+	shouldDisable := cfg.AdvancedSettings.GetDisableLogDeduplication() // unset tribool returns false here
+	isDisabled := !m.registry.DeduplicateLogs.Load()
+	if shouldDisable != isDisabled {
 		state := "enabled"
-		if disable {
+		if shouldDisable {
 			state = "disabled"
 		}
-		m.registry.DeduplicateLogs.Store(!disable)
+		m.registry.DeduplicateLogs.Store(!shouldDisable)
 		m.logger.Infof("Noisy log deduplication is now %s", state)
 	}
 }

--- a/manager_test.go
+++ b/manager_test.go
@@ -62,6 +62,45 @@ func (f *fakeViamServer) DoesNotHandleNeedsRestart() bool { return true }
 func (f *fakeViamServer) MarkAppTriggeredRestart()        {}
 func (f *fakeViamServer) Uptime() *durationpb.Duration    { return nil }
 
+func TestApplyLogDeduplication(t *testing.T) {
+	newManager := func(t *testing.T) (*Manager, *logging.Registry) {
+		t.Helper()
+		logger, registry := logging.NewLoggerWithRegistry("test")
+		logger.AddAppender(logging.NewTestAppender(t))
+		return &Manager{logger: logger, registry: registry}, registry
+	}
+
+	t.Run("enabled by default", func(t *testing.T) {
+		m, registry := newManager(t)
+		// Registry starts with deduplication disabled.
+		test.That(t, registry.DeduplicateLogs.Load(), test.ShouldBeFalse)
+
+		// Default config does not disable deduplication, so it should be enabled.
+		m.applyLogDeduplication(utils.DefaultConfig())
+		test.That(t, registry.DeduplicateLogs.Load(), test.ShouldBeTrue)
+	})
+
+	t.Run("disabled when configured", func(t *testing.T) {
+		m, registry := newManager(t)
+
+		cfg := utils.DefaultConfig()
+		cfg.AdvancedSettings.DisableLogDeduplication = 1
+		m.applyLogDeduplication(cfg)
+		test.That(t, registry.DeduplicateLogs.Load(), test.ShouldBeFalse)
+
+		// Re-enabling via a subsequent config update flips it back on.
+		cfg.AdvancedSettings.DisableLogDeduplication = -1
+		m.applyLogDeduplication(cfg)
+		test.That(t, registry.DeduplicateLogs.Load(), test.ShouldBeTrue)
+	})
+
+	t.Run("nil registry is a no-op", func(t *testing.T) {
+		m := &Manager{logger: logging.NewTestLogger(t)}
+		// Should not panic.
+		m.applyLogDeduplication(utils.DefaultConfig())
+	})
+}
+
 func TestLoadAppConfig(t *testing.T) {
 	// Helper to create a minimal manager for testing
 	createTestManager := func(t *testing.T) *Manager {

--- a/utils/config.go
+++ b/utils/config.go
@@ -41,6 +41,7 @@ var (
 			DisableViamServer:             Tribool(0),
 			DisableNetworkConfiguration:   Tribool(0),
 			DisableSystemConfiguration:    Tribool(0),
+			DisableLogDeduplication:       Tribool(0),
 			ViamServerStartTimeoutMinutes: Timeout(time.Minute * 10),
 			ViamServerExtraEnvVars:        nil,
 		},
@@ -147,6 +148,7 @@ type AdvancedSettings struct {
 	DisableViamServer             Tribool           `json:"disable_viam_server,omitempty"`
 	DisableNetworkConfiguration   Tribool           `json:"disable_network_configuration,omitempty"`
 	DisableSystemConfiguration    Tribool           `json:"disable_system_configuration,omitempty"`
+	DisableLogDeduplication       Tribool           `json:"disable_log_deduplication,omitempty"`
 	ViamServerStartTimeoutMinutes Timeout           `json:"viam_server_start_timeout_minutes,omitempty"`
 	ViamServerExtraEnvVars        map[string]string `json:"viam_server_env,omitempty"`
 }
@@ -178,6 +180,11 @@ func (as AdvancedSettings) GetDisableSystemConfiguration() bool {
 // GetDisableViamServer is a wrapper which checks agent's advanced settings DisableViamServer field.
 func (as AdvancedSettings) GetDisableViamServer() bool {
 	return as.DisableViamServer.Get()
+}
+
+// GetDisableLogDeduplication is a wrapper which checks agent's advanced settings DisableLogDeduplication field.
+func (as AdvancedSettings) GetDisableLogDeduplication() bool {
+	return as.DisableLogDeduplication.Get()
 }
 
 type SystemConfiguration struct {

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -87,3 +87,21 @@ func TestConvertJson(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, *newConfig, test.ShouldResemble, testConfig)
 }
+
+func TestDisableLogDeduplication(t *testing.T) {
+	// Default (unset) means deduplication is not disabled.
+	cfg := DefaultConfig()
+	test.That(t, cfg.AdvancedSettings.GetDisableLogDeduplication(), test.ShouldBeFalse)
+
+	// Explicitly set to true disables deduplication.
+	enabled := &AgentConfig{}
+	err := json.Unmarshal([]byte(`{"advanced_settings": {"disable_log_deduplication": true}}`), enabled)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, enabled.AdvancedSettings.GetDisableLogDeduplication(), test.ShouldBeTrue)
+
+	// Explicitly set to false leaves deduplication enabled.
+	disabled := &AgentConfig{}
+	err = json.Unmarshal([]byte(`{"advanced_settings": {"disable_log_deduplication": false}}`), disabled)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, disabled.AdvancedSettings.GetDisableLogDeduplication(), test.ShouldBeFalse)
+}


### PR DESCRIPTION
RSDK-14125

## What

Activates noisy-log deduplication in viam-agent and adds support for an agent-specific `disable_log_deduplication` advanced setting, mirroring how the `rdk` does it.

  - Adds a `DisableLogDeduplication` field (disable_log_deduplication JSON key) to AdvancedSettings, along with a `GetDisableLogDeduplication()` wrapper.
  - Threads the logger registry into `Manager` via `NewManager` and adds `applyLogDeduplication`, which flips the registry's `DeduplicateLogs` value based on the config.
  - Applies the setting both at startup (in `NewManager`) and on every cloud config reload (in `GetConfig`), next to the existing `setDebug` call.

## Why

 Log deduplication was never activated for the agent, so noisy logs were emitted without any deduplication. This enables it.

## Testing

  - Added `TestDisableLogDeduplication` in utils/config_test.go: verifies the default is not-disabled, and that true/false parse correctly through the `GetDisableLogDeduplication()` wrapper.
  - Added `TestApplyLogDeduplication` in `manager_test.go`: verifies deduplication is enabled by default, disabled when configured (and re-enabled on a subsequent config update), and that a nil registry is a no-op.

  [Description generated by Claude 🤖]
