### PR TITLE
RSDK-14181: Make managed-security the default for os_auto_upgrade_type

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -503,26 +503,17 @@ func validateConfig(cfg AgentConfig) (AgentConfig, error) {
 		cfg.NetworkConfiguration.HotspotSSID = cfg.NetworkConfiguration.HotspotSSID[:32]
 	}
 
-	var haveBadTimeout bool
 	minTimeout := Timeout(time.Minute)
-	if cfg.NetworkConfiguration.OfflineBeforeStartingHotspotMinutes < minTimeout {
-		//nolint:lll
-		cfg.NetworkConfiguration.OfflineBeforeStartingHotspotMinutes = DefaultConfiguration.NetworkConfiguration.OfflineBeforeStartingHotspotMinutes
-		haveBadTimeout = true
-	}
-
-	if cfg.NetworkConfiguration.UserIdleMinutes < minTimeout {
-		cfg.NetworkConfiguration.UserIdleMinutes = DefaultConfiguration.NetworkConfiguration.UserIdleMinutes
-		haveBadTimeout = true
-	}
-
-	if cfg.NetworkConfiguration.RetryConnectionTimeoutMinutes < minTimeout {
-		cfg.NetworkConfiguration.RetryConnectionTimeoutMinutes = DefaultConfiguration.NetworkConfiguration.RetryConnectionTimeoutMinutes
-		haveBadTimeout = true
-	}
-
-	if haveBadTimeout {
-		errOut = errors.Join(errOut, errw.New("timeout values cannot be less than 1 minute"))
+	for k, v := range map[string]*Timeout{
+		"offline_before_starting_hotspot_minutes": &cfg.NetworkConfiguration.OfflineBeforeStartingHotspotMinutes,
+		"user_idle_minutes":                       &cfg.NetworkConfiguration.UserIdleMinutes,
+		"retry_connection_timeout_minutes":        &cfg.NetworkConfiguration.RetryConnectionTimeoutMinutes,
+	} {
+		if *v < minTimeout {
+			//nolint:lll
+			*v = DefaultConfiguration.NetworkConfiguration.OfflineBeforeStartingHotspotMinutes
+			errOut = errors.Join(errOut, errors.New(k+": timeout value cannot be less than 1 minute"))
+		}
 	}
 
 	if cfg.NetworkConfiguration.DeviceRebootAfterOfflineMinutes != 0 &&

--- a/utils/config.go
+++ b/utils/config.go
@@ -510,7 +510,6 @@ func validateConfig(cfg AgentConfig) (AgentConfig, error) {
 		"retry_connection_timeout_minutes":        &cfg.NetworkConfiguration.RetryConnectionTimeoutMinutes,
 	} {
 		if *v < minTimeout {
-			//nolint:lll
 			*v = DefaultConfiguration.NetworkConfiguration.OfflineBeforeStartingHotspotMinutes
 			errOut = errors.Join(errOut, errors.New(k+": timeout value cannot be less than 1 minute"))
 		}

--- a/utils/config.go
+++ b/utils/config.go
@@ -50,7 +50,7 @@ var (
 			LoggingJournaldRuntimeMaxUseMegabytes: 512,
 			LoggingJournaldStorage:                "persistent",
 			ForwardSystemLogs:                     "",
-			OSAutoUpgradeType:                     "",
+			OSAutoUpgradeType:                     OSAutoUpgradeManagedSecurity,
 			OSManagedUpgradeIntervalHours:         24,
 		},
 		NetworkConfiguration{
@@ -202,7 +202,7 @@ type SystemConfiguration struct {
 	ForwardSystemLogs string `json:"forward_system_logs,omitempty"`
 
 	// UpgradeType can be
-	// Empty/missing ("") to make no changes
+	// Empty/missing (""), which is treated as "managed-security"
 	// "disable" (or "disabled") to disable auto-upgrades
 	// "security" to enable ONLY security upgrades via unattended-upgrades (OS-controlled schedule)
 	// "all" to enable upgrades from all configured sources via unattended-upgrades (OS-controlled schedule)
@@ -443,7 +443,11 @@ func validateConfig(cfg AgentConfig) (AgentConfig, error) {
 		cfg.SystemConfiguration.LoggingJournaldStorage = defaultStorage
 	}
 
-	if cfg.SystemConfiguration.OSAutoUpgradeType != "" && !slices.Contains(
+	// An empty/missing value is treated as "managed-security".
+	if cfg.SystemConfiguration.OSAutoUpgradeType == "" {
+		cfg.SystemConfiguration.OSAutoUpgradeType = DefaultConfiguration.SystemConfiguration.OSAutoUpgradeType
+	}
+	if !slices.Contains(
 		slices.Concat(validOSAutoUpgradeTypes, []string{"disable", "disabled"}),
 		cfg.SystemConfiguration.OSAutoUpgradeType,
 	) {

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"go.viam.com/test"
 )
@@ -92,6 +93,31 @@ func TestConvertJson(t *testing.T) {
 
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, *newConfig, test.ShouldResemble, testConfig)
+}
+
+func TestValidateConfig(t *testing.T) {
+	minimumValidConfig := func() AgentConfig {
+		return AgentConfig{
+			AdvancedSettings: AdvancedSettings{
+				ViamServerStartTimeoutMinutes: Timeout(time.Minute),
+			},
+			NetworkConfiguration: NetworkConfiguration{
+				Manufacturer:                        "test",
+				Model:                               "foo",
+				HotspotPrefix:                       "bar",
+				HotspotPassword:                     "foobarbaz",
+				OfflineBeforeStartingHotspotMinutes: Timeout(time.Minute),
+				UserIdleMinutes:                     Timeout(time.Minute),
+				RetryConnectionTimeoutMinutes:       Timeout(time.Minute),
+			},
+		}
+	}
+	t.Run("auto update default is applied", func(t *testing.T) {
+		cfg, err := validateConfig(minimumValidConfig())
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, cfg.SystemConfiguration.OSAutoUpgradeType, test.ShouldEqual, DefaultConfig().SystemConfiguration.OSAutoUpgradeType)
+		test.That(t, cfg.SystemConfiguration.OSManagedUpgradeIntervalHours, test.ShouldEqual, DefaultConfig().SystemConfiguration.OSManagedUpgradeIntervalHours)
+	})
 }
 
 func TestDisableLogDeduplication(t *testing.T) {

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -53,7 +53,7 @@ func TestConvertJson(t *testing.T) {
 			"logging_journald_system_max_use_megabytes": 512,
 			"logging_journald_runtime_max_use_megabytes": 512,
 			"logging_journald_storage": "persistent",
-			"os_auto_upgrade_type": "",
+			"os_auto_upgrade_type": "managed-security",
 			"os_managed_upgrade_interval_hours": 24,
 			"forward_system_logs": ""
 	}

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -7,6 +7,12 @@ import (
 	"go.viam.com/test"
 )
 
+func TestDefaultConfig(t *testing.T) {
+	// Make sure the default config doesn't fail validation
+	_, err := validateConfig(DefaultConfig())
+	test.That(t, err, test.ShouldBeNil)
+}
+
 // basic test for the config structure names.
 func TestConvertJson(t *testing.T) {
 	jsonBytes := `

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -116,7 +116,12 @@ func TestValidateConfig(t *testing.T) {
 		cfg, err := validateConfig(minimumValidConfig())
 		test.That(t, err, test.ShouldBeNil)
 		test.That(t, cfg.SystemConfiguration.OSAutoUpgradeType, test.ShouldEqual, DefaultConfig().SystemConfiguration.OSAutoUpgradeType)
-		test.That(t, cfg.SystemConfiguration.OSManagedUpgradeIntervalHours, test.ShouldEqual, DefaultConfig().SystemConfiguration.OSManagedUpgradeIntervalHours)
+		test.That(
+			t,
+			cfg.SystemConfiguration.OSManagedUpgradeIntervalHours,
+			test.ShouldEqual,
+			DefaultConfig().SystemConfiguration.OSManagedUpgradeIntervalHours,
+		)
 	})
 }
 


### PR DESCRIPTION
# What

Changes the default value for `os_manageds_upgrade_type` to `managed-security`. This replaces the previous default behavior, which was to do nothing.

# Why

We are migrating agent managed machines to use `managed-security` by default. Updating the way agent treats an empty value in the config is consistent with how other default config values are handled. This PR will need to wait to be merged + deployed until we have finished informing users of the upcoming change and allowing them time to opt out.