### PR TITLE
Verify published manifests match the binaries they point at

### DIFF
--- a/.github/workflows/fix-manifest.yaml
+++ b/.github/workflows/fix-manifest.yaml
@@ -1,0 +1,180 @@
+name: Fix Manifest
+
+# Repairs a version whose published manifest and binary disagree, as reported by
+# Test and Build's "Verify manifests published by this run" step, by the Verify
+# Manifests workflow, or by running verify-manifests.sh directly.
+#
+# There are two repairs and they are not interchangeable, because a mismatch
+# looks identical whichever side is at fault. Pick by deciding what the object
+# currently at upload-path is:
+#
+#   manifest  The published binary is the artifact you meant to ship, and only
+#             the manifest's sha256 is wrong. Rewrites the manifest to match the
+#             binary. Published binaries are untouched. This is the repair for
+#             the concurrent-run clobber, where both runs built the same source
+#             and the release binary is correctly signed.
+#
+#   rebuild   The binary itself is wrong, so its checksum should not be blessed.
+#             Rebuilds the tag from source, re-signs, and re-uploads binary,
+#             manifest and MSI from one build so they cannot disagree.
+#             This REPLACES published artifacts. Windows binaries are not
+#             reproducible (Authenticode timestamps), so the rebuilt exe and MSI
+#             will differ byte-for-byte from what was released, even though the
+#             source is identical. Linux and darwin rebuild byte-identical under
+#             -trimpath.
+#
+# Neither repair unsticks machines that already cached the bad sha:
+# version_control.go returns early on an unchanged version string, so it never
+# re-reads a corrected checksum. Those need a version bump or a cache clear.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to repair, e.g. v1.0.1'
+        required: true
+        type: string
+      mode:
+        description: 'manifest = trust the published binary, fix the manifest. rebuild = rebuild the tag and replace the artifacts.'
+        required: true
+        type: choice
+        options:
+          - manifest
+          - rebuild
+      confirm:
+        description: 'Re-type the version tag to confirm. Both modes write to the production bucket.'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  # Cheap and separate so a typo fails before anything authenticates to GCS.
+  guard:
+    name: Confirm target
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check confirmation matches
+      run: |
+        if [ "${{ inputs.confirm }}" != "${{ inputs.version }}" ]; then
+          echo "confirm (${{ inputs.confirm }}) does not match version (${{ inputs.version }})" >&2
+          exit 1
+        fi
+        case "${{ inputs.version }}" in
+          v[0-9]*.[0-9]*.[0-9]*) ;;
+          *) echo "version must look like v1.0.1" >&2; exit 1 ;;
+        esac
+
+  fix-manifest:
+    name: Rewrite manifest to match published binary
+    needs: guard
+    if: inputs.mode == 'manifest'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+    - uses: actions/checkout@v4
+    - uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+    - uses: google-github-actions/setup-gcloud@v2
+    # --fix rewrites only mismatched manifests; platforms that already agree are
+    # left alone, so this is a no-op when there is nothing to repair.
+    - name: Fix and verify
+      run: ./verify-manifests.sh --version "${{ inputs.version }}" --fix
+
+  rebuild:
+    name: Rebuild and replace binaries
+    needs: guard
+    if: inputs.mode == 'rebuild'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+    # fetch-depth 0 so dev-version.sh sees the tag; it short-circuits on a
+    # direct tag and yields the bare version, which is what puts the manifests
+    # on the release path rather than under prerelease/.
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.version }}
+        fetch-depth: 0
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+    - name: Confirm the tag computes the version being repaired
+      run: |
+        COMPUTED=$(./dev-version.sh)
+        if [ "$COMPUTED" != "${{ inputs.version }}" ]; then
+          echo "tag ${{ inputs.version }} computes version '$COMPUTED'; refusing to publish" >&2
+          exit 1
+        fi
+    - name: Build
+      run: make all
+    - name: Sign Windows binaries
+      uses: ./.github/actions/sign-windows
+      with:
+        files: 'bin/viam-agent-*-windows-x86_64'
+    - name: Generate manifest
+      run: make manifest
+    # The MSI job wraps this exact exe, so it has to consume the artifact rather
+    # than rebuild its own.
+    - uses: actions/upload-artifact@v4
+      with:
+        name: viam-agent-windows
+        path: bin/viam-agent-*-windows-x86_64
+    - uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+    - uses: google-github-actions/setup-gcloud@v2
+    # Scoped to the versioned artifacts on purpose. `make all` also drops
+    # bin/viam-agent-stable-* copies (Makefile:51), and stable tracks the newest
+    # release, not the one being repaired — uploading them would roll stable
+    # back to an older tag. If the repaired version is also the current stable,
+    # refresh that separately.
+    - name: Upload binaries and manifests to GCS
+      run: |
+        gsutil -h "Cache-Control:no-cache" cp bin/viam-agent-${{ inputs.version }}-* gs://packages.viam.com/apps/viam-agent/
+        gsutil -h "Cache-Control:no-cache" cp etc/viam-agent-*.json gs://packages.viam.com/apps/viam-subsystems/
+    - name: Verify
+      run: ./verify-manifests.sh --version "${{ inputs.version }}"
+
+  rebuild-msi:
+    name: Rebuild and replace MSI
+    needs: rebuild
+    if: inputs.mode == 'rebuild'
+    runs-on: windows-2022
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.version }}
+    - uses: actions/download-artifact@v4
+      with:
+        name: viam-agent-windows
+        path: msi
+    - name: Build MSI
+      shell: bash
+      run: |
+        mv msi/viam-agent-${{ inputs.version }}-windows-x86_64 msi/viam-agent-from-installer.exe
+        dotnet tool restore
+        dotnet build msi -c Release
+        mv msi/bin/x64/Release/en-US/Package.msi "viam-agent-${{ inputs.version }}-windows-x86_64.msi"
+    - name: Sign MSI
+      uses: ./.github/actions/sign-windows
+      with:
+        files: 'viam-agent-*-windows-x86_64.msi'
+    - uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+    - uses: google-github-actions/setup-gcloud@v2
+    # Versioned MSI only. The release path also refreshes
+    # viam-agent-stable-windows-x86_64.msi, but that tracks the newest release
+    # rather than the tag being repaired, so it is deliberately left alone here.
+    - name: Upload MSI to GCS
+      shell: bash
+      run: gsutil -h "Cache-Control:no-cache" cp "viam-agent-${{ inputs.version }}-windows-x86_64.msi" gs://packages.viam.com/apps/viam-agent/

