### PR TITLE
Don't publish prerelease artifacts from a release-tagged commit

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -130,18 +130,27 @@ jobs:
       if: github.event_name == 'release'
       run: |
         gsutil -h "Cache-Control:no-cache" cp bin/viam-agent-* install.sh uninstall.sh preinstall.sh gs://packages.viam.com/apps/viam-agent/
-        gsutil cp etc/viam-agent-*.json gs://packages.viam.com/apps/viam-subsystems/
+        gsutil -h "Cache-Control:no-cache" cp etc/viam-agent-*.json gs://packages.viam.com/apps/viam-subsystems/
+    # Skipped when HEAD is a release tag. dev-version.sh short-circuits on a direct
+    # tag, so a main push sitting on the tagged commit computes the bare version
+    # (v1.0.1, no -dev suffix) and produces the same filenames and the same manifest
+    # `upload-path` as the release-event run. Both runs then race to write the same
+    # apps/viam-subsystems/ manifest, and if this one wins, the published manifest
+    # advertises the sha of the prerelease binary while apps/viam-agent/ holds the
+    # release binary. Windows only, since Authenticode timestamps make that the one
+    # artifact whose bytes differ between two builds of the same commit. The release
+    # run already publishes these artifacts, so there is nothing to add here.
     - name: Upload binaries to GCS (Prerelease)
-      if: github.event_name != 'release' && github.event_name != 'pull_request'
+      if: github.event_name != 'release' && github.event_name != 'pull_request' && contains(steps.version.outputs.value, '-dev.')
       run: |
         gsutil -h "Cache-Control:no-cache" cp bin/viam-agent-* gs://packages.viam.com/apps/viam-agent/prerelease/
-        gsutil cp etc/viam-agent-*.json gs://packages.viam.com/apps/viam-subsystems/
+        gsutil -h "Cache-Control:no-cache" cp etc/viam-agent-*.json gs://packages.viam.com/apps/viam-subsystems/
     - name: Upload binaries to GCS (PR dev release)
       if: github.event_name == 'pull_request'
       run: |
         PR_PATH="gs://packages.viam.com/apps/viam-agent/prerelease/pr-${{ github.event.pull_request.number }}"
         gsutil -h "Cache-Control:no-cache" cp bin/viam-agent-* "$PR_PATH/"
-        gsutil cp etc/viam-agent-*.json "$PR_PATH/"
+        gsutil -h "Cache-Control:no-cache" cp etc/viam-agent-*.json "$PR_PATH/"
     - name: Collect PR dev release URLs
       id: pr_urls
       if: github.event_name == 'pull_request'
@@ -196,8 +205,9 @@ jobs:
       run: |
         cp viam-agent-*-windows-x86_64.msi viam-agent-stable-windows-x86_64.msi
         gsutil -h "Cache-Control:no-cache" cp viam-agent-*-windows-x86_64.msi gs://packages.viam.com/apps/viam-agent/
+    # Same tagged-commit guard as the binary prerelease upload above.
     - name: Upload MSI to GCS (Prerelease)
-      if: github.event_name != 'release' && github.event_name != 'pull_request'
+      if: github.event_name != 'release' && github.event_name != 'pull_request' && contains(needs.build.outputs.version, '-dev.')
       shell: bash
       run: gsutil -h "Cache-Control:no-cache" cp viam-agent-*-windows-x86_64.msi gs://packages.viam.com/apps/viam-agent/prerelease/
     - name: Upload MSI to GCS (PR dev release)


### PR DESCRIPTION
## Problem

`viam-agent` v1.0.1 is unusable on Windows. The published manifest advertises a sha256 that no released binary has:

| Object | sha256 |
|---|---|
| `apps/viam-subsystems/viam-agent-v1.0.1-windows-x86_64.json` says | `f913f953…` |
| `apps/viam-agent/viam-agent-v1.0.1-windows-x86_64` (actual) | `8e0c004a…` |
| `apps/viam-agent/**prerelease**/viam-agent-v1.0.1-windows-x86_64` | `f913f953…` |

The production manifest describes the **prerelease** binary. Every Windows machine targeting 1.0.1 downloads the release binary, correctly rejects it, and retries forever — roughly 29 MB every few seconds, with each failed attempt left on disk until the `.duplicate-NNN` counter saturates at 099 (~2.9 GB in `c:\opt\viam\cache`).

## Root cause

Two runs raced:

- `30480287163` — `release`, tag `v1.0.1`
- `30480253275` — `push` to `main`, same commit ("Revert managed-security default…")

`dev-version.sh` short-circuits on a direct tag, so the `main` push computed the bare `v1.0.1` rather than a `-dev.N` label. That build therefore produced identical binary filenames and an identical manifest `upload-path` to the release run. The binaries diverge (`prerelease/` vs the release path) but both runs write the *same* manifest object, so the last writer decides which sha is advertised:

```
release run wrote manifest  18:34:00.82
push run wrote manifest     18:34:02.41  ← won
```

**Only Windows is affected.** Authenticode timestamps make the signed exe the one artifact whose bytes differ between two builds of the same commit (same 29,004,144 bytes, different signature). The Linux and darwin binaries are byte-identical under `-trimpath`, so the race is harmless there — I verified Linux v1.0.1 and Windows v1.0.0 manifests both match their binaries.

## Fix

Gate both prerelease upload steps on the computed version actually containing `-dev.`. The release-event run already publishes those exact artifacts, so nothing is lost. Genuine prereleases (`v1.0.2-dev.4`) are unaffected — they keep their distinct filenames and their `upload-path` into `prerelease/`.

Also adds `Cache-Control:no-cache` to the manifest uploads, matching what the binary uploads already do. The manifests currently get the GCS default `public, max-age=3600`, so a bad manifest keeps being served for up to an hour after it is corrected.

## Not fixed here

- **The bad v1.0.1 manifest still needs correcting** out of band, to sha256 `8e0c004af9f156f4bdef1ca9cff0bb0544653c17706660deb742909bbd139fc4`. The released binary is correctly signed and fine as-is.
- **Correcting it will not unstick already-affected machines.** `version_control.go:182` returns before `info.UnpackedSHA = cfg.GetSha256()` on line 197, so a corrected sha for an unchanged version string is never re-read, and the cache persists in `version_cache.json` across restarts. That needs a 1.0.2 or a cache clear.
- Agent-side hardening worth filing separately: back off on repeated checksum failure instead of hot-looping, and delete bad-checksum downloads (the existing `TODO(APP-10012)`).

## Test

YAML validated. Not exercised end-to-end — the tagged-commit path only occurs during an actual release, so the guard is verified by inspection of `dev-version.sh` and the two run logs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)