### PR TITLE
RSDK-13183 Add a `networking` sublogger for diagnostic logs

### DIFF
--- a/subsystems/networking/networking_linux.go
+++ b/subsystems/networking/networking_linux.go
@@ -76,6 +76,10 @@ type Subsystem struct {
 }
 
 func New(ctx context.Context, logger logging.Logger, cfg utils.AgentConfig) *Subsystem {
+	// Route all networking logs through a "networking" sublogger (e.g. "viam-agent.networking")
+	// so that app can treat them as diagnostic rather than user-facing. See diagnosticLoggerNames
+	// in the app repo.
+	logger = logger.Sublogger("networking")
 	subsys := &Subsystem{
 		cfg:    cfg.NetworkConfiguration,
 		nets:   cfg.AdditionalNetworks,


### PR DESCRIPTION
RSDK-13183

## What

Routes all logs from the networking subsystem through a dedicated "networking" sublogger. As a result, every log emitted within the subsystems/networking package now carries the logger name `viam-agent.networking` (and nested names like `viam-agent.networking.network_status`).

## Why

The networking subsystem emits a lot of operational/diagnostic chatter (`NetworkManager` state, connectivity checks, provisioning loop status, etc.) that is not meaningful to most end users in app's "Logs" tab. Those logs can be diagnostic (marked in an app PR here).

[Description generated by Claude 🤖]