### PR TITLE
RSDK-14291: Better account for stale PID lock files

### DIFF
--- a/cmd/viam-agent/main.go
+++ b/cmd/viam-agent/main.go
@@ -410,7 +410,7 @@ func pidIsSelfOrThread(pid int) (bool, string) {
 	if runtime.GOOS != "linux" {
 		return false, ""
 	}
-	//nolint:gosec
+
 	status, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
 	if err != nil {
 		// process is gone or unreadable; let the caller's other checks decide

--- a/cmd/viam-agent/main.go
+++ b/cmd/viam-agent/main.go
@@ -365,17 +365,26 @@ func getLock() (lockfile.Lockfile, error) {
 		if errors.Is(err, lockfile.ErrBusy) {
 			var staleFile bool
 			proc, err := pidFile.GetOwner()
-			if err != nil {
+			if err != nil || proc == nil {
 				globalLogger.Error(errors.Wrap(err, "getting lockfile owner"))
 				staleFile = true
-			}
-			runPath, err := pidCmd(proc.Pid)
-			if err != nil {
-				globalLogger.Error(errors.Wrap(err, "cannot get info on lockfile owner"))
+			} else if stale, reason := pidIsSelfOrThread(proc.Pid); stale {
+				// A leftover lockfile PID can also be reused by an OS thread (TID) of this
+				// very process: boot-time PID assignment is nearly deterministic, so the
+				// previous boot's agent PID often lands within the current agent's own
+				// thread ID range. Threads pass the pidCmd check below (/proc/<tid>/exe is
+				// this binary), so they must be ruled out first.
+				globalLogger.Warnf("lockfile PID %d is %s, not another agent instance", proc.Pid, reason)
 				staleFile = true
-			} else if !strings.Contains(runPath, agent.SubsystemName) {
-				globalLogger.Warnf("lockfile owner isn't %s", agent.SubsystemName)
-				staleFile = true
+			} else {
+				runPath, err := pidCmd(proc.Pid)
+				if err != nil {
+					globalLogger.Error(errors.Wrap(err, "cannot get info on lockfile owner"))
+					staleFile = true
+				} else if !strings.Contains(runPath, agent.SubsystemName) {
+					globalLogger.Warnf("lockfile owner isn't %s", agent.SubsystemName)
+					staleFile = true
+				}
 			}
 			if staleFile {
 				globalLogger.Warnf("deleting lockfile %s", pidFile)
@@ -388,6 +397,43 @@ func getLock() (lockfile.Lockfile, error) {
 		}
 	}
 	return "", err
+}
+
+// pidIsSelfOrThread reports whether pid cannot be a distinct viam-agent process because it
+// is this process itself, one of this process's OS threads, or (on Linux) a thread ID (TID)
+// of any process rather than a real process ID. A genuine lock owner always writes its main
+// PID, so any of these means the lockfile is stale. The reason string is for logging.
+func pidIsSelfOrThread(pid int) (bool, string) {
+	if pid == os.Getpid() {
+		return true, "this process"
+	}
+	if runtime.GOOS != "linux" {
+		return false, ""
+	}
+	//nolint:gosec
+	status, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+	if err != nil {
+		// process is gone or unreadable; let the caller's other checks decide
+		return false, ""
+	}
+	for _, line := range strings.Split(string(status), "\n") {
+		tgidStr, ok := strings.CutPrefix(line, "Tgid:")
+		if !ok {
+			continue
+		}
+		tgid, err := strconv.Atoi(strings.TrimSpace(tgidStr))
+		if err != nil {
+			return false, ""
+		}
+		if tgid == os.Getpid() {
+			return true, "an OS thread of this process"
+		}
+		if tgid != pid {
+			return true, fmt.Sprintf("an OS thread (TID) of process %d", tgid)
+		}
+		return false, ""
+	}
+	return false, ""
 }
 
 // pidCmd returns the command of the given pid.

--- a/cmd/viam-agent/main_lock_linux_test.go
+++ b/cmd/viam-agent/main_lock_linux_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+	"testing"
+
+	"go.viam.com/test"
+)
+
+// A TID of one of this process's own OS threads must be recognized as stale: after an
+// unclean shutdown, the previous boot's agent PID in the leftover lockfile frequently
+// collides with a thread ID of the newly started agent (boot-time PID assignment is
+// nearly deterministic), and threads pass the /proc/<pid>/exe binary check.
+func TestPidIsSelfOrThreadWithOwnTID(t *testing.T) {
+	// Pin this goroutine to an OS thread so the TID stays valid for the duration.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	tid := syscall.Gettid()
+	if tid == os.Getpid() {
+		t.Skip("goroutine is on the main thread; TID == PID exercises the self case instead")
+	}
+
+	stale, reason := pidIsSelfOrThread(tid)
+	test.That(t, stale, test.ShouldBeTrue)
+	test.That(t, reason, test.ShouldEqual, "an OS thread of this process")
+}

--- a/cmd/viam-agent/main_lock_test.go
+++ b/cmd/viam-agent/main_lock_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestPidIsSelfOrThread(t *testing.T) {
+	stale, _ := pidIsSelfOrThread(os.Getpid())
+	test.That(t, stale, test.ShouldBeTrue)
+
+	// PID 1 (init/systemd/launchd) is a real, foreign process on all platforms.
+	stale, _ = pidIsSelfOrThread(1)
+	test.That(t, stale, test.ShouldBeFalse)
+}


### PR DESCRIPTION
RSDK-14291

## What

Fixes `getLock()` in `cmd/viam-agent/main.go` mistaking an OS thread for another running `viam-agent` instance when validating a leftover lockfile. Adds a `pidIsSelfOrThread` helper that rejects a lockfile owner PID when it is this process itself, one of this process's own OS threads, or (on Linux, via the `Tgid:` field of `/proc/<pid>/status`) a thread ID of any process rather than a real process ID. Also guards against a `nil` dereference when `lockfile.GetOwner()` fails.

## Why

On Linux, thread IDs share a number space with process IDs, and `/proc/<tid>` is directly addressable: `kill -0 <tid>` reports alive and `/proc/<tid>/exe` resolves to the owning process's binary. The existing stale-lockfile check (`pidCmd` + `strings.Contains(runPath, agent.SubsystemName)`) therefore passes when the leftover PID is actually a thread of the newly started agent itself, and startup dies with "other instance of viam-agent is already running".

This is not a theoretical collision. Because boot-time PID assignment is nearly deterministic, the agent lands at almost the same PID every boot, and its Go runtime threads occupy the next few dozen IDs — so after any unclean shutdown (power cut, hardware watchdog reset), the previous boot's agent PID in the stale lockfile very likely falls inside the new agent's own TID range. This exact failure produced a `would-detach exit-code exit_status=1` exit-probe event on a production machine on `2026-07-19`: a WDAT hardware watchdog reset left a stale pidfile containing 2238, the next boot's agent started as PID 2203, and its _own_ thread with TID 2238 passed both liveness and binary checks, causing a spurious fatal (recovered only by systemd's 5-second restart) log. With the [proposed bad-binary/detached-mode safeguard](https://docs.google.com/document/d/1sZ1QBMDrtURnp3eiIKyFJa_UrCeycPCdsjcUW0ANutA/edit?tab=t.0), such false positives would wrongly count toward detaching.

## Testing

- Adds `TestPidIsSelfOrThread`
- Adds `TestPidIsSelfOrThreadWithOwnTID`

  [Description generated by Claude 🤖]