--- a/.github/workflows/verify-manifests.yaml
+++ b/.github/workflows/verify-manifests.yaml
@@ -1,0 +1,51 @@
+name: Verify Manifests
+
+# On-demand sweep for manifests whose sha256 does not match the binary their
+# upload-path points at, which leaves every agent on that version rejecting its
+# download and retrying forever.
+#
+# Deliberately not scheduled. Test and Build verifies the version it just
+# published, after publishing it, so any run that writes a manifest re-reads it
+# and a clobber is caught by whichever run wrote last. That leaves only writes no
+# workflow run made or verified — a manifest corrected by hand, or a job killed
+# between its upload and its check — which is what this is for. It is also the
+# only way to cover prerelease manifests or the full history, neither of which
+# the per-run check looks at.
+
+on:
+  workflow_dispatch:
+    inputs:
+      count:
+        description: 'Most recently written manifests to check (0 = all)'
+        default: '20'
+        type: string
+      include_prerelease:
+        description: 'Also check -dev./-pr. manifests'
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify published manifests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Verify
+      run: |
+        set -o pipefail
+        ARGS=(--count "${{ inputs.count || '20' }}")
+        if [ "${{ inputs.include_prerelease }}" = "true" ]; then
+          ARGS+=(--include-prerelease)
+        fi
+        ./verify-manifests.sh "${ARGS[@]}" | tee /tmp/verify.log
+    - name: Summarize
+      if: always()
+      run: |
+        {
+          echo '```'
+          cat /tmp/verify.log
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -127,6 +127,7 @@ jobs:
         credentials_json: ${{ secrets.GCP_CREDENTIALS }}
     - uses: google-github-actions/setup-gcloud@v2
     - name: Upload binaries to GCS (Release)
+      id: upload_release
       if: github.event_name == 'release'
       run: |
         gsutil -h "Cache-Control:no-cache" cp bin/viam-agent-* install.sh uninstall.sh preinstall.sh gs://packages.viam.com/apps/viam-agent/
@@ -141,10 +142,26 @@ jobs:
     # artifact whose bytes differ between two builds of the same commit. The release
     # run already publishes these artifacts, so there is nothing to add here.
     - name: Upload binaries to GCS (Prerelease)
+      id: upload_prerelease
       if: github.event_name != 'release' && github.event_name != 'pull_request' && contains(steps.version.outputs.value, '-dev.')
       run: |
         gsutil -h "Cache-Control:no-cache" cp bin/viam-agent-* gs://packages.viam.com/apps/viam-agent/prerelease/
         gsutil -h "Cache-Control:no-cache" cp etc/viam-agent-*.json gs://packages.viam.com/apps/viam-subsystems/
+    # Every manifest this run wrote has to advertise the sha256 of the object its
+    # upload-path names. Because this runs after the upload, any run that writes
+    # a manifest also re-reads it afterwards, so the last writer in a race always
+    # inspects the state it left behind. That is what makes detection independent
+    # of which run wins and of how far apart they land.
+    #
+    # Gated on the upload steps' outcome rather than on a copy of their `if`
+    # conditions, deliberately. Restating `contains(version, '-dev.')` here would
+    # tie this check to the same predicate that guards the prerelease upload, so
+    # a regression in that guard would skip the check in exactly the run that
+    # just clobbered a manifest. Keying off what actually ran instead means a run
+    # that publishes always verifies, however it came to publish.
+    - name: Verify manifests published by this run
+      if: steps.upload_release.outcome == 'success' || steps.upload_prerelease.outcome == 'success'
+      run: ./verify-manifests.sh --version "${{ steps.version.outputs.value }}"
     - name: Upload binaries to GCS (PR dev release)
       if: github.event_name == 'pull_request'
       run: |

--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ The makefile will attempt to get a tagged version from Git. If you want to manua
 Note that there is no "v" in the actual version, though it is expected in git. E.g. a git tag of `v0.1.2` becomes `TAG_VERSION=0.1.2`  
 Ex: `make all TAG_VERSION=0.1.2`
 
+### Release Artifact Verification
+Each published manifest in `apps/viam-subsystems/` advertises a sha256 that must match the binary its `upload-path` names. The manifest and the binary are written by two separate `gsutil` calls, so concurrent runs building the same version can leave a manifest describing a binary nobody can download — agents targeting that version then reject the download and retry indefinitely.
+
+`./verify-manifests.sh` checks that they agree. It reads published state only, so no credentials are needed:
+
+```bash
+./verify-manifests.sh --version v1.0.1   # every platform for one version
+./verify-manifests.sh --count 20         # the 20 most recently written manifests
+./verify-manifests.sh --count 0          # every release manifest
+```
+
+Test and Build runs `--version` against whatever it just published, so a run that writes a manifest always re-reads it. The **Verify Manifests** workflow runs sweeps on demand, for prereleases, full history, or writes made outside CI.
+
+When a mismatch is found, the **Fix Manifest** workflow repairs it. Pick the mode by deciding what the object at `upload-path` actually is: `manifest` when the published binary is the artifact you meant to ship and only the checksum is wrong, `rebuild` when the binary itself is wrong and should be rebuilt from the tag. Note that neither repair unsticks machines that already cached the bad checksum, since `version_control.go` returns early on an unchanged version string — those need a version bump or a cache clear.
+
 ### DevMode
 Agent can be run directly (`./viam-agent`) outside of systemd for local development purposes. It will only manage viam-server by default. Network and system configuration management can be enabled with `--enable-networking` and `--enable-syscfg`. `--viam-dir` can be used to override the default `/opt/viam` location. See `--help` for the full list of options.
 

--- a/verify-manifests.sh
+++ b/verify-manifests.sh
@@ -75,6 +75,12 @@ fi
 
 tmpdir=""
 if [ "$fix_mode" = true ]; then
+	# A sweep has no operator judgement behind it, and --fix is a one-way door
+	# per manifest. Repair one version you have looked at.
+	if [ -z "$version_filter" ]; then
+		echo "--fix repairs one version at a time; pass --version" >&2
+		exit 2
+	fi
 	if ! command -v gsutil >/dev/null; then
 		echo "--fix needs gsutil on PATH, authenticated for gs://$BUCKET" >&2
 		exit 2

--- a/verify-manifests.sh
+++ b/verify-manifests.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+
+# Verify that published viam-agent manifests advertise the sha256 of the object
+# their upload-path actually points at.
+#
+# The manifest and the binary it describes are written by two separate gsutil
+# calls, so concurrent runs building the same version can interleave them and
+# leave a manifest describing a binary nobody can download. When that happens
+# every agent targeting that version rejects its download and retries forever
+# (see v1.0.1 windows), so a mismatch is worth failing loudly over.
+
+set -euo pipefail
+
+BUCKET="packages.viam.com"
+MANIFEST_DIR="apps/viam-subsystems"
+PREFIX="$MANIFEST_DIR/viam-agent-"
+BASE_URL="https://storage.googleapis.com"
+PLATFORMS="x86_64|aarch64|windows-x86_64|darwin-aarch64"
+
+usage() {
+	cat <<'EOF'
+Usage:
+  verify-manifests.sh --version v1.0.1       every platform for one version
+  verify-manifests.sh --count 20             the 20 most recently written manifests
+  verify-manifests.sh --count 0              every release manifest
+  verify-manifests.sh --count 0 --include-prerelease   ... plus -dev./-pr.
+  verify-manifests.sh --version v1.0.1 --fix rewrite mismatched manifests
+
+--fix rewrites a mismatched manifest's sha256 to the published binary's and
+re-uploads it, and needs gsutil authenticated for the bucket. It is only the
+correct repair when the published binary is the artifact you meant to ship; if
+the binary is what is wrong, rebuild the tag instead. Nothing passes --fix
+automatically -- the Fix Manifest workflow is the deliberate entry point.
+EOF
+}
+
+count=""
+include_prerelease=false
+version_filter=""
+fix_mode=false
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--count)
+		count="${2:?--count needs a value}"
+		shift
+		;;
+	--include-prerelease)
+		include_prerelease=true
+		;;
+	--version)
+		version_filter="${2:?--version needs a value}"
+		shift
+		;;
+	--fix)
+		fix_mode=true
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "unknown argument: $1" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
+	shift
+done
+
+if [ -n "$version_filter" ] && [ -n "$count" ]; then
+	echo "--version and --count select different things; pass only one" >&2
+	exit 2
+fi
+
+tmpdir=""
+if [ "$fix_mode" = true ]; then
+	if ! command -v gsutil >/dev/null; then
+		echo "--fix needs gsutil on PATH, authenticated for gs://$BUCKET" >&2
+		exit 2
+	fi
+	tmpdir=$(mktemp -d)
+	trap 'rm -rf "$tmpdir"' EXIT
+fi
+
+sha256() {
+	if command -v sha256sum >/dev/null; then
+		sha256sum
+	else
+		shasum -a 256
+	fi
+}
+
+# Emit "<updated>\t<object name>" for every object under a prefix. Anonymous
+# reads are enough; no gcloud auth required.
+list_objects() {
+	local prefix="$1" token="" url page
+	while :; do
+		url="$BASE_URL/storage/v1/b/$BUCKET/o?prefix=$prefix&fields=items(name,updated),nextPageToken&maxResults=1000"
+		if [ -n "$token" ]; then
+			url="$url&pageToken=$token"
+		fi
+		page=$(curl -fsS --retry 3 -H "Cache-Control: no-cache" "$url")
+		jq -r '.items[]? | "\(.updated)\t\(.name)"' <<<"$page"
+		token=$(jq -r '.nextPageToken // empty' <<<"$page")
+		if [ -z "$token" ]; then
+			break
+		fi
+	done
+}
+
+if [ -n "$version_filter" ]; then
+	# Listed under the version's own prefix, so this is one small API call rather
+	# than a full bucket listing. The platform-suffix anchor still matters: the
+	# prefix v1.0.1- also matches v1.0.1-dev.N, a different set of artifacts.
+	escaped=$(printf '%s' "$version_filter" | sed 's/\./\\./g')
+	candidates=$(list_objects "$PREFIX$version_filter-" | cut -f2 |
+		grep -E "/viam-agent-${escaped}-($PLATFORMS)\.json$" | sort || true)
+else
+	# Newest first by mtime rather than by version: a clobbered manifest gets a
+	# fresh mtime, so the recently-written window is where a race shows up.
+	candidates=$(list_objects "$PREFIX" | sort -r | cut -f2)
+	if [ "$include_prerelease" != true ]; then
+		candidates=$(printf '%s\n' "$candidates" | grep -v -e '-dev\.' -e '-pr\.' || true)
+	fi
+	if [ "${count:-20}" -gt 0 ]; then
+		candidates=$(printf '%s\n' "$candidates" | sed -n "1,${count:-20}p")
+	fi
+fi
+
+if [ -z "$candidates" ]; then
+	echo "no manifests matched gs://$BUCKET/$PREFIX${version_filter}*" >&2
+	exit 1
+fi
+
+names=()
+while IFS= read -r object; do
+	names+=("${object##*/}")
+done <<<"$candidates"
+
+echo "Checking ${#names[@]} manifest(s) in gs://$BUCKET/$MANIFEST_DIR/"
+echo
+
+sha=""
+fix_json=""
+reason_lines=()
+
+# Compare one manifest against the object its upload-path names. Sets `sha` on
+# success, `reason_lines` and `fix_json` on failure.
+check_manifest() {
+	local name="$1" manifest_url manifest want upload_path binary_url got
+	sha=""
+	fix_json=""
+	reason_lines=()
+
+	manifest_url="$BASE_URL/$BUCKET/$MANIFEST_DIR/$name"
+	if ! manifest=$(curl -fsS --retry 3 -H "Cache-Control: no-cache" "$manifest_url"); then
+		reason_lines=("manifest not readable at $manifest_url")
+		return 1
+	fi
+
+	want=$(jq -r '.sha256 // empty' <<<"$manifest")
+	upload_path=$(jq -r '."upload-path" // empty' <<<"$manifest")
+	if [ -z "$want" ] || [ -z "$upload_path" ]; then
+		reason_lines=("manifest is missing sha256 or upload-path")
+		return 1
+	fi
+
+	binary_url="$BASE_URL/$upload_path"
+	if ! got=$(curl -fsSL --retry 3 -H "Cache-Control: no-cache" "$binary_url" | sha256 | cut -d' ' -f1); then
+		reason_lines=("cannot download upload-path $binary_url")
+		return 1
+	fi
+
+	if [ "$want" != "$got" ]; then
+		reason_lines=("manifest sha256 $want" "binary   sha256 $got  ($binary_url)")
+		# Printed, and applied only under --fix. A mismatch looks the same whether
+		# the manifest's sha is wrong or the wrong binary landed at upload-path,
+		# and this script cannot tell which; applying it in the second case
+		# blesses the wrong artifact for every agent on that version.
+		fix_json=$(jq --tab --arg s "$got" '.sha256 = $s' <<<"$manifest")
+		reason_lines+=("" "if the object above is the artifact you meant to publish," "correct the manifest with:" "")
+		while IFS= read -r line; do
+			reason_lines+=("  $line")
+		done <<<"$fix_json"
+		reason_lines+=("" "  gsutil -h \"Cache-Control:no-cache\" cp $name gs://$BUCKET/$MANIFEST_DIR/" "")
+		reason_lines+=("otherwise the binary itself is wrong; see the summary below.")
+		return 1
+	fi
+
+	sha="$want"
+	return 0
+}
+
+failures=0
+for name in "${names[@]}"; do
+	if check_manifest "$name"; then
+		echo "ok    $name  $sha"
+		continue
+	fi
+
+	# An upload writes the binary before the manifest, so re-publishing a version
+	# looks like a mismatch until its manifest lands. Re-check once before
+	# failing; a real mismatch persists.
+	sleep 10
+	if check_manifest "$name"; then
+		echo "ok    $name  $sha  (cleared on re-check, publish was in flight)"
+		continue
+	fi
+
+	# --fix only ever repairs the manifest side, which is safe exactly when the
+	# published binary is the intended artifact. The workflow makes the caller
+	# assert that; the script does not decide it.
+	if [ "$fix_mode" = true ] && [ -n "$fix_json" ]; then
+		echo "fix   $name  rewriting sha256 to $(jq -r '.sha256' <<<"$fix_json")"
+		printf '%s\n' "$fix_json" >"$tmpdir/$name"
+		gsutil -h "Cache-Control:no-cache" cp "$tmpdir/$name" "gs://$BUCKET/$MANIFEST_DIR/$name"
+		if check_manifest "$name"; then
+			echo "ok    $name  $sha  (corrected)"
+			continue
+		fi
+		echo "FAIL  $name  still mismatched after --fix"
+	fi
+
+	echo "FAIL  $name"
+	printf '        %s\n' "${reason_lines[@]}"
+	failures=$((failures + 1))
+done
+
+echo
+if [ "$failures" -gt 0 ]; then
+	echo "$failures of ${#names[@]} manifest(s) do not match the object they point at."
+	echo
+	echo "Repair with the Fix Manifest workflow, choosing the mode that matches"
+	echo "what the object at upload-path actually is:"
+	echo
+	echo "  mode=manifest  The published binary is the artifact you meant to"
+	echo "                 ship and only the sha256 is wrong. Rewrites the"
+	echo "                 manifest as printed above. Binaries are untouched."
+	echo "                 This is the repair for a concurrent-run clobber."
+	echo
+	echo "  mode=rebuild   The binary itself is wrong. Rebuilds the tag and"
+	echo "                 replaces binary, manifest and MSI together. Windows"
+	echo "                 binaries are not reproducible (Authenticode"
+	echo "                 timestamps), so this publishes new bytes rather than"
+	echo "                 restoring the old ones; linux and darwin rebuild"
+	echo "                 byte-identical under -trimpath."
+	echo
+	echo "Either way, agents cache the bad sha in version_cache.json and"
+	echo "version_control.go returns early on an unchanged version string, so"
+	echo "expect a version bump or cache clear to unstick machines that already"
+	echo "pulled it."
+	exit 1
+fi
+echo "All ${#names[@]} manifest(s) match."


