### PR TITLE
RSDK-13903: Improve path handling on Windows

### DIFF
--- a/utils/urlparse_test.go
+++ b/utils/urlparse_test.go
@@ -1,0 +1,67 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/test"
+)
+
+// TestDownloadFileURLForms documents which URL spellings DownloadFile accepts for a local file
+func TestDownloadFileURLForms(t *testing.T) {
+	MockAndCreateViamDirs(t)
+	logger := logging.NewTestLogger(t)
+
+	const content = "canonical source binary contents"
+	// EvalSymlinks so the path matches what the getter resolves (e.g. /var -> /private/var on darwin).
+	td, err := filepath.EvalSymlinks(t.TempDir())
+	test.That(t, err, test.ShouldBeNil)
+	src := filepath.Join(td, "source.bin")
+	test.That(t, os.WriteFile(src, []byte(content), 0o644), test.ShouldBeNil)
+
+	// forward-slash spelling of the source path; on Windows "C:\x" -> "C:/x", on unix unchanged.
+	fwd := filepath.ToSlash(src)
+
+	type urlCase struct {
+		name    string
+		url     string
+		wantErr bool
+	}
+
+	var cases []urlCase
+	if runtime.GOOS == "windows" {
+		cases = []urlCase{
+			// Native Windows path after the scheme: file://C:\Users\...\source.bin
+			{"two-slash, backslashes", "file://" + src, false},
+			// Forward slashes; the drive letter parses into the URL host and we move it back.
+			{"two-slash, forward slashes", "file://" + fwd, false},
+			// Standards-correct Windows file URI: three slashes, then the drive letter.
+			{"three-slash, drive letter", "file:///" + fwd, false},
+		}
+	} else {
+		cases = []urlCase{
+			// Canonical POSIX file URI: the leading "/" of the absolute path makes three slashes.
+			{"absolute path", "file://" + src, false},
+		}
+	}
+	// A path that does not exist must surface an error regardless of platform or spelling.
+	cases = append(cases, urlCase{"nonexistent file", "file://" + filepath.ToSlash(filepath.Join(td, "missing.bin")), true})
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("url = %q", tc.url)
+			downloadedPath, err := DownloadFile(t.Context(), tc.url, logger)
+			if tc.wantErr {
+				test.That(t, err, test.ShouldNotBeNil)
+				return
+			}
+			test.That(t, err, test.ShouldBeNil)
+			got, err := os.ReadFile(downloadedPath)
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, string(got), test.ShouldEqual, content)
+		})
+	}
+}

--- a/utils/urlparse_test.go
+++ b/utils/urlparse_test.go
@@ -37,9 +37,9 @@ func TestDownloadFileURLForms(t *testing.T) {
 			// Native Windows path after the scheme: file://C:\Users\...\source.bin
 			{"two-slash, backslashes", "file://" + src, false},
 			// Forward slashes; the drive letter parses into the URL host and we move it back.
-			{"two-slash, forward slashes", "file://" + fwd, false},
+			{"two-slash, forward slashes, drive letter", "file://" + fwd, false},
 			// Standards-correct Windows file URI: three slashes, then the drive letter.
-			{"three-slash, drive letter", "file:///" + fwd, false},
+			{"three-slash, drive letter, drive letter", "file:///" + fwd, false},
 		}
 	} else {
 		cases = []urlCase{

--- a/utils/urlparse_test.go
+++ b/utils/urlparse_test.go
@@ -24,6 +24,7 @@ func TestDownloadFileURLForms(t *testing.T) {
 
 	// forward-slash spelling of the source path; on Windows "C:\x" -> "C:/x", on unix unchanged.
 	fwd := filepath.ToSlash(src)
+	vol := filepath.VolumeName(src)
 
 	type urlCase struct {
 		name    string
@@ -35,11 +36,14 @@ func TestDownloadFileURLForms(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		cases = []urlCase{
 			// Native Windows path after the scheme: file://C:\Users\...\source.bin
-			{"two-slash, backslashes", "file://" + src, false},
+			{"two-slash, backslashes, drive letter", "file://" + src, false},
 			// Forward slashes; the drive letter parses into the URL host and we move it back.
 			{"two-slash, forward slashes, drive letter", "file://" + fwd, false},
 			// Standards-correct Windows file URI: three slashes, then the drive letter.
-			{"three-slash, drive letter, drive letter", "file:///" + fwd, false},
+			{"three-slash, forward slash, drive letter", "file:///" + fwd, false},
+			// Windows path with forward slashes and no drive letter: file:///Users/...
+			// This resolves implicitly to the current working directory of the agent binary.
+			{"three-slash, no drive letter", "file://" + fwd[len(vol):], false},
 		}
 	} else {
 		cases = []urlCase{

--- a/utils/urlparse_test.go
+++ b/utils/urlparse_test.go
@@ -10,7 +10,7 @@ import (
 	"go.viam.com/test"
 )
 
-// TestDownloadFileURLForms documents which URL spellings DownloadFile accepts for a local file
+// TestDownloadFileURLForms documents which URL spellings DownloadFile accepts for a local file.
 func TestDownloadFileURLForms(t *testing.T) {
 	MockAndCreateViamDirs(t)
 	logger := logging.NewTestLogger(t)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-getter"
+	urlhelper "github.com/hashicorp/go-getter/helper/url"
 	errw "github.com/pkg/errors"
 	"github.com/schollz/progressbar/v3"
 	"github.com/ulikunitz/xz"
@@ -358,7 +359,8 @@ func GetLastModified(ctx context.Context, rawURL string, logger logging.Logger) 
 // DownloadFile downloads or copies a file into the cache directory and returns a path to the file.
 // If this is an http/s URL, you must check the checksum of the result; the partial logic does not check etags.
 func DownloadFile(ctx context.Context, rawURL string, logger logging.Logger) (string, error) {
-	parsedURL, err := url.Parse(rawURL)
+	// use go-getter's urlhelper for better Windows filepath handling and file:// url handling
+	parsedURL, err := urlhelper.Parse(rawURL)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Certain ways of specifying local paths to the agent binary wouldn't work on Windows, and it wasn't clear which kinds of paths should work.

This branch just swaps the usage of `url.Parse` in `DownloadFile` with `urlhelper.Parse` from `go-getter`. On unix, `urlhelper.Parse` literally resolves back to `url.Parse`. On Windows, `urlhelper.Parse` resolves to a custom parser with lots of special casing to handle the various kinds of path problems we were dealing with (it handles drive letters and `file://` url prefixes).

This branch also adds a test with a few different URL schemes for Windows - might be good to add that to CI.