### PR TITLE
RSDK-14222 Emit actionable errors on provisioning port conflicts

### DIFF
--- a/subsystems/networking/definitions_linux.go
+++ b/subsystems/networking/definitions_linux.go
@@ -40,9 +40,12 @@ var (
 	ErrBadPassword             = errors.New("bad or missing password")
 	ErrConnCheckDisabled       = errors.New("NetworkManager connectivity checking disabled by user, network management will be unavailable")
 	ErrNoActiveConnectionFound = errors.New("no active connection found")
-	scanLoopDelay              = time.Second * 15
-	scanTimeout                = time.Second * 30
-	connectTimeout             = time.Second * 50 // longer than the 45 second timeout in NetworkManager
+	// ErrIPConfigUnavailable wraps a NetworkManager IpConfigUnavailable failure so the hotspot
+	// path can recognize it and emit an actionable hint (commonly a port 53 conflict).
+	ErrIPConfigUnavailable = errors.New("NetworkManager could not configure IP for the hotspot")
+	scanLoopDelay          = time.Second * 15
+	scanTimeout            = time.Second * 30
+	connectTimeout         = time.Second * 50 // longer than the 45 second timeout in NetworkManager
 )
 
 type lockingNetwork struct {

--- a/subsystems/networking/grpc_linux.go
+++ b/subsystems/networking/grpc_linux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"syscall"
 
 	errw "github.com/pkg/errors"
 	"github.com/viamrobotics/agent/utils"
@@ -18,6 +19,11 @@ func (n *Subsystem) startGRPC(bindAddr string, bindPort int) error {
 	//nolint: noctx
 	lis, err := net.Listen("tcp", bind)
 	if err != nil {
+		if errors.Is(err, syscall.EADDRINUSE) {
+			return errw.Wrapf(err, "cannot bind %s: another service is already using this port. "+
+				"Stop it or scope its listen address away from %s (find it with: ss -ltnp | grep :%d)",
+				bind, bindAddr, bindPort)
+		}
 		return errw.Wrapf(err, "listening on: %s", bind)
 	}
 

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -321,6 +321,13 @@ func (n *Subsystem) startProvisioningHotspot(ctx context.Context) error {
 		return err
 	}
 	if err := n.activateConnection(ctx, n.netState.GenNetKey(NetworkTypeHotspot, "", n.Config().HotspotSSID)); err != nil {
+		if errors.Is(err, ErrIPConfigUnavailable) {
+			n.logger.Error("Hotspot IP configuration failed. This is commonly caused by another " +
+				"DNS/DHCP service (such as a system dnsmasq) holding port 53, which prevents " +
+				"NetworkManager's shared-mode dnsmasq from starting. Check with 'ss -lunp | grep :53' " +
+				"and disable the conflicting service (e.g. 'systemctl disable --now dnsmasq'), or " +
+				"verify nothing else is using the 10.42.0.0/24 subnet.")
+		}
 		return errw.Wrap(err, "starting provisioning mode hotspot")
 	}
 
@@ -524,6 +531,9 @@ func (n *Subsystem) waitForConnect(ctx context.Context, nw *lockingNetwork, devi
 					)
 				}
 				// custom error if it's some other reason for failure
+				if update.Reason == gnm.NmDeviceStateReasonIpConfigUnavailable {
+					return activeConnection, errw.Wrapf(ErrIPConfigUnavailable, "connection failed: %s", update.Reason)
+				}
 				return activeConnection, errw.Errorf("connection failed: %s", update.Reason)
 			default:
 			}

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -325,8 +325,7 @@ func (n *Subsystem) startProvisioningHotspot(ctx context.Context) error {
 			n.logger.Error("Hotspot IP configuration failed. This is commonly caused by another " +
 				"DNS/DHCP service (such as a system dnsmasq) holding port 53, which prevents " +
 				"NetworkManager's shared-mode dnsmasq from starting. Check with 'ss -lunp | grep :53' " +
-				"and disable the conflicting service (e.g. 'systemctl disable --now dnsmasq'), or " +
-				"verify nothing else is using the 10.42.0.0/24 subnet.")
+				"and disable the conflicting service, or verify nothing else is using the 10.42.0.0/24 subnet.")
 		}
 		return errw.Wrap(err, "starting provisioning mode hotspot")
 	}

--- a/subsystems/networking/portal_linux.go
+++ b/subsystems/networking/portal_linux.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strconv"
+	"syscall"
 	"time"
 
 	errw "github.com/pkg/errors"
@@ -59,6 +60,11 @@ func (n *Subsystem) startWeb(bindAddr string, bindPort int) error {
 	//nolint: noctx
 	lis, err := net.Listen("tcp", bind)
 	if err != nil {
+		if errors.Is(err, syscall.EADDRINUSE) {
+			return errw.Wrapf(err, "cannot bind %s: another service is already using this port. "+
+				"Stop it or scope its listen address away from %s (find it with: ss -ltnp | grep :%d)",
+				bind, bindAddr, bindPort)
+		}
 		return errw.Wrapf(err, "listening on: %s", bind)
 	}
 


### PR DESCRIPTION
## Problem

Provisioning could fail with opaque errors when another process holds a port the provisioning stack needs, giving operators no signal about the real cause. Seen in the field (Raspberry Pi OS Trixie): a stray system `dnsmasq` bound to `0.0.0.0:53` blocked NetworkManager's shared-mode dnsmasq from binding `10.42.0.1:53`, surfacing only as `NmDeviceStateReasonIpConfigUnavailable`. Similarly, a service holding `:80` (e.g. nginx wildcard-bound) makes the captive portal fail with a bare "address already in use".

## Change

Enrich these failures **without inspecting the holding process** — just report that the port is taken and hand the operator the one command to find the owner. ~25 LOC, no new files/deps.

- **Portal `:80` / gRPC `:4772`** — the kernel already returns `EADDRINUSE` with the exact port. Special-case it at the `net.Listen` sites in `startWeb`/`startGRPC` and return an enriched error telling the operator to stop the service or scope its listen address (`ss -ltnp | grep :<port>`).
- **Hotspot `:53`** — NM only gives us `IpConfigUnavailable` (not *proven* to be a port conflict — could be a subnet collision). Wrap that reason in a new `ErrIPConfigUnavailable` sentinel in `waitForConnect`, and in `startProvisioningHotspot` log a hedged, actionable hint covering both likely causes (a dnsmasq on `:53`, or a `10.42.0.0/24` collision), with the commands to diagnose and fix.

Deliberately does **not** identify the exact PID/process. For `:80/:4772` there's no loss of precision (`EADDRINUSE` is unambiguous); for `:53` the hedged message also covers the subnet-collision cause a port scan would miss. A follow-up could add best-effort `/proc` process-naming if desired — tracked in the ticket.

## Testing

- `GOOS=linux GOARCH=arm64 go build ./subsystems/networking/...` — clean
- `GOOS=linux GOARCH=arm64 go vet ./subsystems/networking/...` — clean

Jira: RSDK-14222

🤖 Generated with [Claude Code](https://claude.com/claude-code)