### PR TITLE
RSDK-14355: Better handling of updates to already cached versions

### DIFF
--- a/version_control.go
+++ b/version_control.go
@@ -179,12 +179,13 @@ func (c *VersionCache) Update(cfg *pb.UpdateInfo, binary string) error {
 		return errw.Errorf("empty string given as version for %v", binary)
 	}
 
-	if newVersion == data.TargetVersion {
-		return nil
+	newTarget := newVersion != data.TargetVersion
+	if newTarget {
+		// only reset on a new target, so a broken custom URL isn't retried every poll
+		data.brokenTarget = false
 	}
 
 	data.TargetVersion = newVersion
-	data.brokenTarget = false
 	info, ok := data.Versions[newVersion]
 	if !ok {
 		info = &VersionInfo{}
@@ -194,7 +195,13 @@ func (c *VersionCache) Update(cfg *pb.UpdateInfo, binary string) error {
 	info.Version = newVersion
 	info.URL = cfg.GetUrl()
 	info.SymlinkPath = path.Join(utils.ViamDirs.Bin, cfg.GetFilename())
-	info.UnpackedSHA = cfg.GetSha256()
+	// The config never carries a real sha for a custom URL, so a steady-state poll
+	// must preserve the locally computed one (see UpdateBinary) or we'd redownload
+	// every cycle. Every other case takes the config's value; for a re-targeted
+	// custom URL that's empty, forcing the re-fetch that picks up a rebuilt binary.
+	if newTarget || !strings.HasPrefix(newVersion, "customURL+") {
+		info.UnpackedSHA = cfg.GetSha256()
+	}
 
 	return c.save()
 }

--- a/version_control_test.go
+++ b/version_control_test.go
@@ -17,10 +17,112 @@ import (
 
 	"github.com/viamrobotics/agent/subsystems/viamserver"
 	"github.com/viamrobotics/agent/utils"
+	pb "go.viam.com/api/app/agent/v1"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/test"
 	goutils "go.viam.com/utils"
 )
+
+func TestUpdate(t *testing.T) {
+	utils.MockAndCreateViamDirs(t)
+	logger := logging.NewTestLogger(t)
+
+	// sha of an empty file
+	goodSHA, err := hex.DecodeString("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+	test.That(t, err, test.ShouldBeNil)
+
+	td := t.TempDir()
+	binPath := filepath.Join(td, "fake-binary")
+	f, err := os.Create(binPath)
+	test.That(t, err, test.ShouldBeNil)
+	f.Close()
+
+	vc := NewVersionCache(logger)
+
+	t.Run("corrected-sha-is-picked-up", func(t *testing.T) {
+		err := vc.Update(&pb.UpdateInfo{
+			Version:  "0.90.0",
+			Url:      "file://" + binPath,
+			Filename: "viam-server",
+			Sha256:   []byte("WRONG_SHA_WRONG_SHA_WRONG_SHA_WW"),
+		}, viamserver.SubsysName)
+		test.That(t, err, test.ShouldBeNil)
+
+		// the download succeeds but the checksum comparison fails
+		_, err = vc.UpdateBinary(t.Context(), viamserver.SubsysName)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "sha256")
+
+		// the manifest is corrected in place: same version string, fixed sha
+		err = vc.Update(&pb.UpdateInfo{
+			Version:  "0.90.0",
+			Url:      "file://" + binPath,
+			Filename: "viam-server",
+			Sha256:   goodSHA,
+		}, viamserver.SubsysName)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, vc.ViamServer.Versions["0.90.0"].UnpackedSHA, test.ShouldResemble, goodSHA)
+
+		// the already-downloaded binary now matches, so the update completes
+		needsRestart, err := vc.UpdateBinary(t.Context(), viamserver.SubsysName)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, needsRestart, test.ShouldBeTrue)
+		test.That(t, vc.ViamServer.CurrentVersion, test.ShouldEqual, "0.90.0")
+	})
+
+	t.Run("unchanged-update-leaves-brokenTarget", func(t *testing.T) {
+		vc.ViamServer.brokenTarget = true
+		err := vc.Update(&pb.UpdateInfo{
+			Version:  "0.90.0",
+			Url:      "file://" + binPath,
+			Filename: "viam-server",
+			Sha256:   goodSHA,
+		}, viamserver.SubsysName)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, vc.ViamServer.brokenTarget, test.ShouldBeTrue)
+		vc.ViamServer.brokenTarget = false
+	})
+
+	t.Run("customURL-sha-not-overwritten", func(t *testing.T) {
+		customURL := "file://" + binPath
+		err := vc.Update(&pb.UpdateInfo{
+			Version:  "customURL",
+			Url:      customURL,
+			Filename: "viam-server",
+		}, viamserver.SubsysName)
+		test.That(t, err, test.ShouldBeNil)
+
+		// simulate UpdateBinary having stored the locally computed sha
+		info := vc.ViamServer.Versions["customURL+"+customURL]
+		localSHA := []byte("locally-computed-sha-32-bytes-xx")
+		info.UnpackedSHA = localSHA
+
+		err = vc.Update(&pb.UpdateInfo{
+			Version:  "customURL",
+			Url:      customURL,
+			Filename: "viam-server",
+			Sha256:   []byte("some-serverside-value-32-bytes-x"),
+		}, viamserver.SubsysName)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, info.UnpackedSHA, test.ShouldResemble, localSHA)
+	})
+
+	t.Run("retarget-customURL-clears-sha", func(t *testing.T) {
+		customURL := "file://" + binPath
+		info := vc.ViamServer.Versions["customURL+"+customURL]
+		info.UnpackedSHA = []byte("locally-computed-sha-32-bytes-xx")
+
+		// switching away and back is the dev workflow for picking up a rebuilt
+		// binary at the same URL; it must clear the sha to force a re-fetch
+		for _, update := range []*pb.UpdateInfo{
+			{Version: "0.90.0", Url: "file://" + binPath, Filename: "viam-server", Sha256: goodSHA},
+			{Version: "customURL", Url: customURL, Filename: "viam-server"},
+		} {
+			test.That(t, vc.Update(update, viamserver.SubsysName), test.ShouldBeNil)
+		}
+		test.That(t, info.UnpackedSHA, test.ShouldBeNil)
+	})
+}
 
 func TestUpdateBinary(t *testing.T) {
 	utils.MockAndCreateViamDirs(t)


### PR DESCRIPTION
Change `version_control.Update` to better handle cases where the new version string coming in is equal to the current cached version, but the new version info differs (because of an app-side change like a corrected binary for a given version, for example).

Previously, `Update` would return early if the new version string were equal to the cached version string, so the rest of the version cache would never be updated. So we would never be able to "fix" a bad binary upload without uploading a new version number.

This change allows agent to take on new version metadata for the same version string, and the new metadata will cause agent to redownload the binary. I don't think there's any real cost to getting rid of the short circuit.