### PR TITLE
RSDK-14173 Add an agent "exit probe" to measure how often we would enter detached mode

### DIFF
--- a/agent-exit-probe.sh
+++ b/agent-exit-probe.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# agent-exit-probe.sh is invoked by viam-agent.service as an ExecStopPost= command.
+# It is OBSERVABILITY ONLY: it never starts, stops, or restarts anything and never
+# affects the viam-agent service. Its sole job is to log, on every exit of the
+# service, whether viam-agent would have been thrown into "detached mode" (running
+# viam-server alone) under the proposed bad-binary safeguard -- WITHOUT actually
+# doing so. That lets us measure, in the wild, how often a "would-detach" exit
+# really happens and why, before we trust it to launch viam-server-detached.
+#
+# systemd runs ExecStopPost= after the service stops, INCLUDING when the service
+# exited unexpectedly or never managed to start (e.g. an unrunnable "bad" binary --
+# the case from the Feb file-permissions postmortem that motivates this work). It
+# passes the same exit information systemd itself uses to decide success vs failure:
+#
+#   $SERVICE_RESULT  the overall verdict, e.g. success, exit-code, signal, timeout,
+#                    core-dump, watchdog, oom-kill, start-limit-hit, resources
+#   $EXIT_CODE       how the main process ended: exited | killed | dumped
+#   $EXIT_STATUS     numeric exit code (when exited) or signal name (when killed/dumped)
+#
+# We classify the verdict primarily from $SERVICE_RESULT, which is systemd's own
+# overall judgement of the exit. This is what lets us distinguish a clean stop from
+# an OOM kill or a timeout: all three end the process with SIGKILL/SIGTERM, so the
+# raw signal alone ($EXIT_STATUS) is ambiguous, but $SERVICE_RESULT is not (oom-kill
+# and timeout are their own results). $SERVICE_RESULT is well defined here because
+# this unit does not set SuccessExitStatus=; it follows systemd's documented
+# defaults, under which exit 0 and the signals SIGHUP/SIGINT/SIGTERM/SIGPIPE are
+# already "success". We still log $EXIT_CODE/$EXIT_STATUS raw for context.
+#
+# "Clean" (would NOT detach) mirrors the proposed detached-mode design's definition:
+#   - $SERVICE_RESULT=success: a clean exit (status 0, e.g. a self-update) or a
+#     stop signal (systemctl stop, or the process exiting on SIGTERM/INT/HUP/PIPE)
+#   - $SERVICE_RESULT=signal with $EXIT_STATUS=KILL: a stray `kill -9`, which the
+#     design whitelists so it does not look "bad"
+# Everything else is a "would-detach" exit, covering all five cases the design would
+# act on: non-zero exit ($SERVICE_RESULT=exit-code, the Feb postmortem), crash
+# signals like SIGSEGV/SIGABRT (signal), timeout, watchdog, and OOM kill (oom-kill).
+#
+# The "viam-agent exit probe:" marker below is what the app side keys a metric off
+# of (counting verdict=would-detach, labeled by part ID). Keep this script trivial
+# and fast: it runs as root inside the service stop timeout, and the leading "-" on
+# the ExecStopPost= line means a failure here can never affect the service.
+
+set -u
+
+case "${SERVICE_RESULT:-}" in
+success)
+	verdict=clean
+	;;
+signal)
+	# A bare `kill -9` reports result=signal/status=KILL here (this unit does not
+	# whitelist SIGKILL via SuccessExitStatus=). The design treats that as not-bad;
+	# every other signal (SIGSEGV, SIGABRT, ...) is a crash and would detach.
+	case "${EXIT_STATUS:-}" in
+	KILL) verdict=clean ;;
+	*) verdict=would-detach ;;
+	esac
+	;;
+*)
+	# exit-code, timeout, watchdog, oom-kill, core-dump, start-limit-hit, protocol,
+	# resources, or an empty/unrecognized result -- all treated as would-detach.
+	verdict=would-detach
+	;;
+esac
+
+# Single-line, greppable. stdout from ExecStopPost= is captured by the journal under
+# the viam-agent.service unit.
+echo "viam-agent exit probe: verdict=${verdict} service_result=${SERVICE_RESULT:-} exit_code=${EXIT_CODE:-} exit_status=${EXIT_STATUS:-}"

--- a/agent.go
+++ b/agent.go
@@ -100,6 +100,16 @@ func Install(ctx context.Context, logger logging.Logger, sManager systemManager)
 		}
 	}
 
