### PR TITLE
Revert managed-security default for os_auto_upgrade_type

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -50,7 +50,7 @@ var (
 			LoggingJournaldRuntimeMaxUseMegabytes: 512,
 			LoggingJournaldStorage:                "persistent",
 			ForwardSystemLogs:                     "",
-			OSAutoUpgradeType:                     OSAutoUpgradeManagedSecurity,
+			OSAutoUpgradeType:                     "",
 			OSManagedUpgradeIntervalHours:         24,
 		},
 		NetworkConfiguration{
@@ -202,7 +202,7 @@ type SystemConfiguration struct {
 	ForwardSystemLogs string `json:"forward_system_logs,omitempty"`
 
 	// UpgradeType can be
-	// Empty/missing (""), which is treated as "managed-security"
+	// Empty/missing ("") to make no changes
 	// "disable" (or "disabled") to disable auto-upgrades
 	// "security" to enable ONLY security upgrades via unattended-upgrades (OS-controlled schedule)
 	// "all" to enable upgrades from all configured sources via unattended-upgrades (OS-controlled schedule)
@@ -443,11 +443,7 @@ func validateConfig(cfg AgentConfig) (AgentConfig, error) {
 		cfg.SystemConfiguration.LoggingJournaldStorage = defaultStorage
 	}
 
-	// An empty/missing value is treated as "managed-security".
-	if cfg.SystemConfiguration.OSAutoUpgradeType == "" {
-		cfg.SystemConfiguration.OSAutoUpgradeType = DefaultConfiguration.SystemConfiguration.OSAutoUpgradeType
-	}
-	if !slices.Contains(
+	if cfg.SystemConfiguration.OSAutoUpgradeType != "" && !slices.Contains(
 		slices.Concat(validOSAutoUpgradeTypes, []string{"disable", "disabled"}),
 		cfg.SystemConfiguration.OSAutoUpgradeType,
 	) {

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -60,7 +60,7 @@ func TestConvertJson(t *testing.T) {
 			"logging_journald_system_max_use_megabytes": 512,
 			"logging_journald_runtime_max_use_megabytes": 512,
 			"logging_journald_storage": "persistent",
-			"os_auto_upgrade_type": "managed-security",
+			"os_auto_upgrade_type": "",
 			"os_managed_upgrade_interval_hours": 24,
 			"forward_system_logs": ""
 	}


### PR DESCRIPTION
Sets the default for `os_auto_upgrade_type` back to `""` (make no changes).

This undoes only the default-value portion of #267 rather than reverting the whole commit, since that commit also contained an unrelated refactor of the network timeout validation plus new `TestDefaultConfig`/`TestValidateConfig` coverage, which stay in place.

- `DefaultConfiguration.SystemConfiguration.OSAutoUpgradeType` back to `""`
- `validateConfig` no longer coerces an empty value to the default; restored the `!= ""` guard on the validity check
- doc comment and JSON test fixture updated to match

Downstream handling of `""` is unchanged and already a no-op: `EnforceUpgrades` returns early on empty, and `isManaged("")` is false so the managed upgrade loop doesn't start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)