### PR DESCRIPTION
## Problem

#280 stopped a release-tagged commit from publishing prerelease artifacts, closing the route by which `viam-agent-v1.0.1-windows-x86_64.json` came to advertise a sha256 no released binary had. But nothing *detects* a manifest/binary disagreement, so if one arises by another route it stays invisible until Windows machines start rejecting downloads and retrying forever.

## What this adds

**`verify-manifests.sh`** reads a published manifest's `sha256`, downloads whatever object its own `upload-path` names, and compares. It never consults a local build — it answers "is the bucket self-consistent?" rather than "does the bucket match me?", which makes it meaningful regardless of which of two racing runs published last. Published reads are anonymous; no credentials except under `--fix`.

```
./verify-manifests.sh --version v1.0.1   # every platform for one version
./verify-manifests.sh --count 20         # the 20 most recently written manifests
./verify-manifests.sh --count 0          # every release manifest
```

**Test and Build** runs it against the version it just published. **Verify Manifests** (dispatch) sweeps on demand. **Fix Manifest** (dispatch) repairs a mismatch in whichever direction is correct.

## Why the check is gated on step outcome

```yaml
if: steps.upload_release.outcome == 'success' || steps.upload_prerelease.outcome == 'success'
```

rather than on a copy of the upload steps' `if` conditions. Restating `contains(version, '-dev.')` would tie the check to the same predicate that guards the prerelease upload, so a regression in that guard would skip the check in exactly the run that just clobbered a manifest.