+	// On platforms whose service uses it (currently Linux only), install the
+	// ExecStopPost= exit probe script. It is invoked via "/bin/sh <path>", so it does
+	// not need an executable bit. Path must match the one in viam-agent.service.
+	if len(exitProbeScriptContents) > 0 {
+		scriptPath := filepath.Join(utils.ViamDirs.Etc, exitProbeScriptName)
+		if _, err := utils.WriteFileIfNew(scriptPath, exitProbeScriptContents); err != nil {
+			return errw.Wrap(err, "installing agent exit probe script")
+		}
+	}
+
 	_, err = os.Stat("/etc/viam.json")
 	if err != nil {
 		if errw.Is(err, fs.ErrNotExist) {

--- a/agent_darwin.go
+++ b/agent_darwin.go
@@ -16,10 +16,17 @@ import (
 
 const (
 	serviceName = "com.viam.agent"
+
+	// exitProbeScriptName is unused on MacOS; the exit probe is a Linux/systemd
+	// ExecStopPost= helper.
+	exitProbeScriptName = ""
 )
 
 //go:embed com.viam.agent.plist
 var serviceFileContents []byte
+
+// exitProbeScriptContents is nil on MacOS; the exit probe is Linux/systemd only.
+var exitProbeScriptContents []byte
 
 // InstallNewVersion runs the newly downloaded binary's Install() for installation of launchd service files and the like.
 func InstallNewVersion(ctx context.Context, logger logging.Logger) (bool, error) {

--- a/agent_linux.go
+++ b/agent_linux.go
@@ -14,10 +14,19 @@ import (
 
 const (
 	serviceName = "viam-agent"
+
+	// exitProbeScriptName is the ExecStopPost= helper for viam-agent.service. It is
+	// observability only -- it logs whether each exit would have triggered detached
+	// mode under the proposed bad-binary safeguard. The path must match the one
+	// referenced in viam-agent.service.
+	exitProbeScriptName = "agent-exit-probe.sh"
 )
 
 //go:embed viam-agent.service
 var serviceFileContents []byte
+
+//go:embed agent-exit-probe.sh
+var exitProbeScriptContents []byte
 
 // InstallNewVersion runs the newly downloaded binary's Install() for installation of systemd files and the like.
 func InstallNewVersion(ctx context.Context, logger logging.Logger) (bool, error) {

--- a/agent_windows.go
+++ b/agent_windows.go
@@ -11,6 +11,10 @@ import (
 
 const (
 	serviceName = "viam-agent"
+
+	// exitProbeScriptName is unused on Windows; the exit probe is a Linux/systemd
+	// ExecStopPost= helper.
+	exitProbeScriptName = ""
 )
 
 // AgentETW is the Event Tracing for Windows (ETW) identity for viam-agent.
@@ -23,6 +27,9 @@ var AgentETW = logging.ETWProvider{
 }
 
 var serviceFileContents []byte
+
+// exitProbeScriptContents is nil on Windows; the exit probe is Linux/systemd only.
+var exitProbeScriptContents []byte
 
 // InstallNewVersion is a no-op on Windows as there is no system service update mechanism.
 func InstallNewVersion(_ context.Context, _ logging.Logger) (bool, error) {

--- a/subsystems/syscfg/log_forwarding_linux.go
+++ b/subsystems/syscfg/log_forwarding_linux.go
@@ -118,12 +118,18 @@ func (s *Subsystem) forwardRecentSystemdAgentLogs(ctx context.Context) error {
 
 	sinceArg := cache.SystemdAgentLogsLastForwarded.Format("2006-01-02 15:04:05" /* systemd time format */)
 	// `journalctl -u viam-agent -t systemd -S [sinceArg] -o json` gets logs from the
-	// viam-agent systemd service (-u viam-agent), from systemd itself (-t systemd), as JSON
-	// (-o JSON), and from only the last time systemd agent logs were forwarded (-S
-	// [sinceArg]).
+	// viam-agent systemd service (-u viam-agent), from systemd itself and any shell scripts
+	// like the exit probe (-t systemd -t sh), as JSON (-o JSON), and from only the last
+	// time systemd agent logs were forwarded (-S [sinceArg]).
 	//nolint:gosec
-	out, err := exec.CommandContext(ctx, "journalctl", "-u", "viam-agent", "-t", "systemd", "-o", "json", "-S", sinceArg).
-		CombinedOutput()
+	out, err := exec.CommandContext(
+		ctx,
+		"journalctl",
+		"-u", "viam-agent",
+		"-t", "systemd", "-t", "sh",
+		"-o", "json",
+		"-S", sinceArg,
+	).CombinedOutput()
 	if err != nil {
 		return errw.Wrap(err, "running journalctl to forward recent systemd agent logs")
 	}

--- a/viam-agent.service
+++ b/viam-agent.service
@@ -11,6 +11,11 @@ RestartSec=5
 User=root
 TimeoutSec=240
 ExecStart=/opt/viam/bin/viam-agent --config /etc/viam.json --enable-syscfg --enable-networking
+# Observability only (does not affect the service): logs, on every exit, whether
+# this exit would have triggered "detached mode" under the proposed bad-binary
+# safeguard, plus the systemd exit reason. Leading "-" so a probe failure can never
+# affect viam-agent. See agent-exit-probe.sh.
+ExecStopPost=-/bin/sh /opt/viam/etc/agent-exit-probe.sh
 KillMode=mixed
 FinalKillSignal=SIGKILL
 


### PR DESCRIPTION
A concept proposed in an ongoing discussion in the Safeguard Against Bad Agent Binaries [scope](https://docs.google.com/document/d/1sZ1QBMDrtURnp3eiIKyFJa_UrCeycPCdsjcUW0ANutA/edit?tab=t.0).

## What

Adds an `ExecStopPost=` "exit probe" to `viam-agent.service` that logs, on every exit of the service, whether that exit would have triggered "detached mode" under the proposed bad-binary safeguard without actually launching `viam-server-detached`.

Defines `agent-exit-probe.sh`: a shell script invoked via `ExecStopPost=-/bin/sh /opt/viam/etc/agent-exit-probe.sh`. It reads the `$SERVICE_RESULT`, `$EXIT_CODE`, and `$EXIT_STATUS` variables systemd passes to stop handlers, classifies the exit as clean or would-detach, and emits a single greppable log line:

```
6/22/2026, 3:33:29 PM info viam-agent.systemd     viam-agent exit probe: verdict=clean service_result=success exit_code=exited exit_status=0
```

or

```
6/22/2026, 3:56:39 PM info viam-agent.systemd     viam-agent exit probe: verdict=would-detach service_result=exit-code exit_code=exited exit_status=2
```

Wires installation of the script into `Install` in `agent.go`, embedding it via `//go:embed` in `agent_linux.go` and adding nil/empty placeholders in `agent_darwin.go` and `agent_windows.go` (the probe is Linux/systemd only).

Updates `forwardRecentSystemdAgentLogs` in `subsystems/syscfg/log_forwarding_linux.go` to also forward logs with the `sh` syslog identifier (`-t systemd -t sh`), so the probe's output reaches the cloud.

## Why

The team is wary of "false positives" in the detached-mode safeguard: entering `viam-server-detached` when the `viam-agent` binary was actually fine. Before trusting an `OnFailure= trigger` to launch detached mode, we want to measure, in the wild, how often viam-agent actually exits in a way that would be treated as a "failure" and why.

[`ExecStopPost=`](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html?__goaway_challenge=meta-refresh&__goaway_id=49724e5dd4e1b94c62d05643db7ab085&__goaway_referer=https%3A%2F%2Fduckduckgo.com%2F#ExecStopPost=) is a better fit than [`OnFailure=`](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#OnFailure=) for this measurement phase: it runs on every stop regardless of restart policy, so the unit can stay otherwise identical to today's production behavior while still capturing exactly the exit information systemd itself uses to judge success vs. failure. 

On the app side, a metric will count the would-detach marker (labeled by part ID), so we can learn whether would-detach exits are rare (genuinely "bad binary") or common (too noisy to trust as a detach trigger).

## Testing

  - Cross-compiled the agent for linux, darwin, and windows (go build ./...); confirmed gofmt clean and no new go vet findings
  - Exercised `agent-exit-probe.sh` directly with a simulated systemd environment variables across eight scenarios: clean exit 0, systemctl stop (SIGTERM), kill -9 (SIGKILL), non-zero exit, SIGSEGV crash, OOM kill, timeout, and empty/unset env and confirmed the verdicts match the scope's definition (the five would-detach cases vs. clean stops)
  - Manually tested on raspberry pi that exit log basically behaves as expected and causes no issues if it fails (`exit 1` and nonexistent script file do not affect the `viam-agent` service due to the leading `-` in the `ExecStopPost` line)

[Description generated by Claude 🤖]