### PR TITLE
RSDK-14219 Reduce log verbosity for hotspot provisioning failures

### DIFF
--- a/subsystems/networking/bluetooth_linux.go
+++ b/subsystems/networking/bluetooth_linux.go
@@ -169,7 +169,7 @@ func (n *Subsystem) initializeBluetoothService(
 	ctx context.Context, deviceName string, characteristics []bluetooth.CharacteristicConfig,
 ) error {
 	if err := rfkillUnblock(ctx); err != nil {
-		n.logger.Warnw("Failed to unblock bluetooth with rfkill; bluetooth initialization will continue but may fail", "err", err)
+		n.logger.Warnw("Failed to unblock bluetooth with rfkill; bluetooth initialization will continue but may fail", "err", err.Error())
 	}
 
 	serviceUUID := bluetooth.NewUUID(uuid.NewSHA1(uuid.MustParse(uuidNamespace), []byte(serviceNameKey)))

--- a/subsystems/networking/networking_linux.go
+++ b/subsystems/networking/networking_linux.go
@@ -426,7 +426,7 @@ func (n *Subsystem) processAdditionalnetworks(ctx context.Context) {
 	for _, network := range n.Nets() {
 		_, err := n.addOrUpdateConnection(network)
 		if err != nil {
-			n.logger.Warnw("error adding network", "err", err, "ssid", network.SSID)
+			n.logger.Warnw("error adding network", "err", err.Error(), "ssid", network.SSID)
 			continue
 		}
 		if network.Interface != "" {

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -298,7 +298,7 @@ func (n *Subsystem) startProvisioning(ctx context.Context) error {
 	n.portalData.resetInputData()
 	hotspotErr := n.startProvisioningHotspot(ctx)
 	if hotspotErr != nil {
-		n.logger.Errorw("failed to start hotspot provisioning", "err", hotspotErr)
+		n.logger.Errorw("failed to start hotspot provisioning", "err", hotspotErr.Error())
 	}
 
 	n.connState.setProvisioning(hotspotErr == nil)
@@ -1029,7 +1029,7 @@ func (n *Subsystem) mainLoop(ctx context.Context) {
 				)
 				n.netState.mu.RUnlock()
 				if err := n.stopProvisioning(); err != nil {
-					n.logger.Warnw("failed to stop provisioning", "err", err)
+					n.logger.Warnw("failed to stop provisioning", "err", err.Error())
 				} else {
 					pMode = n.connState.getProvisioning()
 					pModeChange = n.connState.getProvisioningChange()
@@ -1098,7 +1098,7 @@ func (n *Subsystem) mainLoop(ctx context.Context) {
 			)
 			n.netState.mu.RUnlock()
 			if err := n.startProvisioning(ctx); err != nil {
-				n.logger.Warnw("failed to start provisioning mode", "err", err)
+				n.logger.Warnw("failed to start provisioning mode", "err", err.Error())
 			}
 		}
 	}
@@ -1113,7 +1113,7 @@ func (n *Subsystem) doReboot(ctx context.Context) bool {
 	cmd := exec.CommandContext(ctx, "systemctl", "reboot")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		n.logger.Warnw("Error running systemctl reboot", "output", output, "err", err)
+		n.logger.Warnw("Error running systemctl reboot", "output", output, "err", err.Error())
 	}
 	const rebootWaitDuration = time.Minute * 5
 	if !n.mainLoopHealth.Sleep(ctx, rebootWaitDuration) {

--- a/subsystems/networking/portal_linux.go
+++ b/subsystems/networking/portal_linux.go
@@ -68,7 +68,7 @@ func (n *Subsystem) startWeb(bindAddr string, bindPort int) error {
 			n.logger.Warnw("stopping provisioning, panic in web goroutine",
 				"panic", panickedWith)
 			if err := n.stopProvisioning(); err != nil {
-				n.logger.Warnw("failed to stop provisioning", "err", err)
+				n.logger.Warnw("failed to stop provisioning", "err", err.Error())
 			}
 		})
 		defer n.portalData.workers.Done()


### PR DESCRIPTION
## Problem

The viam-agent logs full stack traces (`errVerbose`) when hotspot provisioning fails due to expected NetworkManager reasons like `NmDeviceStateReasonIpConfigUnavailable`, producing excessively large log entries. Example:

```
ERROR viam-agent networking/networkmanager_linux.go:269 failed to start hotspot provisioning {"err":"...","errVerbose":"connection failed: NmDeviceStateReasonIpConfigUnavailable\ngithub.com/viamrobotics/agent/subsystems/networking.(*Networking).waitForConnect\n\t.../networkmanager_linux.go:504\n... [full stack trace] ..."}
```

The `errVerbose` field is added automatically by zap: when an error value from `github.com/pkg/errors` (aka `errw`) is passed as a structured log field, zap sees it implements `fmt.Formatter` and appends a `${key}Verbose` field containing the full `%+v` stack trace.

## Fix

Pass `err.Error()` instead of the raw error value at the affected structured log sites in the networking subsystem. The wrapped message chain still prints on a single readable line, without the stack blob.

All 7 sites are inside `err != nil` guards, so this is nil-safe (no `.Error()` on nil).

## Scope

Targeted to the networking subsystem — the site named in RSDK-14219 (`startProvisioning` hotspot failure) plus 6 adjacent same-class `Warn` sites (provisioning start/stop, add network, systemctl reboot, rfkill unblock). Log levels and message text are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)