Keying off what actually ran means any run that publishes also re-reads what it published, so the last writer in a race always inspects the state it left behind. Replaying the original incident, the release run's verify reads the bucket tens of seconds after its upload — well past the losing run's write at +1.6s — and fails on the windows manifest.

## Why Fix Manifest has two modes

A mismatch looks identical whichever side is at fault, and the script has no information to choose:

- **`manifest`** — the published binary is what you meant to ship and only the checksum is wrong. Rewrites the manifest; binaries untouched. This is the repair for a concurrent-run clobber, and the one v1.0.1 needs.
- **`rebuild`** — the binary itself is wrong. Rebuilds the tag, re-signs, replaces binary + manifest + MSI from one build. Windows binaries aren't reproducible (Authenticode timestamps), so this publishes new bytes rather than restoring the old ones.

Applying the wrong one is a one-way door: rewriting the manifest when the *binary* is wrong permanently blesses the wrong artifact, since the checksum then validates. So the script prints the corrected manifest and the operator picks; nothing passes `--fix` automatically.

`rebuild` deliberately does not touch the `stable` aliases — `stable` tracks the newest release, not the tag being repaired.

## Test

Verified against the live production bucket:

| Check | Result |
|---|---|
| `--version v1.0.1` | flags windows, passes the other 3 platforms |
| `--version v1.0.2` | all 4 match |
| `--version v1.0.1-dev.1` | all 4 match (prerelease paths) |
| `--count` sweep | works, ~55s / ~600MB for 20 |

`shfmt -d *.sh` clean, all workflows parse. The dispatch workflows are not exercised end-to-end — they need production bucket credentials.

## Follow-ups, not fixed here

- **v1.0.1's manifest is still wrong in production.** Needs Fix Manifest with `mode=manifest`; its sha should be `8e0c004af9f156f4bdef1ca9cff0bb0544653c17706660deb742909bbd139fc4`.
- **Neither repair unsticks already-affected machines.** `version_control.go:182` returns before assigning `UnpackedSHA` on line 197, so a corrected checksum for an unchanged version string is never re-read.
- **PR dev-release manifests have a broken `upload-path`.** `manifest.sh`'s version regex doesn't recognise `-pr.`, so PR manifests get a release-path `upload-path` while their binaries go to `prerelease/pr-N/`. Same underlying flaw as the v1.0.1 bug, still latent — PR runs are excluded from the check for this reason.
- **Neither dispatch workflow has an approval gate** beyond a typed confirmation. If there's a GitHub environment with required reviewers, putting `environment:` on the writing jobs would be stronger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
