### PR TITLE
Retry on a 5 minute interval if managed upgrade is blocked my maintenance windows

### DIFF
--- a/subsystems/syscfg/managed_upgrades_common.go
+++ b/subsystems/syscfg/managed_upgrades_common.go
@@ -1,6 +1,7 @@
 package syscfg
 
 import (
+	"errors"
 	"slices"
 	"time"
 
@@ -11,7 +12,26 @@ import (
 const (
 	defaultUpgradeInterval = 24 * time.Hour
 	minimumUpgradeInterval = time.Hour
+	// maintenanceRetryInterval is how often to retry an upgrade that was blocked
+	// by viam-server's maintenance window, instead of waiting for the full
+	// configured interval.
+	maintenanceRetryInterval = 5 * time.Minute
 )
+
+// errBlockedByMaintenanceWindow is returned by runManagedUpgrade when the
+// upgrade could not run because viam-server's maintenance window is closed.
+var errBlockedByMaintenanceWindow = errors.New("upgrade blocked by maintenance window")
+
+// nextUpgradeInterval returns how long to wait before the next managed upgrade
+// attempt, given the error (if any) from the previous attempt. When the previous
+// attempt was blocked by the maintenance window we retry sooner so the upgrade
+// runs promptly once the window opens.
+func nextUpgradeInterval(err error, interval time.Duration) time.Duration {
+	if errors.Is(err, errBlockedByMaintenanceWindow) {
+		return maintenanceRetryInterval
+	}
+	return interval
+}
 
 // isManaged returns true for the set of configuration values for
 // `os_auto_upgrade_type` that are considered "managed upgrades", i.e.

--- a/subsystems/syscfg/managed_upgrades_common.go
+++ b/subsystems/syscfg/managed_upgrades_common.go
@@ -35,7 +35,7 @@ func nextUpgradeInterval(err error, interval time.Duration) time.Duration {
 
 // logIfNewlyBlocked emits a warning the first time an upgrade attempt is blocked
 // by the maintenance window, using alreadyLogged to avoid repeating the warning
-// on every retry. It resets once upgrades are no longer blocked
+// on every retry. It resets once upgrades are no longer blocked.
 func logIfNewlyBlocked(logger logging.Logger, err error, alreadyLogged *bool) {
 	blocked := errors.Is(err, errBlockedByMaintenanceWindow)
 	if blocked && !*alreadyLogged {

--- a/subsystems/syscfg/managed_upgrades_common.go
+++ b/subsystems/syscfg/managed_upgrades_common.go
@@ -33,6 +33,17 @@ func nextUpgradeInterval(err error, interval time.Duration) time.Duration {
 	return interval
 }
 
+// logIfNewlyBlocked emits a warning the first time an upgrade attempt is blocked
+// by the maintenance window, using alreadyLogged to avoid repeating the warning
+// on every retry. It resets once upgrades are no longer blocked
+func logIfNewlyBlocked(logger logging.Logger, err error, alreadyLogged *bool) {
+	blocked := errors.Is(err, errBlockedByMaintenanceWindow)
+	if blocked && !*alreadyLogged {
+		logger.Warn("managed upgrade check blocked by maintenance window, will retry until window opens")
+	}
+	*alreadyLogged = blocked
+}
+
 // isManaged returns true for the set of configuration values for
 // `os_auto_upgrade_type` that are considered "managed upgrades", i.e.
 // viam-agent manages performing the upgrades and related tasks like triggering

--- a/subsystems/syscfg/managed_upgrades_linux.go
+++ b/subsystems/syscfg/managed_upgrades_linux.go
@@ -39,16 +39,17 @@ func (s *Subsystem) startManagedUpgrades(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		s.runManagedUpgrade(upgradeCtx)
+		err := s.runManagedUpgrade(upgradeCtx)
 
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
+		timer := time.NewTimer(nextUpgradeInterval(err, interval))
+		defer timer.Stop()
 		for {
 			select {
 			case <-upgradeCtx.Done():
 				return
-			case <-ticker.C:
-				s.runManagedUpgrade(upgradeCtx)
+			case <-timer.C:
+				err = s.runManagedUpgrade(upgradeCtx)
+				timer.Reset(nextUpgradeInterval(err, interval))
 			}
 		}
 	})
@@ -136,13 +137,16 @@ func getPackageManager(logger logging.Logger) (packageManager, error) {
 }
 
 // runManagedUpgrade detects the package manager and installs available upgrades.
-func (s *Subsystem) runManagedUpgrade(ctx context.Context) {
+// It returns errBlockedByMaintenanceWindow if the upgrade could not run because
+// viam-server's maintenance window is closed, so the caller can retry sooner
+// than the configured interval.
+func (s *Subsystem) runManagedUpgrade(ctx context.Context) error {
 	if ctx.Err() != nil {
-		return
+		return ctx.Err()
 	}
 
 	if !s.maintenanceAllowed(ctx) {
-		return
+		return errBlockedByMaintenanceWindow
 	}
 
 	s.mu.RLock()
@@ -152,7 +156,7 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) {
 	pm, err := getPackageManager(s.logger)
 	if err != nil {
 		s.logger.Warnw("skipping managed OS upgrade", "error", err)
-		return
+		return err
 	}
 
 	s.logger.Infow("Running managed OS package update", "package_manager", pm)
@@ -160,7 +164,7 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) {
 
 	if err := pm.runUpgrade(ctx, securityOnly); err != nil {
 		s.logger.Warnw("managed OS upgrade failed", "package_manager", pm, "error", err)
-		return
+		return err
 	}
 	s.logger.Info("OS package upgrade completed")
 
@@ -171,6 +175,8 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) {
 		s.mu.Unlock()
 		s.logger.Info("OS reboot required after package updates, will reboot when maintenance window opens")
 	}
+
+	return nil
 }
 
 // pkgCmd runs a package manager command, setting DEBIAN_FRONTEND=noninteractive

--- a/subsystems/syscfg/managed_upgrades_linux.go
+++ b/subsystems/syscfg/managed_upgrades_linux.go
@@ -39,7 +39,9 @@ func (s *Subsystem) startManagedUpgrades(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
+		var blockedLogged bool
 		err := s.runManagedUpgrade(upgradeCtx)
+		logIfNewlyBlocked(s.logger, err, &blockedLogged)
 
 		timer := time.NewTimer(nextUpgradeInterval(err, interval))
 		defer timer.Stop()
@@ -49,6 +51,7 @@ func (s *Subsystem) startManagedUpgrades(ctx context.Context) {
 				return
 			case <-timer.C:
 				err = s.runManagedUpgrade(upgradeCtx)
+				logIfNewlyBlocked(s.logger, err, &blockedLogged)
 				timer.Reset(nextUpgradeInterval(err, interval))
 			}
 		}

--- a/subsystems/syscfg/managed_upgrades_windows.go
+++ b/subsystems/syscfg/managed_upgrades_windows.go
@@ -65,29 +65,33 @@ func (s *Subsystem) startManagedUpgrades(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		s.runManagedUpgrade(upgradeCtx)
+		err := s.runManagedUpgrade(upgradeCtx)
 
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
+		timer := time.NewTimer(nextUpgradeInterval(err, interval))
+		defer timer.Stop()
 		for {
 			select {
 			case <-upgradeCtx.Done():
 				return
-			case <-ticker.C:
-				s.runManagedUpgrade(upgradeCtx)
+			case <-timer.C:
+				err = s.runManagedUpgrade(upgradeCtx)
+				timer.Reset(nextUpgradeInterval(err, interval))
 			}
 		}
 	})
 }
 
 // runManagedUpgrade runs a Windows Update cycle via PSWindowsUpdate.
-func (s *Subsystem) runManagedUpgrade(ctx context.Context) {
+// It returns errBlockedByMaintenanceWindow if the upgrade could not run because
+// viam-server's maintenance window is closed, so the caller can retry sooner
+// than the configured interval.
+func (s *Subsystem) runManagedUpgrade(ctx context.Context) error {
 	if ctx.Err() != nil {
-		return
+		return ctx.Err()
 	}
 
 	if !s.maintenanceAllowed(ctx) {
-		return
+		return errBlockedByMaintenanceWindow
 	}
 
 	s.mu.RLock()
@@ -98,7 +102,7 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) {
 
 	if err := runWindowsUpdate(ctx, mode == utils.OSAutoUpgradeManagedSecurity); err != nil {
 		s.logger.Warnw("Windows Update failed", "error", err)
-		return
+		return err
 	}
 
 	s.logger.Info("Windows Update completed")
@@ -109,6 +113,8 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) {
 		s.mu.Unlock()
 		s.logger.Info("OS reboot required after Windows updates, will reboot when maintenance window opens")
 	}
+
+	return nil
 }
 
 // stopManagedUpgrades cancels the background upgrade goroutine and waits for it to exit.

--- a/subsystems/syscfg/managed_upgrades_windows.go
+++ b/subsystems/syscfg/managed_upgrades_windows.go
@@ -65,7 +65,9 @@ func (s *Subsystem) startManagedUpgrades(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
+		var blockedLogged bool
 		err := s.runManagedUpgrade(upgradeCtx)
+		logIfNewlyBlocked(s.logger, err, &blockedLogged)
 
 		timer := time.NewTimer(nextUpgradeInterval(err, interval))
 		defer timer.Stop()
@@ -75,6 +77,7 @@ func (s *Subsystem) startManagedUpgrades(ctx context.Context) {
 				return
 			case <-timer.C:
 				err = s.runManagedUpgrade(upgradeCtx)
+				logIfNewlyBlocked(s.logger, err, &blockedLogged)
 				timer.Reset(nextUpgradeInterval(err, interval))
 			}
 		}


### PR DESCRIPTION
This fixes an edge case in agent managed upgrades where an upgrade blocked by maintenance windows wouldn't retry for at least another hour, or 24 hours by default. This could lead to a situation where machines with very restrictive maintenance windows never apply upgrades. The new behavior is to enter a 5 minute retry loop when blocked by maintenance windows until an upgrade check succeeds. It will log a warning when entering this state but not on every subsequent loop. 5 minutes was chosen arbitrarily, we can change it or make it configurable