### PR TITLE
RSDK-14044 Wait for download progress goroutine before returning: flaky test fix TestInitPaths/failure_not_directory flake

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -436,9 +436,19 @@ func DownloadFile(ctx context.Context, rawURL string, logger logging.Logger) (st
 			}
 		}
 
-		done := make(chan struct{})
-		defer close(done)
-		goutils.PanicCapturingGo(func() { fileSizeProgress(done, ctx, logger, rawURL, partialDest) })
+		// fileSizeProgress must not outlive this function: if it logged after
+		// DownloadFile returned it could race with a test logger whose test has
+		// already completed. Cancel it and wait for it to exit before returning.
+		progressCtx, cancelProgress := context.WithCancel(ctx)
+		progressDone := make(chan struct{})
+		goutils.PanicCapturingGo(func() {
+			defer close(progressDone)
+			fileSizeProgress(progressCtx, logger, rawURL, partialDest)
+		})
+		defer func() {
+			cancelProgress()
+			<-progressDone
+		}()
 		if err := g.GetFile(partialDest, parsedURL); err != nil {
 			return "", errw.Wrap(err, "downloading file")
 		}
@@ -824,8 +834,8 @@ func (sb *SafeBuffer) Reset() {
 	sb.buf.Reset()
 }
 
-// starts a goroutine that watches `dest` file size, logs progress until `dest` no longer exists or `done` is closed.
-func fileSizeProgress(done chan struct{}, ctx context.Context, logger logging.Logger, url, dest string) {
+// watches `dest` file size, logging progress until `dest` no longer exists or `ctx` is cancelled.
+func fileSizeProgress(ctx context.Context, logger logging.Logger, url, dest string) {
 	// note: go-getter is also doing a HEAD request internally, so this is redundant, but we don't have access to it.
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
 	if err != nil {
@@ -834,7 +844,10 @@ func fileSizeProgress(done chan struct{}, ctx context.Context, logger logging.Lo
 	}
 	res, err := socksClient(url, logger).Do(req)
 	if err != nil {
-		logger.Warnw("progress bar failed", "err", err)
+		// don't warn if the request was cancelled because the download already finished
+		if ctx.Err() == nil {
+			logger.Warnw("progress bar failed", "err", err)
+		}
 		return
 	}
 	size := res.ContentLength
@@ -870,7 +883,7 @@ func fileSizeProgress(done chan struct{}, ctx context.Context, logger logging.Lo
 			// todo: use fancy progress bar instead
 			bar.Set64(stat.Size()) //nolint:errcheck,gosec
 			logger.Info(bar)
-		case <-done:
+		case <-ctx.Done():
 			return
 		}
 	}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -420,6 +420,46 @@ func TestDownloadFile(t *testing.T) {
 	})
 }
 
+// fileSizeProgress runs in a goroutine spawned by DownloadFile. It must stop and
+// stay quiet once its context is cancelled so it never logs after DownloadFile (and
+// any test that owns the logger) has returned, which would otherwise be a data race.
+func TestFileSizeProgressStopsOnCancel(t *testing.T) {
+	logger, logs := logging.NewObservedTestLogger(t)
+
+	headReceived := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Mimic a slow progress HEAD request that is still in flight when the
+		// download completes: block until the request's context is cancelled.
+		if r.Method == http.MethodHead {
+			close(headReceived)
+			<-r.Context().Done()
+			return
+		}
+		w.Write([]byte("hello"))
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	goutils.PanicCapturingGo(func() {
+		defer close(done)
+		fileSizeProgress(ctx, logger, server.URL, filepath.Join(t.TempDir(), "dest"))
+	})
+
+	<-headReceived
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Minute):
+		t.Fatal("fileSizeProgress did not return after its context was cancelled")
+	}
+
+	// A cancellation is expected here (the download finished), so we should not have
+	// emitted a spurious warning.
+	test.That(t, logs.FilterMessage("progress bar failed").Len(), test.ShouldEqual, 0)
+}
+
 // If either of the tests on ViamDirsData become outdated be sure there is at
 // least some test remaining on the ViamDirsData.Values method. As long as it
 // uses reflection it could break at runtime if we accidentally add a


### PR DESCRIPTION
## Summary

`TestInitPaths/failure_not_directory` was intermittently failing under `go test -race` with a `DATA RACE` whose stack pointed at a completely different test: a goroutine in `utils.fileSizeProgress` (spawned by `utils.DownloadFile`) was calling `logger.Warnw(...)` → `t.Log(...)` *after* the test that owned the logger had finished. The race detector attributes such failures to whatever test happens to be active, which is why an unrelated test (`TestInitPaths/failure_not_directory`) was reported as failing.

## Root cause

`DownloadFile` started the `fileSizeProgress` progress-logger goroutine with `PanicCapturingGo` and only `close`d a `done` channel via `defer` when it returned — it never *waited* for the goroutine to actually exit. While that goroutine was blocked in its progress HEAD request (`socksClient(...).Do(req)`), closing `done` did not interrupt it. Once the request eventually completed (often with an error, e.g. after the test's `httptest` server was closed), the goroutine logged via `logger.Warnw` — after `DownloadFile` had already returned and the owning subtest had completed. Writing to a completed test's logger is a data race.

RDK's `logging.NewTestLogger` is intentionally non-silent (see `NewTestLoggerSilentAfterComplete`'s docs) so that goroutines logging after test completion are surfaced as race/panic failures. So this was a genuine goroutine-leak bug, not a test-harness quirk — silencing the logger would only have hidden it.

## Fix

- Run `fileSizeProgress` under a cancelable child context. On return, `DownloadFile` cancels it (interrupting any in-flight HEAD request) and waits for it to exit before returning, so it can never log after `DownloadFile` returns.
- Suppress the now-expected `"progress bar failed"` warning when the progress request is cancelled because the download already finished (avoids new log spam on every successful download).
- `fileSizeProgress` now selects on `ctx.Done()` instead of a separate `done` channel, and takes `ctx` as its first parameter.

## Testing

Added `TestFileSizeProgressStopsOnCancel`, a deterministic regression test: it stands up a server whose HEAD handler blocks until its request context is cancelled (mimicking an in-flight progress request), cancels the context, and asserts the goroutine returns promptly without emitting a spurious warning.

Note: the module targets `go 1.26` (RDK requires `go 1.25.9`); the sandbox only has `go 1.24.7`/`go 1.25.1` and the toolchain download host is blocked, so the suite could not be executed locally. The changed files parse cleanly and pass the project's gofumpt/gci formatters; the fix and test were verified by careful review against the race trace and RDK's test-logger semantics. CI will run the full `go test -race ./...`.

Key: RSDK-14044

Co-authored by Claude agent for Jira.