### PR TITLE
Log when managed OS upgrades are enabled

### DIFF
--- a/subsystems/syscfg/managed_upgrades_common.go
+++ b/subsystems/syscfg/managed_upgrades_common.go
@@ -52,6 +52,16 @@ func isManaged(mode string) bool {
 	return slices.Contains([]string{utils.OSAutoUpgradeManagedAll, utils.OSAutoUpgradeManagedSecurity}, mode)
 }
 
+// logManagedUpgradesStarted announces that agent-managed OS upgrades are active.
+// Without this the only positive signal is an upgrade actually running, which
+// never happens on a device whose maintenance window has been closed since boot.
+func logManagedUpgradesStarted(logger logging.Logger, mode string, interval time.Duration) {
+	logger.Infow("Managed OS upgrades enabled, viam-agent will install updates directly",
+		"os_auto_upgrade_type", mode,
+		"check_interval", interval,
+	)
+}
+
 func clampUpgradeInterval(logger logging.Logger, hours float64) time.Duration {
 	if hours == 0 {
 		return defaultUpgradeInterval

--- a/subsystems/syscfg/managed_upgrades_linux.go
+++ b/subsystems/syscfg/managed_upgrades_linux.go
@@ -30,6 +30,7 @@ func (s *Subsystem) startManagedUpgrades(ctx context.Context) {
 	}
 
 	interval := clampUpgradeInterval(s.logger, s.cfg.OSManagedUpgradeIntervalHours)
+	logManagedUpgradesStarted(s.logger, s.cfg.OSAutoUpgradeType, interval)
 
 	upgradeCtx, cancel := context.WithCancel(ctx)
 	s.upgradeCancel = cancel

--- a/subsystems/syscfg/managed_upgrades_windows.go
+++ b/subsystems/syscfg/managed_upgrades_windows.go
@@ -56,6 +56,7 @@ func (s *Subsystem) startManagedUpgrades(ctx context.Context) {
 	}
 
 	interval := clampUpgradeInterval(s.logger, s.cfg.OSManagedUpgradeIntervalHours)
+	logManagedUpgradesStarted(s.logger, s.cfg.OSAutoUpgradeType, interval)
 
 	upgradeCtx, cancel := context.WithCancel(ctx)
 	s.upgradeCancel = cancel

--- a/subsystems/syscfg/upgrades_linux.go
+++ b/subsystems/syscfg/upgrades_linux.go
@@ -57,7 +57,14 @@ func (s *Subsystem) EnforceUpgrades(ctx context.Context) error {
 			return err
 		}
 		if isNew {
-			s.logger.Info("Disabled OS auto-upgrades.")
+			if isManaged(cfg) {
+				s.logger.Infow(
+					"Disabled apt unattended-upgrades, OS upgrades are now run by viam-agent instead",
+					"os_auto_upgrade_type", cfg,
+				)
+			} else {
+				s.logger.Info("Disabled apt unattended-upgrades, no OS upgrades will be installed automatically.")
+			}
 		}
 		return nil
 	}


### PR DESCRIPTION
## Problem

There is no positive log signal that managed OS upgrade mode is active.

The other nearby signal, `Disabled OS auto-upgrades.`, made this worse: that branch in `EnforceUpgrades` is shared by `disable` **and** the two managed modes, so the message read as "upgrades are off" in exactly the case where the agent had taken over installing them.

## Changes

- New `logManagedUpgradesStarted` helper in `managed_upgrades_common.go`, called from `startManagedUpgrades` on both Linux and Windows once the interval is clamped:

  ```
  Managed OS upgrades enabled, viam-agent will install updates directly
      os_auto_upgrade_type=managed-security  check_interval=24h0m0s
  ```

  It lives in the common file so the two platforms can't drift, and logs the clamped interval rather than the raw config value.

## Testing

`go build` / `go vet` clean for linux, windows, and darwin; `go test ./utils/` passes. No behavior change beyond logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)