### PR TITLE
Allow overriding config-fetch host via VIAM_ROOT_URL (RSDK-14255)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,7 +73,7 @@ fetch_config() {
 		curl -fsSL \
 			-H "key_id:$VIAM_API_KEY_ID" \
 			-H "key:$VIAM_API_KEY" \
-			"https://app.viam.com/api/json1/config?client=true&id=$VIAM_PART_ID" \
+			"${VIAM_ROOT_URL:-https://app.viam.com}/api/json1/config?client=true&id=$VIAM_PART_ID" \
 			-o /etc/viam.json
 	fi
 }


### PR DESCRIPTION
`fetch_config()` hardcoded `https://app.viam.com`. It now honors an optional `VIAM_ROOT_URL`, defaulting to production — existing published install commands are unaffected.

Enables internal envs (dev/staging/PR) to install an agent pointed at their own app. The fetched `/etc/viam.json` carries that env's `app_address`, so repointing the config fetch is enough for the whole machine to target it.

Consumer: app PR #12778, which emits `VIAM_ROOT_URL=<url>` in the generated install command for internal envs only. That PR is a no-op in prod until this `install.sh` is merged **and published** to `gs://packages.viam.com/apps/viam-agent/`.

Tested in an Ubuntu container against the #12778 PR env using this local script:
- with `VIAM_ROOT_URL=<pr-env>` → `/etc/viam.json` fetched, `app_address` = the PR env ✅
- without it → request goes to `https://app.viam.com` ✅

Ticket: RSDK-14255

🤖 Generated with [Claude Code](https://claude.com/claude-code)