### PR TITLE
Add more detailed os update logging

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -1017,13 +1017,11 @@ func (m *Manager) CheckIfOSNeedsReboot(ctx context.Context) {
 	} else {
 		rebootCmd = exec.CommandContext(ctx, "systemctl", "reboot")
 	}
-	m.logger.Activity(syscfg.UpdateActivity, "reboot")
+	m.logger.Activity("system", "reboot", "reason", "os_update")
 	if output, err := rebootCmd.CombinedOutput(); err != nil {
-		m.logger.Activity(syscfg.UpdateActivity, "reboot_abort", "error", err, "output", string(output))
+		m.logger.Activity("system", "reboot_abort", "error", err, "output", string(output))
 		return
 	}
-
-	m.logger.Activity("system", "reboot", "reason", "os_update")
 
 	m.Exit("system reboot initiated for OS package updates", "os_reboot")
 }

--- a/manager.go
+++ b/manager.go
@@ -1017,8 +1017,9 @@ func (m *Manager) CheckIfOSNeedsReboot(ctx context.Context) {
 	} else {
 		rebootCmd = exec.CommandContext(ctx, "systemctl", "reboot")
 	}
+	m.logger.Activity(syscfg.UpdateActivity, "reboot")
 	if output, err := rebootCmd.CombinedOutput(); err != nil {
-		m.logger.Errorw("failed to initiate system reboot", "error", err, "output", string(output))
+		m.logger.Activity(syscfg.UpdateActivity, "reboot_abort", "error", err, "output", string(output))
 		return
 	}
 

--- a/subsystems/syscfg/managed_upgrades_apt_linux.go
+++ b/subsystems/syscfg/managed_upgrades_apt_linux.go
@@ -19,9 +19,16 @@ const rebootRequiredPath = "/var/run/reboot-required"
 // installed version is absent for packages being newly installed.
 var aptInstLineRegex = regexp.MustCompile(`^Inst (\S+)(?: \[([^\]]*)\])? \(([^)]*)\)`)
 
-// unattendedDryRunPrefix is the line unattended-upgrade --dry-run prints listing
-// the packages it would install.
-const unattendedDryRunPrefix = "Packages that will be upgraded:"
+// unattendedUpgradeListPrefix is the line unattended-upgrade prints listing the
+// packages it is about to install (or, with --dry-run, would install).
+const unattendedUpgradeListPrefix = "Packages that will be upgraded:"
+
+// aptSettingUpRegex matches the "Setting up <name> (<version>) ..." lines dpkg
+// prints as it configures each package, the per-package record of what a real
+// apt-get upgrade actually installed. The name carries a ":<arch>" qualifier for
+// multi-arch packages, which the simulated upgrade's names don't, so it is
+// matched separately and dropped.
+var aptSettingUpRegex = regexp.MustCompile(`^Setting up ([^\s:]+)(?::\S+)? \(([^)]*)\)`)
 
 type aptPackageManager struct {
 	logger logging.Logger
@@ -89,7 +96,7 @@ func (a aptPackageManager) pendingUpgrades(ctx context.Context, securityOnly boo
 		if err != nil {
 			return nil, err
 		}
-		updates = restrictToNames(candidates, parseUnattendedUpgradeDryRun(string(dryRun)))
+		updates = restrictToNames(candidates, parseUnattendedUpgradeList(string(dryRun)))
 	}
 
 	a.fillPackageSizes(ctx, updates)
@@ -161,18 +168,24 @@ func (a aptPackageManager) fillPackageSizes(ctx context.Context, updates []pendi
 	}
 }
 
-func (a aptPackageManager) runUpgrade(ctx context.Context, securityOnly bool) error {
+// runUpgrade implements [packageManager].
+func (a aptPackageManager) runUpgrade(ctx context.Context, securityOnly bool) ([]pendingUpdate, error) {
 	if securityOnly {
 		return a.runSecurityUpgrade(ctx)
 	}
 	return a.runFullUpgrade(ctx)
 }
 
-func (a aptPackageManager) runFullUpgrade(ctx context.Context) error {
-	return pkgCmd(ctx, a.logger, "apt-get", "upgrade", "-y",
+// runFullUpgrade installs all pending upgrades, returning the packages dpkg's
+// output confirms it set up. Parsed even when the upgrade fails: any "Setting up"
+// line that made it out describes a package that was installed before the batch
+// died.
+func (a aptPackageManager) runFullUpgrade(ctx context.Context) ([]pendingUpdate, error) {
+	output, err := pkgCmdOutput(ctx, a.logger, "apt-get", "upgrade", "-y",
 		"-o", "Dpkg::Options::=--force-confold",
 		"-o", "Dpkg::Options::=--force-confdef",
 	)
+	return parseAptUpgradeOutput(output), err
 }
 
 func (a aptPackageManager) ensureUnattendedUpgrades(ctx context.Context) error {
@@ -206,9 +219,23 @@ func (a aptPackageManager) writeSecurityOrigins(ctx context.Context) error {
 	return nil
 }
 
-func (a aptPackageManager) runSecurityUpgrade(ctx context.Context) error {
-	_, err := a.unattendedUpgrade(ctx)
-	return err
+// runSecurityUpgrade installs pending security upgrades via unattended-upgrade,
+// returning the packages its output reports it upgraded. unattended-upgrade
+// prints the list before installing anything and keeps the per-package dpkg
+// output in its own log file, so a failed run proves nothing about what landed
+// and returns no packages.
+func (a aptPackageManager) runSecurityUpgrade(ctx context.Context) ([]pendingUpdate, error) {
+	output, err := a.unattendedUpgrade(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	names := parseUnattendedUpgradeList(string(output))
+	installed := make([]pendingUpdate, 0, len(names))
+	for _, name := range names {
+		installed = append(installed, pendingUpdate{Name: name})
+	}
+	return installed, nil
 }
 
 // unattendedUpgrade runs the unattended-upgrade binary, returning its combined
@@ -296,17 +323,32 @@ func parseAptCacheSizes(output string) map[string]pendingUpdate {
 	return sizes
 }
 
-// parseUnattendedUpgradeDryRun extracts package names from the output of
-// `unattended-upgrade --verbose --dry-run`. Versions aren't reported, so this is
-// names only.
-func parseUnattendedUpgradeDryRun(output string) []string {
+// parseUnattendedUpgradeList extracts package names from the output of
+// `unattended-upgrade --verbose`, with or without --dry-run. Versions aren't
+// reported, so this is names only.
+func parseUnattendedUpgradeList(output string) []string {
 	var updates []string
 	for _, line := range strings.Split(output, "\n") {
 		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, unattendedDryRunPrefix) {
+		if !strings.HasPrefix(line, unattendedUpgradeListPrefix) {
 			continue
 		}
-		updates = append(updates, strings.Fields(strings.TrimPrefix(line, unattendedDryRunPrefix))...)
+		updates = append(updates, strings.Fields(strings.TrimPrefix(line, unattendedUpgradeListPrefix))...)
+	}
+	return updates
+}
+
+// parseAptUpgradeOutput extracts the packages a real (non-simulated) apt-get
+// upgrade installed, by way of the "Setting up" line dpkg prints once a package
+// is unpacked and configured.
+func parseAptUpgradeOutput(output string) []pendingUpdate {
+	var updates []pendingUpdate
+	for _, line := range strings.Split(output, "\n") {
+		match := aptSettingUpRegex.FindStringSubmatch(strings.TrimSpace(line))
+		if match == nil {
+			continue
+		}
+		updates = append(updates, pendingUpdate{Name: match[1], Version: match[2]})
 	}
 	return updates
 }

--- a/subsystems/syscfg/managed_upgrades_apt_linux.go
+++ b/subsystems/syscfg/managed_upgrades_apt_linux.go
@@ -89,7 +89,7 @@ func (a aptPackageManager) pendingUpgrades(ctx context.Context, securityOnly boo
 		if err != nil {
 			return nil, err
 		}
-		updates = restrictToNames(candidates, parseUnattendedUpgradeDryRun(string(dryRun)), categorySecurity)
+		updates = restrictToNames(candidates, parseUnattendedUpgradeDryRun(string(dryRun)))
 	}
 
 	a.fillPackageSizes(ctx, updates)
@@ -108,11 +108,11 @@ func (a aptPackageManager) simulateUpgrade(ctx context.Context) ([]pendingUpdate
 	return parseAptSimulateUpgrade(string(output)), nil
 }
 
-// restrictToNames returns the passed names as updates, in the order given, reusing
-// the detail from candidates for the names found there and tagging every entry
-// with category. Names with no matching candidate still get an entry, so an
-// upgrade the simulation held back is logged rather than silently dropped.
-func restrictToNames(candidates []pendingUpdate, names []string, category string) []pendingUpdate {
+// restrictToNames returns the passed names as updates, in the order given,
+// reusing the detail from candidates for the names found there. Names with no
+// matching candidate still get an entry, so an upgrade the simulation held
+// back is logged rather than silently dropped.
+func restrictToNames(candidates []pendingUpdate, names []string) []pendingUpdate {
 	byName := make(map[string]pendingUpdate, len(candidates))
 	for _, candidate := range candidates {
 		byName[candidate.Name] = candidate
@@ -124,7 +124,6 @@ func restrictToNames(candidates []pendingUpdate, names []string, category string
 		if !ok {
 			update = pendingUpdate{Name: name}
 		}
-		update.Category = category
 		updates = append(updates, update)
 	}
 	return updates

--- a/subsystems/syscfg/managed_upgrades_apt_linux.go
+++ b/subsystems/syscfg/managed_upgrades_apt_linux.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"regexp"
+	"strings"
 
 	errw "github.com/pkg/errors"
 	"github.com/viamrobotics/agent/utils"
@@ -11,6 +13,15 @@ import (
 )
 
 const rebootRequiredPath = "/var/run/reboot-required"
+
+// aptInstLineRegex matches the "Inst <name> [<installed version>] (<candidate
+// version> <origins> [<arch>])" lines emitted by `apt-get --simulate upgrade`. The
+// installed version is absent for packages being newly installed.
+var aptInstLineRegex = regexp.MustCompile(`^Inst (\S+)(?: \[([^\]]*)\])? \(([^)]*)\)`)
+
+// unattendedDryRunPrefix is the line unattended-upgrade --dry-run prints listing
+// the packages it would install.
+const unattendedDryRunPrefix = "Packages that will be upgraded:"
 
 type aptPackageManager struct {
 	logger logging.Logger
@@ -32,7 +43,8 @@ func (a aptPackageManager) lockPaths() []string {
 	return []string{"/var/lib/dpkg/lock-frontend", "/var/lib/dpkg/lock"}
 }
 
-func (a aptPackageManager) runUpgrade(ctx context.Context, securityOnly bool) error {
+// prepare implements [packageManager].
+func (a aptPackageManager) prepare(ctx context.Context, securityOnly bool) error {
 	// Refresh package lists.
 	if err := pkgCmd(ctx, a.logger, "apt-get", "update"); err != nil {
 		return err
@@ -43,6 +55,114 @@ func (a aptPackageManager) runUpgrade(ctx context.Context, securityOnly bool) er
 		return err
 	}
 
+	if securityOnly {
+		// Both the dry run that lists pending upgrades and the real upgrade read this
+		// config, so write it before either of them runs.
+		return a.writeSecurityOrigins(ctx)
+	}
+	return nil
+}
+
+// pendingUpgrades implements [packageManager].
+//
+// Names, versions and the origin the package comes from are read from a simulated
+// upgrade; sizes come from the package cache, since the simulation only reports
+// totals. apt has no update classification beyond the source archive, so Category
+// is "security" for packages coming from a security archive and empty otherwise.
+func (a aptPackageManager) pendingUpgrades(ctx context.Context, securityOnly bool) ([]pendingUpdate, error) {
+	candidates, err := a.simulateUpgrade(ctx)
+	if err != nil {
+		if !securityOnly {
+			return nil, err
+		}
+		// In security mode the simulation only adds detail to the list below, so carry
+		// on without it.
+		a.logger.Debugw("Could not simulate apt upgrade for pending update detail", "err", err)
+	}
+
+	updates := candidates
+	if securityOnly {
+		// unattended-upgrade, not apt-get, decides what a security upgrade installs, so
+		// it has the authoritative list. It reports names only, so pair them up with
+		// the detail from the simulation.
+		dryRun, err := a.unattendedUpgrade(ctx, "--dry-run")
+		if err != nil {
+			return nil, err
+		}
+		updates = restrictToNames(candidates, parseUnattendedUpgradeDryRun(string(dryRun)), categorySecurity)
+	}
+
+	a.fillPackageSizes(ctx, updates)
+	return updates, nil
+}
+
+// simulateUpgrade lists the packages a full upgrade would install, without
+// installing anything.
+func (a aptPackageManager) simulateUpgrade(ctx context.Context) ([]pendingUpdate, error) {
+	cmd := exec.CommandContext(ctx, "apt-get", "--simulate", "upgrade")
+	cmd.Env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, errw.Wrap(err, "simulating apt-get upgrade")
+	}
+	return parseAptSimulateUpgrade(string(output)), nil
+}
+
+// restrictToNames returns the passed names as updates, in the order given, reusing
+// the detail from candidates for the names found there and tagging every entry
+// with category. Names with no matching candidate still get an entry, so an
+// upgrade the simulation held back is logged rather than silently dropped.
+func restrictToNames(candidates []pendingUpdate, names []string, category string) []pendingUpdate {
+	byName := make(map[string]pendingUpdate, len(candidates))
+	for _, candidate := range candidates {
+		byName[candidate.Name] = candidate
+	}
+
+	updates := make([]pendingUpdate, 0, len(names))
+	for _, name := range names {
+		update, ok := byName[name]
+		if !ok {
+			update = pendingUpdate{Name: name}
+		}
+		update.Category = category
+		updates = append(updates, update)
+	}
+	return updates
+}
+
+// fillPackageSizes looks up the download and installed sizes of the passed
+// updates, which a simulated upgrade reports only as totals. Sizes are a logging
+// nicety, so a lookup failure is logged and left as an unknown size rather than
+// failing the upgrade.
+func (a aptPackageManager) fillPackageSizes(ctx context.Context, updates []pendingUpdate) {
+	specs := make([]string, 0, len(updates))
+	for _, update := range updates {
+		if update.Version != "" {
+			specs = append(specs, update.Name+"="+update.Version)
+		}
+	}
+	if len(specs) == 0 {
+		return
+	}
+
+	//nolint: gosec
+	cmd := exec.CommandContext(ctx, "apt-cache", append([]string{"show"}, specs...)...)
+	output, err := cmd.Output()
+	if err != nil {
+		a.logger.Debugw("Could not read pending update sizes from apt-cache", "err", err)
+		return
+	}
+
+	sizes := parseAptCacheSizes(string(output))
+	for i, update := range updates {
+		if size, ok := sizes[update.Name+"="+update.Version]; ok {
+			updates[i].DownloadSize = size.DownloadSize
+			updates[i].InstalledSize = size.InstalledSize
+		}
+	}
+}
+
+func (a aptPackageManager) runUpgrade(ctx context.Context, securityOnly bool) error {
 	if securityOnly {
 		return a.runSecurityUpgrade(ctx)
 	}
@@ -58,6 +178,7 @@ func (a aptPackageManager) runFullUpgrade(ctx context.Context) error {
 
 func (a aptPackageManager) ensureUnattendedUpgrades(ctx context.Context) error {
 	if err := verifyUnattendedUpgrade(ctx); err != nil {
+		a.logger.Infow("Installing unattended-upgrades package", "reason", err)
 		if installErr := doInstall(ctx); installErr != nil {
 			return errw.Wrap(installErr, "installing unattended-upgrades package")
 		}
@@ -68,25 +189,125 @@ func (a aptPackageManager) ensureUnattendedUpgrades(ctx context.Context) error {
 	return nil
 }
 
-func (a aptPackageManager) runSecurityUpgrade(ctx context.Context) error {
-	// Generate and write origins config scoped to security repos only.
+// writeSecurityOrigins scopes unattended-upgrade to the security repos only.
+func (a aptPackageManager) writeSecurityOrigins(ctx context.Context) error {
 	confContents, err := generateOrigins(ctx, true)
 	if err != nil {
 		return errw.Wrap(err, "generating security origins")
 	}
 
-	if _, err := utils.WriteFileIfNew(unattendedUpgradesPath, []byte(confContents)); err != nil {
+	isNew, err := utils.WriteFileIfNew(unattendedUpgradesPath, []byte(confContents))
+	if err != nil {
 		return errw.Wrap(err, "writing unattended-upgrades config")
 	}
+	if isNew {
+		a.logger.Infow("Wrote security-only unattended-upgrades config",
+			"path", unattendedUpgradesPath, "contents", confContents)
+	}
+	return nil
+}
 
-	cmd := exec.CommandContext(ctx, "unattended-upgrade", "--verbose")
+func (a aptPackageManager) runSecurityUpgrade(ctx context.Context) error {
+	_, err := a.unattendedUpgrade(ctx)
+	return err
+}
+
+// unattendedUpgrade runs the unattended-upgrade binary, returning its combined
+// output. Pass --dry-run to list what would be installed without installing it.
+func (a aptPackageManager) unattendedUpgrade(ctx context.Context, extraArgs ...string) ([]byte, error) {
+	args := append([]string{"--verbose"}, extraArgs...)
+	//nolint: gosec
+	cmd := exec.CommandContext(ctx, "unattended-upgrade", args...)
 	cmd.Env = append(os.Environ(),
 		"DEBIAN_FRONTEND=noninteractive",
 		"APT_LISTCHANGES_FRONTEND=none",
 	)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return errw.Wrapf(err, "unattended-upgrade: %s", output)
+		return output, errw.Wrapf(err, "unattended-upgrade %v: %s", args, output)
 	}
-	return nil
+	a.logger.Debugw("unattended-upgrade succeeded", "args", args, "output", string(output))
+	return output, nil
+}
+
+// parseAptSimulateUpgrade extracts the packages to be installed from the output of
+// `apt-get --simulate upgrade`, which reports no sizes.
+func parseAptSimulateUpgrade(output string) []pendingUpdate {
+	var updates []pendingUpdate
+	for _, line := range strings.Split(output, "\n") {
+		match := aptInstLineRegex.FindStringSubmatch(strings.TrimSpace(line))
+		if match == nil {
+			continue
+		}
+		// The parenthesized detail is "<candidate version> <origins...> [<arch>]".
+		detail := strings.Fields(match[3])
+		if len(detail) == 0 {
+			continue
+		}
+		updates = append(updates, pendingUpdate{
+			Name:           match[1],
+			CurrentVersion: match[2],
+			Version:        detail[0],
+			Category:       aptCategory(strings.Join(detail[1:], " ")),
+		})
+	}
+	return updates
+}
+
+// aptCategory classifies an update by the origins it is available from, the only
+// classification apt exposes. Origins look like
+// "Debian-Security:12/stable-security" or "Debian:12.9/stable".
+func aptCategory(origins string) string {
+	if strings.Contains(strings.ToLower(origins), categorySecurity) {
+		return categorySecurity
+	}
+	return ""
+}
+
+// parseAptCacheSizes extracts package sizes from `apt-cache show` output, keyed by
+// the "<name>=<version>" spec that selects that exact package.
+func parseAptCacheSizes(output string) map[string]pendingUpdate {
+	sizes := map[string]pendingUpdate{}
+	// Stanzas, one per package version, are separated by a blank line.
+	for _, stanza := range strings.Split(output, "\n\n") {
+		var name, version string
+		var update pendingUpdate
+		for _, line := range strings.Split(stanza, "\n") {
+			field, value, found := strings.Cut(line, ": ")
+			if !found {
+				continue
+			}
+			value = strings.TrimSpace(value)
+			switch field {
+			case "Package":
+				name = value
+			case "Version":
+				version = value
+			case "Size":
+				update.DownloadSize = parseSize(value)
+			case "Installed-Size":
+				// Unlike Size, which is in bytes, Installed-Size is in kibibytes.
+				update.InstalledSize = parseSize(value) * 1024
+			}
+		}
+		if name != "" && version != "" {
+			sizes[name+"="+version] = update
+		}
+	}
+	return sizes
+}
+
+// parseUnattendedUpgradeDryRun extracts package names from the output of
+// `unattended-upgrade --verbose --dry-run`. Versions aren't reported, so this is
+// names only.
+func parseUnattendedUpgradeDryRun(output string) []string {
+	var updates []string
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, unattendedDryRunPrefix) {
+			continue
+		}
+		updates = append(updates, strings.Fields(strings.TrimPrefix(line, unattendedDryRunPrefix))...)
+	}
+	return updates
 }

--- a/subsystems/syscfg/managed_upgrades_common.go
+++ b/subsystems/syscfg/managed_upgrades_common.go
@@ -1,8 +1,11 @@
 package syscfg
 
 import (
+	"context"
 	"errors"
 	"slices"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -114,6 +117,118 @@ func logManagedUpgradesStarted(logger logging.Logger, mode string, interval time
 		"os_auto_upgrade_type", mode,
 		"check_interval", interval,
 	)
+}
+
+// pendingUpdate describes a single update that a managed upgrade is about to
+// install, as reported by the platform's package manager.
+//
+// Package managers differ in what they report, so only Name is guaranteed to be
+// populated. The remaining fields carry whatever the underlying tool exposes:
+// sizes are zero and Category is empty when it isn't available. See each
+// packageManager's pendingUpgrades implementation for what a given platform fills
+// in.
+//
+// The whole struct is logged as-is, so the json tags decide what the fields are
+// called in the logs. Everything the package manager didn't report is omitted
+// rather than logged as an empty string or a zero size.
+type pendingUpdate struct {
+	// Name identifies the package, including its architecture when the package
+	// manager reports one.
+	Name string `json:"name"`
+	// Version is the version being installed.
+	Version string `json:"version,omitempty"`
+	// CurrentVersion is the installed version being replaced, and is empty for
+	// packages being installed for the first time.
+	CurrentVersion string `json:"current_version,omitempty"`
+	// DownloadSize is the compressed size fetched from the repository, in bytes.
+	DownloadSize uint64 `json:"download_size,omitempty"`
+	// InstalledSize is the size the package occupies on disk once unpacked, in
+	// bytes.
+	InstalledSize uint64 `json:"installed_size,omitempty"`
+	// Category classifies the update, e.g. "security". Package managers that don't
+	// classify individual packages leave this empty.
+	Category string `json:"category,omitempty"`
+}
+
+// updateSummary describes the updates a managed upgrade is about to install.
+// Listing updates is best effort: when it fails we still attempt the upgrade, and
+// listErr is logged in place of the update list so the logs say why the list is
+// missing rather than implying nothing was pending.
+type updateSummary struct {
+	updates []pendingUpdate
+	listErr error
+}
+
+// sizeSuffixes maps the unit suffixes package managers print sizes with to their
+// multiplier. Both the SI-style ("2.3 M") and binary ("2.3 MiB") spellings appear
+// in practice, and both mean a power of 1024 in this context.
+var sizeSuffixes = []struct {
+	suffix     string
+	multiplier uint64
+}{
+	{"k", 1 << 10},
+	{"m", 1 << 20},
+	{"g", 1 << 30},
+	{"t", 1 << 40},
+}
+
+// parseSize reads a size that a package manager may report either as a plain byte
+// count ("2799652") or as a human readable string ("2.7 M", "2.7 MiB", "2.7MB").
+// It returns 0 for anything it can't make sense of, matching the "size unknown"
+// zero value of [pendingUpdate].
+func parseSize(size string) uint64 {
+	size = strings.ToLower(strings.TrimSpace(size))
+	size = strings.TrimSuffix(strings.TrimSuffix(size, "b"), "i")
+	multiplier := uint64(1)
+	for _, unit := range sizeSuffixes {
+		if strings.HasSuffix(size, unit.suffix) {
+			size = strings.TrimSuffix(size, unit.suffix)
+			multiplier = unit.multiplier
+			break
+		}
+	}
+	value, err := strconv.ParseFloat(strings.TrimSpace(size), 64)
+	if err != nil || value < 0 {
+		return 0
+	}
+	return uint64(value * float64(multiplier))
+}
+
+// logPendingUpdates summarizes the updates about to be installed. Call this
+// immediately before applying them, so a device that hangs or reboots mid-upgrade
+// still leaves behind a record of what it was installing.
+func logPendingUpdates(logger logging.Logger, updates updateSummary, keysAndValues ...any) {
+	if updates.listErr != nil {
+		logger.Warnw("Installing OS updates, but could not determine which ones",
+			append([]any{"update_list_err", updates.listErr}, keysAndValues...)...)
+		return
+	}
+
+	fields := append([]any{"updates", updates.updates}, keysAndValues...)
+	if len(updates.updates) == 0 {
+		logger.Infow("No OS updates pending, nothing to install", fields...)
+		return
+	}
+	logger.Infow("Installing OS updates", fields...)
+}
+
+// logUpgradeResult reports whether the updates summarized by logPendingUpdates
+// were installed successfully. A cancelled ctx means the agent is shutting down
+// and killed the upgrade itself, which isn't an error worth alarming about.
+func logUpgradeResult(ctx context.Context, logger logging.Logger, updates updateSummary, err error, keysAndValues ...any) {
+	fields := []any{"updates", updates.updates}
+	if updates.listErr != nil {
+		fields = append(fields, "update_list_err", updates.listErr)
+	}
+	fields = append(fields, keysAndValues...)
+	switch {
+	case err != nil && ctx.Err() != nil:
+		logger.Warnw("OS update installation interrupted before completing", append(fields, "err", err)...)
+	case err != nil:
+		logger.Errorw("OS update installation failed", append(fields, "err", err)...)
+	default:
+		logger.Infow("OS update installation succeeded", fields...)
+	}
 }
 
 func clampUpgradeInterval(logger logging.Logger, hours float64) time.Duration {

--- a/subsystems/syscfg/managed_upgrades_common.go
+++ b/subsystems/syscfg/managed_upgrades_common.go
@@ -222,13 +222,16 @@ func logPendingUpdates(logger logging.Logger, updates updateSummary, keysAndValu
 	logger.Activity(UpdateActivity, updateActivityStart, fields...)
 }
 
-// logUpgradeResult reports whether the updates summarized by logPendingUpdates
-// were installed successfully. A cancelled ctx means the agent is shutting down
-// and killed the upgrade itself, which isn't an error worth alarming about.
-func logUpgradeResult(ctx context.Context, logger logging.Logger, updates updateSummary, err error, keysAndValues ...any) {
-	fields := []any{"updates", updates.updates}
-	if updates.listErr != nil {
-		fields = append(fields, "update_list_err", updates.listErr)
+// logUpgradeResult reports how the upgrade went, with installed carrying the
+// packages the package manager's output reported actually installing. When the
+// package manager didn't say, the list is omitted entirely rather than logged
+// empty or guessed at: logPendingUpdates already recorded what the upgrade set
+// out to install. A cancelled ctx means the agent is shutting down and killed
+// the upgrade itself, which isn't an error worth alarming about.
+func logUpgradeResult(ctx context.Context, logger logging.Logger, installed []pendingUpdate, err error, keysAndValues ...any) {
+	var fields []any
+	if len(installed) > 0 {
+		fields = append(fields, "updates", installed)
 	}
 	fields = append(fields, keysAndValues...)
 	switch {

--- a/subsystems/syscfg/managed_upgrades_common.go
+++ b/subsystems/syscfg/managed_upgrades_common.go
@@ -20,6 +20,12 @@ const (
 	// by viam-server's maintenance window, instead of waiting for the full
 	// configured interval.
 	maintenanceRetryInterval = 5 * time.Minute
+
+	UpdateActivity         = "os update"
+	updateActivityStart    = "start"
+	updateActivityComplete = "complete"
+	updateActivityFail     = "fail"
+	updateActivityAbort    = "abort"
 )
 
 // errBlockedByMaintenanceWindow is returned by runManagedUpgrade when the
@@ -213,7 +219,7 @@ func logPendingUpdates(logger logging.Logger, updates updateSummary, keysAndValu
 		logger.Infow("No OS updates pending, nothing to install", fields...)
 		return
 	}
-	logger.Infow("Installing OS updates", fields...)
+	logger.Activity(UpdateActivity, updateActivityStart, fields...)
 }
 
 // logUpgradeResult reports whether the updates summarized by logPendingUpdates
@@ -227,11 +233,11 @@ func logUpgradeResult(ctx context.Context, logger logging.Logger, updates update
 	fields = append(fields, keysAndValues...)
 	switch {
 	case err != nil && ctx.Err() != nil:
-		logger.Warnw("OS update installation interrupted before completing", append(fields, "err", err)...)
+		logger.Activity(UpdateActivity, updateActivityAbort, append(fields, "err", err)...)
 	case err != nil:
-		logger.Errorw("OS update installation failed", append(fields, "err", err)...)
+		logger.Activity(UpdateActivity, updateActivityFail, append(fields, "err", err)...)
 	default:
-		logger.Infow("OS update installation succeeded", fields...)
+		logger.Activity(UpdateActivity, updateActivityComplete, fields...)
 	}
 }
 

--- a/subsystems/syscfg/managed_upgrades_common.go
+++ b/subsystems/syscfg/managed_upgrades_common.go
@@ -148,6 +148,10 @@ type pendingUpdate struct {
 	// Category classifies the update, e.g. "security". Package managers that don't
 	// classify individual packages leave this empty.
 	Category string `json:"category,omitempty"`
+	// Result is how far installing this update got, e.g. "Installed" or "Failed".
+	// Only Windows Update reports per-update outcomes; Linux package managers and
+	// pending-update lists leave it empty.
+	Result string `json:"result,omitempty"`
 }
 
 // updateSummary describes the updates a managed upgrade is about to install.

--- a/subsystems/syscfg/managed_upgrades_common.go
+++ b/subsystems/syscfg/managed_upgrades_common.go
@@ -21,11 +21,10 @@ const (
 	// configured interval.
 	maintenanceRetryInterval = 5 * time.Minute
 
-	UpdateActivity         = "os update"
-	updateActivityStart    = "start"
-	updateActivityComplete = "complete"
-	updateActivityFail     = "fail"
-	updateActivityAbort    = "abort"
+	updateActivityStart    = "os_update_start"
+	updateActivityComplete = "os_update_complete"
+	updateActivityFail     = "os_update_fail"
+	updateActivityAbort    = "os_update_abort"
 )
 
 // errBlockedByMaintenanceWindow is returned by runManagedUpgrade when the
@@ -219,7 +218,7 @@ func logPendingUpdates(logger logging.Logger, updates updateSummary, keysAndValu
 		logger.Infow("No OS updates pending, nothing to install", fields...)
 		return
 	}
-	logger.Activity(UpdateActivity, updateActivityStart, fields...)
+	logger.Activity("system", updateActivityStart, fields...)
 }
 
 // logUpgradeResult reports how the upgrade went, with installed carrying the
@@ -236,11 +235,11 @@ func logUpgradeResult(ctx context.Context, logger logging.Logger, installed []pe
 	fields = append(fields, keysAndValues...)
 	switch {
 	case err != nil && ctx.Err() != nil:
-		logger.Activity(UpdateActivity, updateActivityAbort, append(fields, "err", err)...)
+		logger.Activity("system", updateActivityAbort, append(fields, "err", err)...)
 	case err != nil:
-		logger.Activity(UpdateActivity, updateActivityFail, append(fields, "err", err)...)
+		logger.Activity("system", updateActivityFail, append(fields, "err", err)...)
 	default:
-		logger.Activity(UpdateActivity, updateActivityComplete, fields...)
+		logger.Activity("system", updateActivityComplete, fields...)
 	}
 }
 

--- a/subsystems/syscfg/managed_upgrades_common_test.go
+++ b/subsystems/syscfg/managed_upgrades_common_test.go
@@ -59,7 +59,8 @@ func TestPendingUpdatesAreLoggable(t *testing.T) {
 	entries := logs.All()
 	test.That(t, entries, test.ShouldHaveLength, 1)
 	test.That(t, entries[0].Level, test.ShouldEqual, zapcore.InfoLevel)
-	test.That(t, entries[0].Message, test.ShouldEqual, "Installing OS updates")
+	test.That(t, entries[0].ContextMap()["activity"], test.ShouldEqual, UpdateActivity)
+	test.That(t, entries[0].ContextMap()["event"], test.ShouldEqual, updateActivityStart)
 	test.That(t, entries[0].ContextMap()["updates"], test.ShouldResemble, testPendingUpdates)
 	test.That(t, entries[0].ContextMap()["package_manager"], test.ShouldEqual, "apt")
 
@@ -113,9 +114,10 @@ func TestLogUpgradeResult(t *testing.T) {
 
 		entries := logs.All()
 		test.That(t, entries, test.ShouldHaveLength, 1)
-		test.That(t, entries[0].Level, test.ShouldEqual, zapcore.InfoLevel)
-		test.That(t, entries[0].Message, test.ShouldEqual, "OS update installation succeeded")
+		test.That(t, entries[0].ContextMap()["activity"], test.ShouldEqual, UpdateActivity)
+		test.That(t, entries[0].ContextMap()["event"], test.ShouldEqual, updateActivityComplete)
 		test.That(t, entries[0].ContextMap()["updates"], test.ShouldResemble, testPendingUpdates)
+		test.That(t, entries[0].ContextMap()["security_only"], test.ShouldEqual, true)
 		test.That(t, output.String(), test.ShouldContainSubstring, `"name":"libc6"`)
 	})
 
@@ -125,8 +127,8 @@ func TestLogUpgradeResult(t *testing.T) {
 
 		entries := logs.All()
 		test.That(t, entries, test.ShouldHaveLength, 1)
-		test.That(t, entries[0].Level, test.ShouldEqual, zapcore.ErrorLevel)
-		test.That(t, entries[0].Message, test.ShouldEqual, "OS update installation failed")
+		test.That(t, entries[0].ContextMap()["activity"], test.ShouldEqual, UpdateActivity)
+		test.That(t, entries[0].ContextMap()["event"], test.ShouldEqual, updateActivityFail)
 		// The failed run still reports what it was installing.
 		test.That(t, output.String(), test.ShouldContainSubstring, `"name":"libc6"`)
 		test.That(t, output.String(), test.ShouldContainSubstring, "dpkg failed")
@@ -140,9 +142,9 @@ func TestLogUpgradeResult(t *testing.T) {
 
 		entries := logs.All()
 		test.That(t, entries, test.ShouldHaveLength, 1)
-		// The agent killed the upgrade itself, so this isn't an error.
-		test.That(t, entries[0].Level, test.ShouldEqual, zapcore.WarnLevel)
-		test.That(t, entries[0].Message, test.ShouldEqual, "OS update installation interrupted before completing")
+		// The agent killed the upgrade itself, so this is an abort, not a failure.
+		test.That(t, entries[0].ContextMap()["activity"], test.ShouldEqual, UpdateActivity)
+		test.That(t, entries[0].ContextMap()["event"], test.ShouldEqual, updateActivityAbort)
 	})
 }
 

--- a/subsystems/syscfg/managed_upgrades_common_test.go
+++ b/subsystems/syscfg/managed_upgrades_common_test.go
@@ -59,7 +59,7 @@ func TestPendingUpdatesAreLoggable(t *testing.T) {
 	entries := logs.All()
 	test.That(t, entries, test.ShouldHaveLength, 1)
 	test.That(t, entries[0].Level, test.ShouldEqual, zapcore.InfoLevel)
-	test.That(t, entries[0].ContextMap()["activity"], test.ShouldEqual, UpdateActivity)
+	test.That(t, entries[0].ContextMap()["activity"], test.ShouldEqual, "system")
 	test.That(t, entries[0].ContextMap()["event"], test.ShouldEqual, updateActivityStart)
 	test.That(t, entries[0].ContextMap()["updates"], test.ShouldResemble, testPendingUpdates)
 	test.That(t, entries[0].ContextMap()["package_manager"], test.ShouldEqual, "apt")
@@ -114,7 +114,7 @@ func TestLogUpgradeResult(t *testing.T) {
 
 		entries := logs.All()
 		test.That(t, entries, test.ShouldHaveLength, 1)
-		test.That(t, entries[0].ContextMap()["activity"], test.ShouldEqual, UpdateActivity)
+		test.That(t, entries[0].ContextMap()["activity"], test.ShouldEqual, "system")
 		test.That(t, entries[0].ContextMap()["event"], test.ShouldEqual, updateActivityComplete)
 		test.That(t, entries[0].ContextMap()["updates"], test.ShouldResemble, testPendingUpdates)
 		test.That(t, entries[0].ContextMap()["security_only"], test.ShouldEqual, true)
@@ -127,7 +127,7 @@ func TestLogUpgradeResult(t *testing.T) {
 
 		entries := logs.All()
 		test.That(t, entries, test.ShouldHaveLength, 1)
-		test.That(t, entries[0].ContextMap()["activity"], test.ShouldEqual, UpdateActivity)
+		test.That(t, entries[0].ContextMap()["activity"], test.ShouldEqual, "system")
 		test.That(t, entries[0].ContextMap()["event"], test.ShouldEqual, updateActivityFail)
 		// The failed run still reports what it managed to install.
 		test.That(t, output.String(), test.ShouldContainSubstring, `"name":"libc6"`)
@@ -143,7 +143,7 @@ func TestLogUpgradeResult(t *testing.T) {
 		entries := logs.All()
 		test.That(t, entries, test.ShouldHaveLength, 1)
 		// The agent killed the upgrade itself, so this is an abort, not a failure.
-		test.That(t, entries[0].ContextMap()["activity"], test.ShouldEqual, UpdateActivity)
+		test.That(t, entries[0].ContextMap()["activity"], test.ShouldEqual, "system")
 		test.That(t, entries[0].ContextMap()["event"], test.ShouldEqual, updateActivityAbort)
 	})
 

--- a/subsystems/syscfg/managed_upgrades_common_test.go
+++ b/subsystems/syscfg/managed_upgrades_common_test.go
@@ -1,8 +1,14 @@
 package syscfg
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"testing"
 
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	"go.viam.com/rdk/logging"
 	"go.viam.com/test"
 )
 
@@ -15,4 +21,150 @@ func TestUpgradeState(t *testing.T) {
 
 	done()
 	test.That(t, state.running(), test.ShouldBeFalse)
+}
+
+// testPendingUpdates covers a fully populated update and one where the package
+// manager reported nothing but a name.
+var testPendingUpdates = []pendingUpdate{
+	{
+		Name:           "libc6",
+		CurrentVersion: "2.36-9+deb12u7",
+		Version:        "2.36-9+deb12u10",
+		DownloadSize:   2799652,
+		InstalledSize:  13065216,
+		Category:       "security",
+	},
+	{Name: "2024-01 Cumulative Update for Windows 11 (KB5034123)"},
+}
+
+// newObservedLogger returns a logger that both records its entries and renders them
+// the way the console and file appenders a device actually logs through do, so
+// tests can assert on the structured fields and on the resulting log line.
+func newObservedLogger(t *testing.T) (logging.Logger, *observer.ObservedLogs, *bytes.Buffer) {
+	t.Helper()
+	logger, logs := logging.NewObservedTestLogger(t)
+	var output bytes.Buffer
+	logger.AddAppender(logging.NewWriterAppender(&output))
+	return logger, logs, &output
+}
+
+// TestPendingUpdatesAreLoggable checks that the logger can render a
+// []pendingUpdate, which the log sites hand over as a single value for zap to
+// format by reflection. A value zap can't format would otherwise turn the one log
+// line that says what is being installed into a placeholder.
+func TestPendingUpdatesAreLoggable(t *testing.T) {
+	logger, logs, output := newObservedLogger(t)
+	logPendingUpdates(logger, updateSummary{updates: testPendingUpdates}, "package_manager", "apt")
+
+	entries := logs.All()
+	test.That(t, entries, test.ShouldHaveLength, 1)
+	test.That(t, entries[0].Level, test.ShouldEqual, zapcore.InfoLevel)
+	test.That(t, entries[0].Message, test.ShouldEqual, "Installing OS updates")
+	test.That(t, entries[0].ContextMap()["updates"], test.ShouldResemble, testPendingUpdates)
+	test.That(t, entries[0].ContextMap()["package_manager"], test.ShouldEqual, "apt")
+
+	// Fields that fail to serialize are quietly replaced with a "logging_err" field
+	// rather than failing the write, so assert the rendered line carries the detail.
+	line := output.String()
+	test.That(t, line, test.ShouldNotContainSubstring, "logging_err")
+	test.That(t, line, test.ShouldContainSubstring, `"name":"libc6"`)
+	test.That(t, line, test.ShouldContainSubstring, `"version":"2.36-9+deb12u10"`)
+	test.That(t, line, test.ShouldContainSubstring, `"current_version":"2.36-9+deb12u7"`)
+	test.That(t, line, test.ShouldContainSubstring, `"download_size":2799652`)
+	test.That(t, line, test.ShouldContainSubstring, `"installed_size":13065216`)
+	test.That(t, line, test.ShouldContainSubstring, `"category":"security"`)
+	test.That(t, line, test.ShouldContainSubstring, "KB5034123")
+
+	// Fields the package manager didn't report are left out entirely.
+	test.That(t, line, test.ShouldNotContainSubstring, `"version":""`)
+	test.That(t, line, test.ShouldNotContainSubstring, `"download_size":0`)
+	test.That(t, line, test.ShouldNotContainSubstring, `"category":""`)
+}
+
+func TestLogPendingUpdates(t *testing.T) {
+	t.Run("nothing pending", func(t *testing.T) {
+		logger, logs, _ := newObservedLogger(t)
+		logPendingUpdates(logger, updateSummary{})
+
+		entries := logs.All()
+		test.That(t, entries, test.ShouldHaveLength, 1)
+		test.That(t, entries[0].Level, test.ShouldEqual, zapcore.InfoLevel)
+		test.That(t, entries[0].Message, test.ShouldEqual, "No OS updates pending, nothing to install")
+	})
+
+	t.Run("listing failed", func(t *testing.T) {
+		logger, logs, output := newObservedLogger(t)
+		logPendingUpdates(logger, updateSummary{listErr: errors.New("apt-get exploded")})
+
+		entries := logs.All()
+		test.That(t, entries, test.ShouldHaveLength, 1)
+		// A failed listing is a warning: the upgrade still runs, but we've lost the
+		// record of what it installs.
+		test.That(t, entries[0].Level, test.ShouldEqual, zapcore.WarnLevel)
+		test.That(t, entries[0].Message, test.ShouldEqual, "Installing OS updates, but could not determine which ones")
+		test.That(t, output.String(), test.ShouldContainSubstring, "apt-get exploded")
+	})
+}
+
+func TestLogUpgradeResult(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		logger, logs, output := newObservedLogger(t)
+		logUpgradeResult(t.Context(), logger, updateSummary{updates: testPendingUpdates}, nil, "security_only", true)
+
+		entries := logs.All()
+		test.That(t, entries, test.ShouldHaveLength, 1)
+		test.That(t, entries[0].Level, test.ShouldEqual, zapcore.InfoLevel)
+		test.That(t, entries[0].Message, test.ShouldEqual, "OS update installation succeeded")
+		test.That(t, entries[0].ContextMap()["updates"], test.ShouldResemble, testPendingUpdates)
+		test.That(t, output.String(), test.ShouldContainSubstring, `"name":"libc6"`)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		logger, logs, output := newObservedLogger(t)
+		logUpgradeResult(t.Context(), logger, updateSummary{updates: testPendingUpdates}, errors.New("dpkg failed"))
+
+		entries := logs.All()
+		test.That(t, entries, test.ShouldHaveLength, 1)
+		test.That(t, entries[0].Level, test.ShouldEqual, zapcore.ErrorLevel)
+		test.That(t, entries[0].Message, test.ShouldEqual, "OS update installation failed")
+		// The failed run still reports what it was installing.
+		test.That(t, output.String(), test.ShouldContainSubstring, `"name":"libc6"`)
+		test.That(t, output.String(), test.ShouldContainSubstring, "dpkg failed")
+	})
+
+	t.Run("interrupted by shutdown", func(t *testing.T) {
+		logger, logs, _ := newObservedLogger(t)
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		logUpgradeResult(ctx, logger, updateSummary{updates: testPendingUpdates}, errors.New("signal: killed"))
+
+		entries := logs.All()
+		test.That(t, entries, test.ShouldHaveLength, 1)
+		// The agent killed the upgrade itself, so this isn't an error.
+		test.That(t, entries[0].Level, test.ShouldEqual, zapcore.WarnLevel)
+		test.That(t, entries[0].Message, test.ShouldEqual, "OS update installation interrupted before completing")
+	})
+}
+
+func TestParseSize(t *testing.T) {
+	for _, tc := range []struct {
+		size     string
+		expected uint64
+	}{
+		{"2799652", 2799652},
+		{"0", 0},
+		{"1.4 M", 1468006},
+		{"1.4M", 1468006},
+		{"1.4 MiB", 1468006},
+		{"108MB", 113246208},
+		{" 12 k ", 12288},
+		{"3.5 G", 3758096384},
+		{"2 T", 2199023255552},
+		// Unparseable sizes read as "unknown" rather than a wrong number.
+		{"", 0},
+		{"unknown", 0},
+		{"-5 M", 0},
+	} {
+		test.That(t, parseSize(tc.size), test.ShouldEqual, tc.expected)
+	}
 }

--- a/subsystems/syscfg/managed_upgrades_common_test.go
+++ b/subsystems/syscfg/managed_upgrades_common_test.go
@@ -110,7 +110,7 @@ func TestLogPendingUpdates(t *testing.T) {
 func TestLogUpgradeResult(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		logger, logs, output := newObservedLogger(t)
-		logUpgradeResult(t.Context(), logger, updateSummary{updates: testPendingUpdates}, nil, "security_only", true)
+		logUpgradeResult(t.Context(), logger, testPendingUpdates, nil, "security_only", true)
 
 		entries := logs.All()
 		test.That(t, entries, test.ShouldHaveLength, 1)
@@ -123,13 +123,13 @@ func TestLogUpgradeResult(t *testing.T) {
 
 	t.Run("failure", func(t *testing.T) {
 		logger, logs, output := newObservedLogger(t)
-		logUpgradeResult(t.Context(), logger, updateSummary{updates: testPendingUpdates}, errors.New("dpkg failed"))
+		logUpgradeResult(t.Context(), logger, testPendingUpdates, errors.New("dpkg failed"))
 
 		entries := logs.All()
 		test.That(t, entries, test.ShouldHaveLength, 1)
 		test.That(t, entries[0].ContextMap()["activity"], test.ShouldEqual, UpdateActivity)
 		test.That(t, entries[0].ContextMap()["event"], test.ShouldEqual, updateActivityFail)
-		// The failed run still reports what it was installing.
+		// The failed run still reports what it managed to install.
 		test.That(t, output.String(), test.ShouldContainSubstring, `"name":"libc6"`)
 		test.That(t, output.String(), test.ShouldContainSubstring, "dpkg failed")
 	})
@@ -138,13 +138,27 @@ func TestLogUpgradeResult(t *testing.T) {
 		logger, logs, _ := newObservedLogger(t)
 		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
-		logUpgradeResult(ctx, logger, updateSummary{updates: testPendingUpdates}, errors.New("signal: killed"))
+		logUpgradeResult(ctx, logger, testPendingUpdates, errors.New("signal: killed"))
 
 		entries := logs.All()
 		test.That(t, entries, test.ShouldHaveLength, 1)
 		// The agent killed the upgrade itself, so this is an abort, not a failure.
 		test.That(t, entries[0].ContextMap()["activity"], test.ShouldEqual, UpdateActivity)
 		test.That(t, entries[0].ContextMap()["event"], test.ShouldEqual, updateActivityAbort)
+	})
+
+	t.Run("installed packages unknown", func(t *testing.T) {
+		logger, logs, _ := newObservedLogger(t)
+		logUpgradeResult(t.Context(), logger, nil, nil, "security_only", true)
+
+		entries := logs.All()
+		test.That(t, entries, test.ShouldHaveLength, 1)
+		test.That(t, entries[0].ContextMap()["event"], test.ShouldEqual, updateActivityComplete)
+		// With no report of what was installed, the list is omitted entirely rather
+		// than logged as empty; the start entry already says what was pending.
+		_, present := entries[0].ContextMap()["updates"]
+		test.That(t, present, test.ShouldBeFalse)
+		test.That(t, entries[0].ContextMap()["security_only"], test.ShouldEqual, true)
 	})
 }
 

--- a/subsystems/syscfg/managed_upgrades_linux.go
+++ b/subsystems/syscfg/managed_upgrades_linux.go
@@ -100,7 +100,7 @@ func (s *Subsystem) NeedsOSReboot(ctx context.Context) bool {
 
 	// Needed by both checks below: which reboot indicator to read, and which lock
 	// files a transaction would hold.
-	pkgMgr, err := getPackageManager(s.logger)
+	pkgMgr, err := getPackageManager(ctx, s.logger)
 	if err != nil {
 		s.logger.Warnw("Could not detect package manager to check for OS reboot", "err", err)
 		// A reboot already known to be pending still stands: with no package manager
@@ -128,7 +128,7 @@ func (s *Subsystem) NeedsOSReboot(ctx context.Context) bool {
 // getPackageManager returns an implementation of [packageManager] that
 // matches the package manager binaries available on the OS. A variable so tests
 // can substitute a fake.
-var getPackageManager = func(logger logging.Logger) (packageManager, error) {
+var getPackageManager = func(ctx context.Context, logger logging.Logger) (packageManager, error) {
 	type pmOption struct {
 		binary      string
 		constructor func() packageManager
@@ -140,7 +140,10 @@ var getPackageManager = func(logger logging.Logger) (packageManager, error) {
 		},
 		{
 			"dnf",
-			func() packageManager { return rpmPackageManager{logger: logger.Sublogger("dnf"), useDnf: true} },
+			func() packageManager {
+				logger := logger.Sublogger("dnf")
+				return rpmPackageManager{logger: logger, useDnf: true, dnf5: isDnf5(ctx, logger)}
+			},
 		},
 		{
 			"yum",
@@ -176,7 +179,7 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) error {
 	mode := s.cfg.OSAutoUpgradeType
 	s.mu.RUnlock()
 
-	pm, err := getPackageManager(s.logger)
+	pm, err := getPackageManager(ctx, s.logger)
 	if err != nil {
 		s.logger.Warnw("skipping managed OS upgrade", "error", err)
 		return err

--- a/subsystems/syscfg/managed_upgrades_linux.go
+++ b/subsystems/syscfg/managed_upgrades_linux.go
@@ -22,6 +22,11 @@ import (
 	"go.viam.com/rdk/logging"
 )
 
+// categorySecurity is the [pendingUpdate] Category for a security update, and the
+// only category Linux package managers let us identify per package. Windows
+// reports its own category names instead.
+const categorySecurity = "security"
+
 // startManagedUpgrades launches the background goroutine that periodically runs upgrades.
 // Must be called while s.mu is held.
 func (s *Subsystem) startManagedUpgrades(ctx context.Context) {
@@ -177,22 +182,35 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) error {
 		return err
 	}
 
-	s.logger.Infow("Running managed OS package update", "package_manager", pm)
 	securityOnly := mode == utils.OSAutoUpgradeManagedSecurity
+	s.logger.Infow("Running managed OS package update",
+		"package_manager", pm,
+		"os_auto_upgrade_type", mode,
+		"security_only", securityOnly,
+	)
 
-	// Block reboots for the duration of the install: postinst scripts create
+	// Block reboots for the duration of the upgrade cycle: postinst scripts create
 	// /var/run/reboot-required, so the reboot check would otherwise see it while
-	// dpkg is still working through the rest of the batch.
-	err = func() error {
-		upgradeDone := s.upgrade.begin()
-		defer upgradeDone()
-		return pm.runUpgrade(ctx, securityOnly)
-	}()
-	if err != nil {
-		s.logger.Warnw("managed OS upgrade failed", "package_manager", pm, "error", err)
+	// dpkg is still working through the rest of the batch. prepare is covered too,
+	// since it may install helper packages of its own.
+	upgradeDone := s.upgrade.begin()
+	defer upgradeDone()
+
+	if err := pm.prepare(ctx, securityOnly); err != nil {
+		s.logger.Errorw("Failed to refresh OS package metadata, skipping upgrade",
+			"package_manager", pm, "err", err)
 		return err
 	}
-	s.logger.Info("OS package upgrade completed")
+
+	pending, listErr := pm.pendingUpgrades(ctx, securityOnly)
+	updates := updateSummary{updates: pending, listErr: listErr}
+	logPendingUpdates(s.logger, updates, "package_manager", pm, "security_only", securityOnly)
+
+	upgradeErr := pm.runUpgrade(ctx, securityOnly)
+	logUpgradeResult(ctx, s.logger, updates, upgradeErr, "package_manager", pm, "security_only", securityOnly)
+	if upgradeErr != nil {
+		return upgradeErr
+	}
 
 	// Check if a reboot is required.
 	if pm.needsReboot(ctx) {
@@ -215,11 +233,20 @@ func pkgCmd(ctx context.Context, logger logging.Logger, name string, args ...str
 	if err != nil {
 		return fmt.Errorf("%s %v: %w\n%s", name, args, err, output)
 	}
+	logger.Debugw("Package management command succeeded", "cmd", cmd.String(), "output", string(output))
 	return nil
 }
 
 type packageManager interface {
 	fmt.Stringer
+	// prepare refreshes cached package metadata and installs or writes anything
+	// else needed to list and install upgrades. It must run before
+	// pendingUpgrades or runUpgrade, otherwise both work from stale metadata.
+	prepare(ctx context.Context, securityOnly bool) error
+	// pendingUpgrades lists the upgrades that runUpgrade would install, for
+	// logging, filling in as much detail as the package manager reports. Callers
+	// still run the upgrade if this fails.
+	pendingUpgrades(ctx context.Context, securityOnly bool) ([]pendingUpdate, error)
 	runUpgrade(ctx context.Context, securityOnly bool) error
 	needsReboot(ctx context.Context) bool
 	// lockPaths are the files this package manager fcntl-locks for the duration of a

--- a/subsystems/syscfg/managed_upgrades_linux.go
+++ b/subsystems/syscfg/managed_upgrades_linux.go
@@ -142,12 +142,12 @@ var getPackageManager = func(ctx context.Context, logger logging.Logger) (packag
 			"dnf",
 			func() packageManager {
 				logger := logger.Sublogger("dnf")
-				return rpmPackageManager{logger: logger, useDnf: true, dnf5: isDnf5(ctx, logger)}
+				return rpmPackageManager{logger: logger, variant: detectDnfVariant(ctx, logger)}
 			},
 		},
 		{
 			"yum",
-			func() packageManager { return rpmPackageManager{logger: logger.Sublogger("yum"), useDnf: false} },
+			func() packageManager { return rpmPackageManager{logger: logger.Sublogger("yum"), variant: rpmYum} },
 		},
 	}
 	for _, pm := range pms {

--- a/subsystems/syscfg/managed_upgrades_linux.go
+++ b/subsystems/syscfg/managed_upgrades_linux.go
@@ -209,8 +209,9 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) error {
 	updates := updateSummary{updates: pending, listErr: listErr}
 	logPendingUpdates(s.logger, updates, "package_manager", pm.String(), "security_only", securityOnly)
 
-	upgradeErr := pm.runUpgrade(ctx, securityOnly)
-	logUpgradeResult(ctx, s.logger, updates, upgradeErr, "package_manager", pm.String(), "security_only", securityOnly)
+	installed, upgradeErr := pm.runUpgrade(ctx, securityOnly)
+	logUpgradeResult(ctx, s.logger, fillDetailFromPending(installed, pending), upgradeErr,
+		"package_manager", pm.String(), "security_only", securityOnly)
 	if upgradeErr != nil {
 		return upgradeErr
 	}
@@ -229,15 +230,57 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) error {
 // pkgCmd runs a package manager command, setting DEBIAN_FRONTEND=noninteractive
 // to suppress interactive prompts on apt-based systems (ignored elsewhere).
 func pkgCmd(ctx context.Context, logger logging.Logger, name string, args ...string) error {
+	_, err := pkgCmdOutput(ctx, logger, name, args...)
+	return err
+}
+
+// pkgCmdOutput is [pkgCmd] for callers that parse the command's output. The
+// combined output is returned even on failure, carrying whatever the command
+// managed to do before dying.
+func pkgCmdOutput(ctx context.Context, logger logging.Logger, name string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
 	logger.Debugw("Executing package management command", "cmd", cmd.String())
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("%s %v: %w\n%s", name, args, err, output)
+		return string(output), fmt.Errorf("%s %v: %w\n%s", name, args, err, output)
 	}
 	logger.Debugw("Package management command succeeded", "cmd", cmd.String(), "output", string(output))
-	return nil
+	return string(output), nil
+}
+
+// fillDetailFromPending copies the fields only the pre-upgrade listing knows
+// (sizes, category, versions the output didn't report) onto the packages parsed
+// from the upgrade output, matching by name. Installed packages the listing
+// didn't predict, e.g. newly pulled-in dependencies, pass through with whatever
+// the output reported.
+func fillDetailFromPending(installed, pending []pendingUpdate) []pendingUpdate {
+	byName := make(map[string]pendingUpdate, len(pending))
+	for _, update := range pending {
+		byName[update.Name] = update
+	}
+	for i, update := range installed {
+		detail, ok := byName[update.Name]
+		if !ok {
+			continue
+		}
+		if update.Version == "" {
+			installed[i].Version = detail.Version
+		}
+		if update.CurrentVersion == "" {
+			installed[i].CurrentVersion = detail.CurrentVersion
+		}
+		if update.DownloadSize == 0 {
+			installed[i].DownloadSize = detail.DownloadSize
+		}
+		if update.InstalledSize == 0 {
+			installed[i].InstalledSize = detail.InstalledSize
+		}
+		if update.Category == "" {
+			installed[i].Category = detail.Category
+		}
+	}
+	return installed
 }
 
 type packageManager interface {
@@ -250,7 +293,11 @@ type packageManager interface {
 	// logging, filling in as much detail as the package manager reports. Callers
 	// still run the upgrade if this fails.
 	pendingUpgrades(ctx context.Context, securityOnly bool) ([]pendingUpdate, error)
-	runUpgrade(ctx context.Context, securityOnly bool) error
+	// runUpgrade installs the pending upgrades, returning the packages its output
+	// reports were actually installed. The list is best effort: nil when the
+	// output said nothing recognizable, and possibly partial alongside a non-nil
+	// error when the upgrade died partway through.
+	runUpgrade(ctx context.Context, securityOnly bool) ([]pendingUpdate, error)
 	needsReboot(ctx context.Context) bool
 	// lockPaths are the files this package manager fcntl-locks for the duration of a
 	// transaction, used to spot installs the agent did not start.

--- a/subsystems/syscfg/managed_upgrades_linux.go
+++ b/subsystems/syscfg/managed_upgrades_linux.go
@@ -187,7 +187,7 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) error {
 
 	securityOnly := mode == utils.OSAutoUpgradeManagedSecurity
 	s.logger.Infow("Running managed OS package update",
-		"package_manager", pm,
+		"package_manager", pm.String(),
 		"os_auto_upgrade_type", mode,
 		"security_only", securityOnly,
 	)
@@ -201,16 +201,16 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) error {
 
 	if err := pm.prepare(ctx, securityOnly); err != nil {
 		s.logger.Errorw("Failed to refresh OS package metadata, skipping upgrade",
-			"package_manager", pm, "err", err)
+			"package_manager", pm.String(), "err", err)
 		return err
 	}
 
 	pending, listErr := pm.pendingUpgrades(ctx, securityOnly)
 	updates := updateSummary{updates: pending, listErr: listErr}
-	logPendingUpdates(s.logger, updates, "package_manager", pm, "security_only", securityOnly)
+	logPendingUpdates(s.logger, updates, "package_manager", pm.String(), "security_only", securityOnly)
 
 	upgradeErr := pm.runUpgrade(ctx, securityOnly)
-	logUpgradeResult(ctx, s.logger, updates, upgradeErr, "package_manager", pm, "security_only", securityOnly)
+	logUpgradeResult(ctx, s.logger, updates, upgradeErr, "package_manager", pm.String(), "security_only", securityOnly)
 	if upgradeErr != nil {
 		return upgradeErr
 	}

--- a/subsystems/syscfg/managed_upgrades_linux_test.go
+++ b/subsystems/syscfg/managed_upgrades_linux_test.go
@@ -326,21 +326,29 @@ new-pkg.noarch                     2.0-1.fc40              updates
 	test.That(t, parseRPMCheckUpdate(""), test.ShouldBeNil)
 }
 
+// TestRPMVariantString pins the names log fields render for each variant, so a
+// package_manager field never degrades into a bare enum integer.
+func TestRPMVariantString(t *testing.T) {
+	test.That(t, rpmPackageManager{variant: rpmDnf5}.String(), test.ShouldEqual, "rpm(dnf5)")
+	test.That(t, rpmPackageManager{variant: rpmDnf4}.String(), test.ShouldEqual, "rpm(dnf4)")
+	test.That(t, rpmPackageManager{variant: rpmYum}.String(), test.ShouldEqual, "rpm(yum)")
+}
+
 func TestRPMSizeQueryCommand(t *testing.T) {
-	dnf := rpmPackageManager{useDnf: true}
+	dnf := rpmPackageManager{variant: rpmDnf4}
 	test.That(t, dnf.sizeQueryCommand(t.Context()).Args, test.ShouldResemble, []string{
 		"dnf", "repoquery", "-q", "--upgrades", "--queryformat", dnfSizeQueryFormat,
 	})
 
 	// dnf5 stopped printing a newline after each record, so its format has to ask
 	// for one explicitly.
-	dnf5 := rpmPackageManager{useDnf: true, dnf5: true}
+	dnf5 := rpmPackageManager{variant: rpmDnf5}
 	test.That(t, dnf5.sizeQueryCommand(t.Context()).Args, test.ShouldResemble, []string{
 		"dnf", "repoquery", "-q", "--upgrades", "--queryformat", dnfSizeQueryFormat + `\n`,
 	})
 
 	// On yum systems repoquery is a standalone binary, not a yum subcommand.
-	yum := rpmPackageManager{useDnf: false}
+	yum := rpmPackageManager{variant: rpmYum}
 	test.That(t, yum.sizeQueryCommand(t.Context()).Args, test.ShouldResemble, []string{
 		"repoquery", "-q", "--all", "--pkgnarrow=updates", "--queryformat", yumSizeQueryFormat,
 	})

--- a/subsystems/syscfg/managed_upgrades_linux_test.go
+++ b/subsystems/syscfg/managed_upgrades_linux_test.go
@@ -147,17 +147,148 @@ Size: 1414000
 	test.That(t, parseAptCacheSizes(""), test.ShouldBeEmpty)
 }
 
-func TestParseUnattendedUpgradeDryRun(t *testing.T) {
+func TestParseUnattendedUpgradeList(t *testing.T) {
 	output := `Starting unattended upgrades script
 Allowed origins are: origin=Debian,codename=bookworm-security
 Checking: libc6 ([<Origin component:'main' archive:'stable-security'>])
 Packages that will be upgraded: libc6 openssl
 Writing dpkg log to /var/log/unattended-upgrades/unattended-upgrades-dpkg.log
 `
-	test.That(t, parseUnattendedUpgradeDryRun(output), test.ShouldResemble, []string{"libc6", "openssl"})
+	test.That(t, parseUnattendedUpgradeList(output), test.ShouldResemble, []string{"libc6", "openssl"})
 
 	noUpdates := "No packages found that can be upgraded unattended and no pending auto-removals\n"
-	test.That(t, parseUnattendedUpgradeDryRun(noUpdates), test.ShouldBeNil)
+	test.That(t, parseUnattendedUpgradeList(noUpdates), test.ShouldBeNil)
+}
+
+func TestParseAptUpgradeOutput(t *testing.T) {
+	output := `Reading package lists...
+Building dependency tree...
+Calculating upgrade...
+The following packages will be upgraded:
+  libc6 openssl
+2 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
+Get:1 http://deb.debian.org/debian-security bookworm-security/main arm64 libc6 arm64 2.36-9+deb12u10 [2800 kB]
+Preparing to unpack .../libc6_2.36-9+deb12u10_arm64.deb ...
+Unpacking libc6:arm64 (2.36-9+deb12u10) over (2.36-9+deb12u7) ...
+Setting up libc6:arm64 (2.36-9+deb12u10) ...
+Preparing to unpack .../openssl_3.0.15-1~deb12u1_arm64.deb ...
+Unpacking openssl (3.0.15-1~deb12u1) over (3.0.11-1~deb12u2) ...
+Setting up openssl (3.0.15-1~deb12u1) ...
+Processing triggers for libc-bin (2.36-9+deb12u10) ...
+`
+	// The multi-arch ":arm64" qualifier is dropped so names match the pending list.
+	test.That(t, parseAptUpgradeOutput(output), test.ShouldResemble, []pendingUpdate{
+		{Name: "libc6", Version: "2.36-9+deb12u10"},
+		{Name: "openssl", Version: "3.0.15-1~deb12u1"},
+	})
+
+	test.That(t, parseAptUpgradeOutput("0 upgraded, 0 newly installed, 0 to remove.\n"), test.ShouldBeNil)
+}
+
+func TestParseRPMUpgradeOutput(t *testing.T) {
+	t.Run("dnf4 summary sections", func(t *testing.T) {
+		output := `Dependencies resolved.
+================================================================================
+ Package             Arch     Version              Repository     Size
+================================================================================
+Upgrading:
+ kernel-core         x86_64   6.11.4-201.fc40      updates        48 M
+Running transaction
+  Preparing        :                                                        1/1
+  Upgrading        : openssl-libs-1:3.2.2-3.fc40.x86_64                     1/4
+  Verifying        : kernel-core-6.11.4-201.fc40.x86_64                     2/4
+
+Upgraded:
+  kernel-core-6.11.4-201.fc40.x86_64      openssl-libs-1:3.2.2-3.fc40.x86_64
+
+Installed:
+  kernel-6.11.4-201.fc40.x86_64
+
+Removed:
+  old-kernel-core-6.10.0-100.fc40.x86_64
+
+Complete!
+`
+		test.That(t, parseRPMUpgradeOutput(output), test.ShouldResemble, []pendingUpdate{
+			{Name: "kernel-core.x86_64", Version: "6.11.4-201.fc40"},
+			{Name: "openssl-libs.x86_64", Version: "1:3.2.2-3.fc40"},
+			{Name: "kernel.x86_64", Version: "6.11.4-201.fc40"},
+		})
+	})
+
+	t.Run("yum name and version pairs", func(t *testing.T) {
+		output := `Updated:
+  kernel.x86_64 0:3.10.0-1160.el7   openssl-libs.x86_64 1:1.0.2k-19.el7
+
+Complete!
+`
+		test.That(t, parseRPMUpgradeOutput(output), test.ShouldResemble, []pendingUpdate{
+			{Name: "kernel.x86_64", Version: "0:3.10.0-1160.el7"},
+			{Name: "openssl-libs.x86_64", Version: "1:1.0.2k-19.el7"},
+		})
+	})
+
+	t.Run("dnf5 progress lines", func(t *testing.T) {
+		output := `Total size of inbound packages is 2 MiB. Need to download 2 MiB.
+Downloading Packages:
+[1/1] vim-data-2:9.1.866-1.fc41.noarch 100% | 1.2 MiB/s | 1.6 MiB | 00m01s
+Running transaction
+[1/3] Verify package files 100% | 400.0 B/s | 2.0 B | 00m00s
+[2/3] Prepare transaction 100% | 16.0 B/s | 1.0 B | 00m00s
+[3/3] Upgrading vim-data-2:9.1.866-1.fc41.noarch 100% | 7.4 MiB/s | 7.4 MiB | 00m01s
+Complete!
+`
+		test.That(t, parseRPMUpgradeOutput(output), test.ShouldResemble, []pendingUpdate{
+			{Name: "vim-data.noarch", Version: "2:9.1.866-1.fc41"},
+		})
+	})
+
+	test.That(t, parseRPMUpgradeOutput(""), test.ShouldBeNil)
+	test.That(t, parseRPMUpgradeOutput("Nothing to do.\nComplete!\n"), test.ShouldBeNil)
+}
+
+func TestParseRPMFullName(t *testing.T) {
+	update, ok := parseRPMFullName("kernel-core-6.11.4-201.fc40.x86_64")
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, update, test.ShouldResemble, pendingUpdate{Name: "kernel-core.x86_64", Version: "6.11.4-201.fc40"})
+
+	// Epochs ride along inside the version.
+	update, ok = parseRPMFullName("openssl-libs-1:3.2.2-3.fc40.x86_64")
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, update, test.ShouldResemble, pendingUpdate{Name: "openssl-libs.x86_64", Version: "1:3.2.2-3.fc40"})
+
+	// A bare "name.arch" with dashes and digits in the name must not be misread
+	// as carrying a version.
+	_, ok = parseRPMFullName("java-1.8.0-openjdk.x86_64")
+	test.That(t, ok, test.ShouldBeFalse)
+
+	_, ok = parseRPMFullName("kernel.x86_64")
+	test.That(t, ok, test.ShouldBeFalse)
+	_, ok = parseRPMFullName("Complete!")
+	test.That(t, ok, test.ShouldBeFalse)
+}
+
+func TestFillDetailFromPending(t *testing.T) {
+	pending := []pendingUpdate{
+		{
+			Name: "openssl", CurrentVersion: "3.0.11-1~deb12u2", Version: "3.0.15-1~deb12u1",
+			DownloadSize: 1414000, InstalledSize: 1556480, Category: "security",
+		},
+		{Name: "not-installed", Version: "1.0"},
+	}
+	installed := []pendingUpdate{
+		{Name: "openssl", Version: "3.0.15-1~deb12u1"},
+		// A dependency the pending list didn't predict passes through untouched.
+		{Name: "new-dep", Version: "2.0"},
+	}
+
+	test.That(t, fillDetailFromPending(installed, pending), test.ShouldResemble, []pendingUpdate{
+		{
+			Name: "openssl", CurrentVersion: "3.0.11-1~deb12u2", Version: "3.0.15-1~deb12u1",
+			DownloadSize: 1414000, InstalledSize: 1556480, Category: "security",
+		},
+		{Name: "new-dep", Version: "2.0"},
+	})
 }
 
 func TestRestrictToNames(t *testing.T) {

--- a/subsystems/syscfg/managed_upgrades_linux_test.go
+++ b/subsystems/syscfg/managed_upgrades_linux_test.go
@@ -168,13 +168,13 @@ func TestRestrictToNames(t *testing.T) {
 
 	// "held-back" isn't in the simulated upgrade, but unattended-upgrade still
 	// intends to install it, so it must survive as a name-only entry.
-	updates := restrictToNames(candidates, []string{"openssl", "held-back"}, "security")
+	updates := restrictToNames(candidates, []string{"openssl", "held-back"})
 	test.That(t, updates, test.ShouldResemble, []pendingUpdate{
 		{Name: "openssl", Version: "3.0.15-1~deb12u1", Category: "security"},
 		{Name: "held-back", Category: "security"},
 	})
 
-	test.That(t, restrictToNames(candidates, nil, "security"), test.ShouldBeEmpty)
+	test.That(t, restrictToNames(candidates, nil), test.ShouldBeEmpty)
 }
 
 func TestParseRPMCheckUpdate(t *testing.T) {
@@ -187,12 +187,12 @@ Obsoleting Packages
 new-pkg.noarch                     2.0-1.fc40              updates
     old-pkg.noarch                 1.0-1.fc40              @System
 `
-	test.That(t, parseRPMCheckUpdate(output, "security"), test.ShouldResemble, []pendingUpdate{
+	test.That(t, parseRPMCheckUpdate(output), test.ShouldResemble, []pendingUpdate{
 		{Name: "kernel.x86_64", Version: "6.11.4-201.fc40", Category: "security"},
 		{Name: "openssl-libs.x86_64", Version: "1:3.2.2-3.fc40", Category: "security"},
 	})
 
-	test.That(t, parseRPMCheckUpdate("", ""), test.ShouldBeNil)
+	test.That(t, parseRPMCheckUpdate(""), test.ShouldBeNil)
 }
 
 func TestRPMSizeQueryCommand(t *testing.T) {

--- a/subsystems/syscfg/managed_upgrades_linux_test.go
+++ b/subsystems/syscfg/managed_upgrades_linux_test.go
@@ -92,3 +92,117 @@ func TestNeedsOSRebootWaitsForUpgradeToFinish(t *testing.T) {
 		test.That(t, s.NeedsOSReboot(context.Background()), test.ShouldBeTrue)
 	})
 }
+
+func TestParseAptSimulateUpgrade(t *testing.T) {
+	output := `NOTE: This is only a simulation!
+      apt-get needs root privileges for real execution.
+Reading package lists...
+Building dependency tree...
+Calculating upgrade...
+The following packages will be upgraded:
+  libc6 openssl
+2 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
+Inst libc6 [2.36-9+deb12u7] (2.36-9+deb12u10 Debian:12.9/stable [arm64])
+Conf libc6 (2.36-9+deb12u10 Debian:12.9/stable [arm64])
+Inst openssl [3.0.11-1~deb12u2] (3.0.15-1~deb12u1 Debian-Security:12/stable-security [arm64])
+Inst linux-image-6.1.0-30-arm64 (6.1.124-1 Debian:12.9/stable [arm64])
+Conf openssl (3.0.15-1~deb12u1 Debian-Security:12/stable-security [arm64])
+`
+	test.That(t, parseAptSimulateUpgrade(output), test.ShouldResemble, []pendingUpdate{
+		{Name: "libc6", CurrentVersion: "2.36-9+deb12u7", Version: "2.36-9+deb12u10"},
+		{
+			Name: "openssl", CurrentVersion: "3.0.11-1~deb12u2", Version: "3.0.15-1~deb12u1",
+			Category: "security",
+		},
+		{Name: "linux-image-6.1.0-30-arm64", Version: "6.1.124-1"},
+	})
+
+	test.That(t, parseAptSimulateUpgrade("0 upgraded, 0 newly installed, 0 to remove.\n"), test.ShouldBeNil)
+}
+
+func TestParseAptCacheSizes(t *testing.T) {
+	output := `Package: libc6
+Source: glibc
+Version: 2.36-9+deb12u10
+Installed-Size: 12759
+Depends: libgcc-s1
+Description-en: GNU C Library
+Size: 2799652
+MD5sum: 0123456789abcdef0123456789abcdef
+
+Package: openssl
+Version: 3.0.15-1~deb12u1
+Installed-Size: 1520
+Size: 1414000
+
+`
+	sizes := parseAptCacheSizes(output)
+	test.That(t, sizes, test.ShouldResemble, map[string]pendingUpdate{
+		"libc6=2.36-9+deb12u10": {DownloadSize: 2799652, InstalledSize: 12759 * 1024},
+		"openssl=3.0.15-1~deb12u1": {
+			DownloadSize: 1414000, InstalledSize: 1520 * 1024,
+		},
+	})
+
+	test.That(t, parseAptCacheSizes(""), test.ShouldBeEmpty)
+}
+
+func TestParseUnattendedUpgradeDryRun(t *testing.T) {
+	output := `Starting unattended upgrades script
+Allowed origins are: origin=Debian,codename=bookworm-security
+Checking: libc6 ([<Origin component:'main' archive:'stable-security'>])
+Packages that will be upgraded: libc6 openssl
+Writing dpkg log to /var/log/unattended-upgrades/unattended-upgrades-dpkg.log
+`
+	test.That(t, parseUnattendedUpgradeDryRun(output), test.ShouldResemble, []string{"libc6", "openssl"})
+
+	noUpdates := "No packages found that can be upgraded unattended and no pending auto-removals\n"
+	test.That(t, parseUnattendedUpgradeDryRun(noUpdates), test.ShouldBeNil)
+}
+
+func TestRestrictToNames(t *testing.T) {
+	candidates := []pendingUpdate{
+		{Name: "libc6", CurrentVersion: "2.36-9+deb12u7", Version: "2.36-9+deb12u10"},
+		{Name: "openssl", Version: "3.0.15-1~deb12u1", Category: "security"},
+	}
+
+	// "held-back" isn't in the simulated upgrade, but unattended-upgrade still
+	// intends to install it, so it must survive as a name-only entry.
+	updates := restrictToNames(candidates, []string{"openssl", "held-back"}, "security")
+	test.That(t, updates, test.ShouldResemble, []pendingUpdate{
+		{Name: "openssl", Version: "3.0.15-1~deb12u1", Category: "security"},
+		{Name: "held-back", Category: "security"},
+	})
+
+	test.That(t, restrictToNames(candidates, nil, "security"), test.ShouldBeEmpty)
+}
+
+func TestParseRPMCheckUpdate(t *testing.T) {
+	output := `
+kernel.x86_64                      6.11.4-201.fc40         updates
+openssl-libs.x86_64                1:3.2.2-3.fc40          updates
+Security: kernel-6.11.4-201.fc40.x86_64 is an installed security update
+
+Obsoleting Packages
+new-pkg.noarch                     2.0-1.fc40              updates
+    old-pkg.noarch                 1.0-1.fc40              @System
+`
+	test.That(t, parseRPMCheckUpdate(output, "security"), test.ShouldResemble, []pendingUpdate{
+		{Name: "kernel.x86_64", Version: "6.11.4-201.fc40", Category: "security"},
+		{Name: "openssl-libs.x86_64", Version: "1:3.2.2-3.fc40", Category: "security"},
+	})
+
+	test.That(t, parseRPMCheckUpdate("", ""), test.ShouldBeNil)
+}
+
+func TestParseRPMSizes(t *testing.T) {
+	// dnf versions differ on whether sizes are byte counts or human readable.
+	output := `kernel.x86_64|2799652|48234496
+openssl-libs.x86_64|1.4 M|7.8 M
+malformed-line-without-separator
+`
+	test.That(t, parseRPMSizes(output), test.ShouldResemble, map[string]pendingUpdate{
+		"kernel.x86_64":       {DownloadSize: 2799652, InstalledSize: 48234496},
+		"openssl-libs.x86_64": {DownloadSize: 1468006, InstalledSize: 8178892},
+	})
+}

--- a/subsystems/syscfg/managed_upgrades_linux_test.go
+++ b/subsystems/syscfg/managed_upgrades_linux_test.go
@@ -171,7 +171,7 @@ func TestRestrictToNames(t *testing.T) {
 	updates := restrictToNames(candidates, []string{"openssl", "held-back"})
 	test.That(t, updates, test.ShouldResemble, []pendingUpdate{
 		{Name: "openssl", Version: "3.0.15-1~deb12u1", Category: "security"},
-		{Name: "held-back", Category: "security"},
+		{Name: "held-back"},
 	})
 
 	test.That(t, restrictToNames(candidates, nil), test.ShouldBeEmpty)
@@ -188,8 +188,8 @@ new-pkg.noarch                     2.0-1.fc40              updates
     old-pkg.noarch                 1.0-1.fc40              @System
 `
 	test.That(t, parseRPMCheckUpdate(output), test.ShouldResemble, []pendingUpdate{
-		{Name: "kernel.x86_64", Version: "6.11.4-201.fc40", Category: "security"},
-		{Name: "openssl-libs.x86_64", Version: "1:3.2.2-3.fc40", Category: "security"},
+		{Name: "kernel.x86_64", Version: "6.11.4-201.fc40"},
+		{Name: "openssl-libs.x86_64", Version: "1:3.2.2-3.fc40"},
 	})
 
 	test.That(t, parseRPMCheckUpdate(""), test.ShouldBeNil)

--- a/subsystems/syscfg/managed_upgrades_linux_test.go
+++ b/subsystems/syscfg/managed_upgrades_linux_test.go
@@ -195,6 +195,19 @@ new-pkg.noarch                     2.0-1.fc40              updates
 	test.That(t, parseRPMCheckUpdate("", ""), test.ShouldBeNil)
 }
 
+func TestRPMSizeQueryCommand(t *testing.T) {
+	dnf := rpmPackageManager{useDnf: true}
+	test.That(t, dnf.sizeQueryCommand(t.Context()).Args, test.ShouldResemble, []string{
+		"dnf", "repoquery", "-q", "--upgrades", "--queryformat", dnfSizeQueryFormat,
+	})
+
+	// On yum systems repoquery is a standalone binary, not a yum subcommand.
+	yum := rpmPackageManager{useDnf: false}
+	test.That(t, yum.sizeQueryCommand(t.Context()).Args, test.ShouldResemble, []string{
+		"repoquery", "-q", "--all", "--pkgnarrow=updates", "--queryformat", yumSizeQueryFormat,
+	})
+}
+
 func TestParseRPMSizes(t *testing.T) {
 	// dnf versions differ on whether sizes are byte counts or human readable.
 	output := `kernel.x86_64|2799652|48234496

--- a/subsystems/syscfg/managed_upgrades_linux_test.go
+++ b/subsystems/syscfg/managed_upgrades_linux_test.go
@@ -201,11 +201,32 @@ func TestRPMSizeQueryCommand(t *testing.T) {
 		"dnf", "repoquery", "-q", "--upgrades", "--queryformat", dnfSizeQueryFormat,
 	})
 
+	// dnf5 stopped printing a newline after each record, so its format has to ask
+	// for one explicitly.
+	dnf5 := rpmPackageManager{useDnf: true, dnf5: true}
+	test.That(t, dnf5.sizeQueryCommand(t.Context()).Args, test.ShouldResemble, []string{
+		"dnf", "repoquery", "-q", "--upgrades", "--queryformat", dnfSizeQueryFormat + `\n`,
+	})
+
 	// On yum systems repoquery is a standalone binary, not a yum subcommand.
 	yum := rpmPackageManager{useDnf: false}
 	test.That(t, yum.sizeQueryCommand(t.Context()).Args, test.ShouldResemble, []string{
 		"repoquery", "-q", "--all", "--pkgnarrow=updates", "--queryformat", yumSizeQueryFormat,
 	})
+}
+
+func TestDnfMajorVersion(t *testing.T) {
+	dnf4Output := `4.14.0
+  Installed: dnf-0:4.14.0-1.fc38.noarch at Thu 06 Apr 2023 12:00:00 AM UTC
+  Built    : Fedora Project at Wed 15 Feb 2023 12:00:00 AM UTC
+`
+	test.That(t, dnfMajorVersion(dnf4Output), test.ShouldEqual, 4)
+
+	dnf5Output := "dnf5 version 5.2.6.2\n"
+	test.That(t, dnfMajorVersion(dnf5Output), test.ShouldEqual, 5)
+
+	test.That(t, dnfMajorVersion(""), test.ShouldEqual, 0)
+	test.That(t, dnfMajorVersion("command not found"), test.ShouldEqual, 0)
 }
 
 func TestParseRPMSizes(t *testing.T) {

--- a/subsystems/syscfg/managed_upgrades_locks_linux_test.go
+++ b/subsystems/syscfg/managed_upgrades_locks_linux_test.go
@@ -37,7 +37,7 @@ func (f fakePackageManager) lockPaths() []string                        { return
 func withPackageLocks(t *testing.T, paths ...string) {
 	t.Helper()
 	original := getPackageManager
-	getPackageManager = func(logging.Logger) (packageManager, error) {
+	getPackageManager = func(context.Context, logging.Logger) (packageManager, error) {
 		return fakePackageManager{paths: paths}, nil
 	}
 	t.Cleanup(func() { getPackageManager = original })

--- a/subsystems/syscfg/managed_upgrades_locks_linux_test.go
+++ b/subsystems/syscfg/managed_upgrades_locks_linux_test.go
@@ -23,7 +23,11 @@ type fakePackageManager struct {
 	paths []string
 }
 
-func (f fakePackageManager) String() string                             { return "fake" }
+func (f fakePackageManager) String() string                          { return "fake" }
+func (f fakePackageManager) prepare(_ context.Context, _ bool) error { return nil }
+func (f fakePackageManager) pendingUpgrades(_ context.Context, _ bool) ([]pendingUpdate, error) {
+	return nil, nil
+}
 func (f fakePackageManager) runUpgrade(_ context.Context, _ bool) error { return nil }
 func (f fakePackageManager) needsReboot(_ context.Context) bool         { return false }
 func (f fakePackageManager) lockPaths() []string                        { return f.paths }

--- a/subsystems/syscfg/managed_upgrades_locks_linux_test.go
+++ b/subsystems/syscfg/managed_upgrades_locks_linux_test.go
@@ -28,9 +28,12 @@ func (f fakePackageManager) prepare(_ context.Context, _ bool) error { return ni
 func (f fakePackageManager) pendingUpgrades(_ context.Context, _ bool) ([]pendingUpdate, error) {
 	return nil, nil
 }
-func (f fakePackageManager) runUpgrade(_ context.Context, _ bool) error { return nil }
-func (f fakePackageManager) needsReboot(_ context.Context) bool         { return false }
-func (f fakePackageManager) lockPaths() []string                        { return f.paths }
+
+func (f fakePackageManager) runUpgrade(_ context.Context, _ bool) ([]pendingUpdate, error) {
+	return nil, nil
+}
+func (f fakePackageManager) needsReboot(_ context.Context) bool { return false }
+func (f fakePackageManager) lockPaths() []string                { return f.paths }
 
 // withPackageLocks makes the detected package manager report exactly paths. With
 // none, a real package transaction on the test machine cannot affect the result.

--- a/subsystems/syscfg/managed_upgrades_rpm_linux.go
+++ b/subsystems/syscfg/managed_upgrades_rpm_linux.go
@@ -35,37 +35,57 @@ const (
 	dnf5SizeQueryFormat = dnfSizeQueryFormat + `\n`
 )
 
+// rpmVariant identifies which rpm-based package manager binary drives upgrades.
+// dnf4 and dnf5 are separate variants because dnf5 (Fedora 41+) is a rewrite
+// with its own command line quirks, not an incremental dnf release.
+type rpmVariant int
+
+const (
+	rpmYum rpmVariant = iota
+	rpmDnf4
+	rpmDnf5
+)
+
+// String returns the variant's name. Log sites must go through this (or fmt's
+// %s/%v verbs, which pick it up) rather than logging the field raw, so the logs
+// say "dnf5" instead of an opaque integer.
+func (v rpmVariant) String() string {
+	switch v {
+	case rpmDnf4:
+		return "dnf4"
+	case rpmDnf5:
+		return "dnf5"
+	case rpmYum:
+		return "yum"
+	}
+	return fmt.Sprintf("unknown(%d)", int(v))
+}
+
 type rpmPackageManager struct {
-	logger logging.Logger
-	useDnf bool
-	// dnf5 reports that the dnf binary is dnf5 (Fedora 41+), which is a rewrite
-	// with its own command line quirks, rather than dnf4.
-	dnf5 bool
+	logger  logging.Logger
+	variant rpmVariant
 }
 
 // String implements [packageManager].
 func (r rpmPackageManager) String() string {
-	manager := "yum"
-	switch {
-	case r.dnf5:
-		manager = "dnf5"
-	case r.useDnf:
-		manager = "dnf"
-	}
-	return fmt.Sprintf("rpm(%s)", manager)
+	return fmt.Sprintf("rpm(%s)", r.variant)
 }
 
-// isDnf5 reports whether the installed dnf binary is dnf5. `dnf --version`
-// prints "dnf5 version 5.x.y" on dnf5 and a bare "4.x.y" on dnf4, so the first
-// integer to appear is the major version either way. When the version can't be
-// determined, assume dnf4, whose behavior this code has relied on the longest.
-func isDnf5(ctx context.Context, logger logging.Logger) bool {
+// detectDnfVariant reports whether the installed dnf binary is dnf4 or dnf5.
+// `dnf --version` prints "dnf5 version 5.x.y" on dnf5 and a bare "4.x.y" on
+// dnf4, so the first integer to appear is the major version either way. When the
+// version can't be determined, assume dnf4, whose behavior this code has relied
+// on the longest.
+func detectDnfVariant(ctx context.Context, logger logging.Logger) rpmVariant {
 	output, err := exec.CommandContext(ctx, "dnf", "--version").Output()
 	if err != nil {
 		logger.Debugw("Could not determine dnf version, assuming dnf4", "err", err)
-		return false
+		return rpmDnf4
 	}
-	return dnfMajorVersion(string(output)) >= 5
+	if dnfMajorVersion(string(output)) >= 5 {
+		return rpmDnf5
+	}
+	return rpmDnf4
 }
 
 var dnfVersionRegex = regexp.MustCompile(`\d+`)
@@ -108,11 +128,10 @@ func (r rpmPackageManager) lockPaths() []string {
 }
 
 func (r rpmPackageManager) getProgram() string {
-	program := "yum"
-	if r.useDnf {
-		program = "dnf"
+	if r.variant == rpmYum {
+		return "yum"
 	}
-	return program
+	return "dnf"
 }
 
 func (r rpmPackageManager) ensureNeedsRestarting(ctx context.Context) error {
@@ -193,9 +212,9 @@ func (r rpmPackageManager) fillPackageSizes(ctx context.Context, updates []pendi
 // upgrade. With dnf, repoquery is a subcommand; on yum systems it is a
 // standalone binary shipped in yum-utils.
 func (r rpmPackageManager) sizeQueryCommand(ctx context.Context) *exec.Cmd {
-	if r.useDnf {
+	if r.variant != rpmYum {
 		format := dnfSizeQueryFormat
-		if r.dnf5 {
+		if r.variant == rpmDnf5 {
 			format = dnf5SizeQueryFormat
 		}
 		return exec.CommandContext(ctx, "dnf", "repoquery", "-q", "--upgrades",

--- a/subsystems/syscfg/managed_upgrades_rpm_linux.go
+++ b/subsystems/syscfg/managed_upgrades_rpm_linux.go
@@ -177,7 +177,7 @@ func (r rpmPackageManager) fillPackageSizes(ctx context.Context, updates []pendi
 	output, err := r.sizeQueryCommand(ctx).Output()
 	if err != nil {
 		r.logger.Debugw("Could not read pending update sizes from repoquery",
-			"package_manager", r, "err", err)
+			"package_manager", r.String(), "err", err)
 		return
 	}
 

--- a/subsystems/syscfg/managed_upgrades_rpm_linux.go
+++ b/subsystems/syscfg/managed_upgrades_rpm_linux.go
@@ -16,11 +16,15 @@ const (
 	// sizes never contain it, unlike whitespace which shows up in the human
 	// readable sizes some dnf versions print.
 	rpmQuerySeparator = "|"
-	// rpmSizeQueryFormat asks repoquery for the sizes check-update omits. Sizes are
-	// printed as a byte count by some versions and as a human readable string by
+	// dnfSizeQueryFormat asks dnf repoquery for the sizes check-update omits. Sizes
+	// are printed as a byte count by some versions and as a human readable string by
 	// others; [parseSize] accepts both.
-	rpmSizeQueryFormat = "%{name}.%{arch}" + rpmQuerySeparator +
+	dnfSizeQueryFormat = "%{name}.%{arch}" + rpmQuerySeparator +
 		"%{downloadsize}" + rpmQuerySeparator + "%{installsize}"
+	// yumSizeQueryFormat is the same query for the classic repoquery binary, which
+	// names the size tags differently than dnf does.
+	yumSizeQueryFormat = "%{name}.%{arch}" + rpmQuerySeparator +
+		"%{packagesize}" + rpmQuerySeparator + "%{installedsize}"
 )
 
 type rpmPackageManager struct {
@@ -132,10 +136,7 @@ func (r rpmPackageManager) fillPackageSizes(ctx context.Context, updates []pendi
 		return
 	}
 
-	//nolint: gosec
-	cmd := exec.CommandContext(ctx, r.getProgram(), "repoquery", "-q", "--upgrades",
-		"--queryformat", rpmSizeQueryFormat)
-	output, err := cmd.Output()
+	output, err := r.sizeQueryCommand(ctx).Output()
 	if err != nil {
 		r.logger.Debugw("Could not read pending update sizes from repoquery",
 			"package_manager", r, "err", err)
@@ -149,6 +150,21 @@ func (r rpmPackageManager) fillPackageSizes(ctx context.Context, updates []pendi
 			updates[i].InstalledSize = size.InstalledSize
 		}
 	}
+}
+
+// sizeQueryCommand returns the command that reports the sizes of every pending
+// upgrade. With dnf, repoquery is a subcommand; on yum systems it is a
+// standalone binary shipped in yum-utils.
+func (r rpmPackageManager) sizeQueryCommand(ctx context.Context) *exec.Cmd {
+	if r.useDnf {
+		return exec.CommandContext(ctx, "dnf", "repoquery", "-q", "--upgrades",
+			"--queryformat", dnfSizeQueryFormat)
+	}
+	// --all matches every package, which --pkgnarrow=updates then narrows to the
+	// pending updates, like dnf's --upgrades. -q is accepted (and ignored) for rpm
+	// compatibility.
+	return exec.CommandContext(ctx, "repoquery", "-q", "--all", "--pkgnarrow=updates",
+		"--queryformat", yumSizeQueryFormat)
 }
 
 func (r rpmPackageManager) runUpgrade(ctx context.Context, securityOnly bool) error {
@@ -187,7 +203,8 @@ func parseRPMCheckUpdate(output, category string) []pendingUpdate {
 }
 
 // parseRPMSizes extracts package sizes from repoquery output in
-// [rpmSizeQueryFormat], keyed by the "<name>.<arch>" that check-update lists.
+// [dnfSizeQueryFormat] or [yumSizeQueryFormat], keyed by the "<name>.<arch>" that
+// check-update lists.
 func parseRPMSizes(output string) map[string]pendingUpdate {
 	sizes := map[string]pendingUpdate{}
 	for _, line := range strings.Split(output, "\n") {

--- a/subsystems/syscfg/managed_upgrades_rpm_linux.go
+++ b/subsystems/syscfg/managed_upgrades_rpm_linux.go
@@ -5,9 +5,22 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	errw "github.com/pkg/errors"
 	"go.viam.com/rdk/logging"
+)
+
+const (
+	// rpmQuerySeparator delimits repoquery fields. Package names, versions and
+	// sizes never contain it, unlike whitespace which shows up in the human
+	// readable sizes some dnf versions print.
+	rpmQuerySeparator = "|"
+	// rpmSizeQueryFormat asks repoquery for the sizes check-update omits. Sizes are
+	// printed as a byte count by some versions and as a human readable string by
+	// others; [parseSize] accepts both.
+	rpmSizeQueryFormat = "%{name}.%{arch}" + rpmQuerySeparator +
+		"%{downloadsize}" + rpmQuerySeparator + "%{installsize}"
 )
 
 type rpmPackageManager struct {
@@ -66,13 +79,126 @@ func (r rpmPackageManager) ensureNeedsRestarting(ctx context.Context) error {
 	return pkgCmd(ctx, r.logger, r.getProgram(), "install", "-y", "yum-utils")
 }
 
-func (r rpmPackageManager) runUpgrade(ctx context.Context, securityOnly bool) error {
+// prepare implements [packageManager].
+func (r rpmPackageManager) prepare(ctx context.Context, securityOnly bool) error {
 	if err := r.ensureNeedsRestarting(ctx); err != nil {
 		return errw.Wrap(err, "failed to locate or install needs-restarting")
 	}
+	// check-update refreshes expired metadata itself, so there is nothing else to
+	// do here.
+	return nil
+}
+
+// pendingUpgrades implements [packageManager].
+//
+// The columnar text output of check-update is parsed rather than dnf5's --json,
+// because dnf4 (RHEL 8 and 9) and yum have no JSON support and this path has to
+// work everywhere. check-update reports no sizes, so those are looked up
+// separately. Category is only known when we asked for security updates, since
+// check-update doesn't report per-package advisory types.
+func (r rpmPackageManager) pendingUpgrades(ctx context.Context, securityOnly bool) ([]pendingUpdate, error) {
+	args := []string{"check-update", "-q"}
+	category := ""
+	if securityOnly {
+		args = append(args, "--security")
+		category = categorySecurity
+	}
+	//nolint: gosec
+	cmd := exec.CommandContext(ctx, r.getProgram(), args...)
+	// check-update exits 100 when updates are available and 0 when there are none;
+	// anything else is a real failure.
+	output, err := cmd.Output()
+	if err != nil {
+		exitErr, ok := errors.AsType[*exec.ExitError](err)
+		if !ok {
+			return nil, errw.Wrapf(err, "%s %v", r.getProgram(), args)
+		}
+		if exitErr.ExitCode() != 100 {
+			return nil, errw.Wrapf(err, "%s %v: %s", r.getProgram(), args, exitErr.Stderr)
+		}
+	}
+
+	updates := parseRPMCheckUpdate(string(output), category)
+	r.fillPackageSizes(ctx, updates)
+	return updates, nil
+}
+
+// fillPackageSizes looks up the download and installed sizes of the passed updates,
+// which check-update doesn't report. repoquery isn't available on every
+// distribution and its query tags have varied across versions, so a failed lookup
+// is logged and leaves the sizes unknown rather than failing the upgrade.
+func (r rpmPackageManager) fillPackageSizes(ctx context.Context, updates []pendingUpdate) {
+	if len(updates) == 0 {
+		return
+	}
+
+	//nolint: gosec
+	cmd := exec.CommandContext(ctx, r.getProgram(), "repoquery", "-q", "--upgrades",
+		"--queryformat", rpmSizeQueryFormat)
+	output, err := cmd.Output()
+	if err != nil {
+		r.logger.Debugw("Could not read pending update sizes from repoquery",
+			"package_manager", r, "err", err)
+		return
+	}
+
+	sizes := parseRPMSizes(string(output))
+	for i, update := range updates {
+		if size, ok := sizes[update.Name]; ok {
+			updates[i].DownloadSize = size.DownloadSize
+			updates[i].InstalledSize = size.InstalledSize
+		}
+	}
+}
+
+func (r rpmPackageManager) runUpgrade(ctx context.Context, securityOnly bool) error {
 	args := []string{"upgrade", "-y"}
 	if securityOnly {
 		args = append(args, "--security")
 	}
 	return pkgCmd(ctx, r.logger, r.getProgram(), args...)
+}
+
+// parseRPMCheckUpdate extracts the packages to be installed from the output of
+// `dnf check-update -q`, whose upgradable packages are listed one per line as
+// "<name>.<arch>  <version>  <repo>". Every update is tagged with the passed
+// category, which check-update itself doesn't report.
+func parseRPMCheckUpdate(output, category string) []pendingUpdate {
+	var updates []pendingUpdate
+	for _, line := range strings.Split(output, "\n") {
+		// The trailing "Obsoleting Packages" section repeats packages already listed
+		// above, alongside the installed packages they obsolete.
+		if strings.HasPrefix(line, "Obsoleting") {
+			break
+		}
+		fields := strings.Fields(line)
+		// Skip blank lines and the "Security: ... is an installed security update"
+		// notes yum appends.
+		if len(fields) != 3 || strings.HasSuffix(fields[0], ":") {
+			continue
+		}
+		updates = append(updates, pendingUpdate{
+			Name:     fields[0],
+			Version:  fields[1],
+			Category: category,
+		})
+	}
+	return updates
+}
+
+// parseRPMSizes extracts package sizes from repoquery output in
+// [rpmSizeQueryFormat], keyed by the "<name>.<arch>" that check-update lists.
+func parseRPMSizes(output string) map[string]pendingUpdate {
+	sizes := map[string]pendingUpdate{}
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Split(strings.TrimSpace(line), rpmQuerySeparator)
+		if len(fields) != 3 {
+			continue
+		}
+		sizes[fields[0]] = pendingUpdate{
+			DownloadSize:  parseSize(fields[1]),
+			InstalledSize: parseSize(fields[2]),
+		}
+	}
+	return sizes
 }

--- a/subsystems/syscfg/managed_upgrades_rpm_linux.go
+++ b/subsystems/syscfg/managed_upgrades_rpm_linux.go
@@ -217,8 +217,8 @@ func (r rpmPackageManager) runUpgrade(ctx context.Context, securityOnly bool) er
 
 // parseRPMCheckUpdate extracts the packages to be installed from the output of
 // `dnf check-update -q`, whose upgradable packages are listed one per line as
-// "<name>.<arch>  <version>  <repo>". Every update is tagged with the passed
-// category, which check-update itself doesn't report.
+// "<name>.<arch>  <version>  <repo>". No category is recorded because
+// check-update doesn't report per-package advisory types.
 func parseRPMCheckUpdate(output string) []pendingUpdate {
 	var updates []pendingUpdate
 	for _, line := range strings.Split(output, "\n") {

--- a/subsystems/syscfg/managed_upgrades_rpm_linux.go
+++ b/subsystems/syscfg/managed_upgrades_rpm_linux.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 
 	errw "github.com/pkg/errors"
@@ -25,20 +27,56 @@ const (
 	// names the size tags differently than dnf does.
 	yumSizeQueryFormat = "%{name}.%{arch}" + rpmQuerySeparator +
 		"%{packagesize}" + rpmQuerySeparator + "%{installedsize}"
+	// dnf5SizeQueryFormat is [dnfSizeQueryFormat] for dnf5, which stopped printing a
+	// newline after each record and instead expects the format to ask for one with
+	// an escape sequence. Only dnf5 gets it: dnf4 already separates records itself,
+	// and isn't documented to interpret the escape.
+	dnf5SizeQueryFormat = dnfSizeQueryFormat + `\n`
 )
 
 type rpmPackageManager struct {
 	logger logging.Logger
 	useDnf bool
+	// dnf5 reports that the dnf binary is dnf5 (Fedora 41+), which is a rewrite
+	// with its own command line quirks, rather than dnf4.
+	dnf5 bool
 }
 
 // String implements [packageManager].
 func (r rpmPackageManager) String() string {
 	manager := "yum"
-	if r.useDnf {
+	switch {
+	case r.dnf5:
+		manager = "dnf5"
+	case r.useDnf:
 		manager = "dnf"
 	}
 	return fmt.Sprintf("rpm(%s)", manager)
+}
+
+// isDnf5 reports whether the installed dnf binary is dnf5. `dnf --version`
+// prints "dnf5 version 5.x.y" on dnf5 and a bare "4.x.y" on dnf4, so the first
+// integer to appear is the major version either way. When the version can't be
+// determined, assume dnf4, whose behavior this code has relied on the longest.
+func isDnf5(ctx context.Context, logger logging.Logger) bool {
+	output, err := exec.CommandContext(ctx, "dnf", "--version").Output()
+	if err != nil {
+		logger.Debugw("Could not determine dnf version, assuming dnf4", "err", err)
+		return false
+	}
+	return dnfMajorVersion(string(output)) >= 5
+}
+
+var dnfVersionRegex = regexp.MustCompile(`\d+`)
+
+// dnfMajorVersion extracts the major version from `dnf --version` output,
+// returning 0 when there is none to find.
+func dnfMajorVersion(output string) int {
+	major, err := strconv.Atoi(dnfVersionRegex.FindString(output))
+	if err != nil {
+		return 0
+	}
+	return major
 }
 
 func (r rpmPackageManager) needsReboot(ctx context.Context) bool {
@@ -157,8 +195,12 @@ func (r rpmPackageManager) fillPackageSizes(ctx context.Context, updates []pendi
 // standalone binary shipped in yum-utils.
 func (r rpmPackageManager) sizeQueryCommand(ctx context.Context) *exec.Cmd {
 	if r.useDnf {
+		format := dnfSizeQueryFormat
+		if r.dnf5 {
+			format = dnf5SizeQueryFormat
+		}
 		return exec.CommandContext(ctx, "dnf", "repoquery", "-q", "--upgrades",
-			"--queryformat", dnfSizeQueryFormat)
+			"--queryformat", format)
 	}
 	// --all matches every package, which --pkgnarrow=updates then narrows to the
 	// pending updates, like dnf's --upgrades. -q is accepted (and ignored) for rpm

--- a/subsystems/syscfg/managed_upgrades_rpm_linux.go
+++ b/subsystems/syscfg/managed_upgrades_rpm_linux.go
@@ -140,10 +140,8 @@ func (r rpmPackageManager) prepare(ctx context.Context, securityOnly bool) error
 // check-update doesn't report per-package advisory types.
 func (r rpmPackageManager) pendingUpgrades(ctx context.Context, securityOnly bool) ([]pendingUpdate, error) {
 	args := []string{"check-update", "-q"}
-	category := ""
 	if securityOnly {
 		args = append(args, "--security")
-		category = categorySecurity
 	}
 	//nolint: gosec
 	cmd := exec.CommandContext(ctx, r.getProgram(), args...)
@@ -160,7 +158,7 @@ func (r rpmPackageManager) pendingUpgrades(ctx context.Context, securityOnly boo
 		}
 	}
 
-	updates := parseRPMCheckUpdate(string(output), category)
+	updates := parseRPMCheckUpdate(string(output))
 	r.fillPackageSizes(ctx, updates)
 	return updates, nil
 }
@@ -221,7 +219,7 @@ func (r rpmPackageManager) runUpgrade(ctx context.Context, securityOnly bool) er
 // `dnf check-update -q`, whose upgradable packages are listed one per line as
 // "<name>.<arch>  <version>  <repo>". Every update is tagged with the passed
 // category, which check-update itself doesn't report.
-func parseRPMCheckUpdate(output, category string) []pendingUpdate {
+func parseRPMCheckUpdate(output string) []pendingUpdate {
 	var updates []pendingUpdate
 	for _, line := range strings.Split(output, "\n") {
 		// The trailing "Obsoleting Packages" section repeats packages already listed
@@ -236,9 +234,8 @@ func parseRPMCheckUpdate(output, category string) []pendingUpdate {
 			continue
 		}
 		updates = append(updates, pendingUpdate{
-			Name:     fields[0],
-			Version:  fields[1],
-			Category: category,
+			Name:    fields[0],
+			Version: fields[1],
 		})
 	}
 	return updates

--- a/subsystems/syscfg/managed_upgrades_rpm_linux.go
+++ b/subsystems/syscfg/managed_upgrades_rpm_linux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -207,12 +208,16 @@ func (r rpmPackageManager) sizeQueryCommand(ctx context.Context) *exec.Cmd {
 		"--queryformat", yumSizeQueryFormat)
 }
 
-func (r rpmPackageManager) runUpgrade(ctx context.Context, securityOnly bool) error {
+// runUpgrade implements [packageManager]. The returned packages are parsed from
+// the transaction output even when the upgrade fails, since a package reported
+// there was installed before the transaction died.
+func (r rpmPackageManager) runUpgrade(ctx context.Context, securityOnly bool) ([]pendingUpdate, error) {
 	args := []string{"upgrade", "-y"}
 	if securityOnly {
 		args = append(args, "--security")
 	}
-	return pkgCmd(ctx, r.logger, r.getProgram(), args...)
+	output, err := pkgCmdOutput(ctx, r.logger, r.getProgram(), args...)
+	return parseRPMUpgradeOutput(output), err
 }
 
 // parseRPMCheckUpdate extracts the packages to be installed from the output of
@@ -239,6 +244,112 @@ func parseRPMCheckUpdate(output string) []pendingUpdate {
 		})
 	}
 	return updates
+}
+
+// rpmInstalledSections are the summary headings under which dnf4 and yum list
+// what a completed transaction installed, one heading per transaction verb.
+// Removal headings ("Removed:", "Erased:", "Replaced:") are deliberately absent:
+// those packages left the system rather than landing on it.
+var rpmInstalledSections = []string{
+	"Installed:", "Upgraded:", "Updated:", "Downgraded:", "Reinstalled:",
+	"Dependency Installed:", "Dependency Updated:",
+}
+
+// dnf5ProgressRegex matches the "[3/7] Upgrading <name-version.arch> ..."
+// per-package progress lines dnf5 prints while running the transaction, the only
+// place dnf5's output reports individual packages as installed. The verb keeps
+// non-package steps ("Verify package files", "Prepare transaction") and the
+// verb-less download progress lines from matching.
+var dnf5ProgressRegex = regexp.MustCompile(`^\[\d+/\d+\] (?:Installing|Upgrading|Downgrading|Reinstalling) (\S+)`)
+
+// parseRPMUpgradeOutput extracts the packages a `dnf/yum upgrade -y` run actually
+// installed from its output, in the "<name>.<arch>"/version form check-update
+// lists pending updates in. Anything unrecognized parses to nothing, and the
+// result log omits the package list.
+func parseRPMUpgradeOutput(output string) []pendingUpdate {
+	var updates []pendingUpdate
+	seen := map[string]bool{}
+	add := func(update pendingUpdate) {
+		if !seen[update.Name] {
+			seen[update.Name] = true
+			updates = append(updates, update)
+		}
+	}
+
+	inSection := false
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		if match := dnf5ProgressRegex.FindStringSubmatch(trimmed); match != nil {
+			if update, ok := parseRPMFullName(match[1]); ok {
+				add(update)
+			}
+			continue
+		}
+
+		// Section headings sit flush left; the packages under them are indented.
+		if !strings.HasPrefix(line, " ") {
+			inSection = slices.Contains(rpmInstalledSections, trimmed)
+			continue
+		}
+		if !inSection {
+			continue
+		}
+
+		// Sections list several packages per line, columnar. dnf4 prints each as a
+		// single "name-version-release.arch" token; yum splits the same package into
+		// a "name.arch epoch:version-release" pair.
+		fields := strings.Fields(trimmed)
+		for i := 0; i < len(fields); i++ {
+			if update, ok := parseRPMFullName(fields[i]); ok {
+				add(update)
+				continue
+			}
+			if i+1 < len(fields) && strings.Contains(fields[i], ".") && startsWithDigit(fields[i+1]) {
+				add(pendingUpdate{Name: fields[i], Version: fields[i+1]})
+				i++
+			}
+		}
+	}
+	return updates
+}
+
+// parseRPMFullName splits a full package spec like
+// "openssl-libs-1:3.2.2-3.fc40.x86_64" into the "<name>.<arch>" and version
+// forms check-update uses, so installed packages line up with the pending list
+// by name. Reports false for anything not shaped like name-version-release.arch,
+// including the "name.arch" half of a yum package pair.
+func parseRPMFullName(spec string) (pendingUpdate, bool) {
+	archIdx := strings.LastIndex(spec, ".")
+	if archIdx < 0 {
+		return pendingUpdate{}, false
+	}
+	nvr, arch := spec[:archIdx], spec[archIdx+1:]
+
+	relIdx := strings.LastIndex(nvr, "-")
+	if relIdx < 0 {
+		return pendingUpdate{}, false
+	}
+	verIdx := strings.LastIndex(nvr[:relIdx], "-")
+	if verIdx < 0 {
+		return pendingUpdate{}, false
+	}
+
+	name, version, release := nvr[:verIdx], nvr[verIdx+1:relIdx], nvr[relIdx+1:]
+	// Versions and releases start with a digit (the version possibly behind an
+	// "epoch:" prefix, itself numeric), unlike the dash-separated words of a
+	// package name. This keeps a bare name like "java-1.8.0-openjdk.x86_64" from
+	// being misread as name "java" version "1.8.0-openjdk".
+	if name == "" || arch == "" || !startsWithDigit(version) || !startsWithDigit(release) {
+		return pendingUpdate{}, false
+	}
+	return pendingUpdate{Name: name + "." + arch, Version: version + "-" + release}, true
+}
+
+// startsWithDigit reports whether s begins with an ASCII digit, the shape of rpm
+// versions and releases (an "epoch:" prefix included, epochs being numeric).
+func startsWithDigit(s string) bool {
+	return len(s) > 0 && s[0] >= '0' && s[0] <= '9'
 }
 
 // parseRPMSizes extracts package sizes from repoquery output in

--- a/subsystems/syscfg/managed_upgrades_windows.go
+++ b/subsystems/syscfg/managed_upgrades_windows.go
@@ -204,6 +204,9 @@ type windowsUpdateInfo struct {
 	Size string `json:"size"`
 	// Categories classify the update, e.g. "Security Updates", "Drivers".
 	Categories []string `json:"categories"`
+	// Result is the install stage an update has reached, e.g. "Accepted",
+	// "Downloaded", "Installed" or "Failed". Search results leave it empty.
+	Result string `json:"result"`
 }
 
 // windowsUpdatesJSON renders a PowerShell snippet that prints the updates held in
@@ -213,7 +216,7 @@ type windowsUpdateInfo struct {
 func windowsUpdatesJSON(variable string) string {
 	return `ConvertTo-Json -Compress -Depth 3 -InputObject @(` +
 		variable + ` | ForEach-Object { [PSCustomObject]@{ title = [string]$_.Title; kb = [string]$_.KB; ` +
-		`downloadSize = [uint64]$_.MaxDownloadSize; size = [string]$_.Size; ` +
+		`downloadSize = [uint64]$_.MaxDownloadSize; size = [string]$_.Size; result = [string]$_.Result; ` +
 		`categories = @($_.Categories | ForEach-Object { [string]$_.Name }) } })`
 }
 
@@ -258,6 +261,7 @@ func parseWindowsUpdates(output string) ([]pendingUpdate, error) {
 			// Categories are per-update rather than a single classification, so keep all
 			// of them, separated by "/" to stay distinguishable inside a log line.
 			Category: strings.Join(info.Categories, "/"),
+			Result:   info.Result,
 		})
 	}
 	return updates, nil
@@ -280,8 +284,11 @@ func windowsDownloadSize(info windowsUpdateInfo) uint64 {
 }
 
 // installWindowsUpdates installs updates via the PSWindowsUpdate PowerShell module,
-// returning the updates it reported installing so the caller can log what actually
-// landed rather than what was merely pending beforehand.
+// returning one entry per update it processed, with Result reporting the stage the
+// update reached, so the caller can log what actually landed rather than what was
+// merely pending beforehand. An update that failed to install is a "Failed" entry
+// in that list, not an error: PSWindowsUpdate reports per-update failures in its
+// output rather than its exit code.
 // Devices already configured to use a WSUS server (via Group Policy or registry) will
 // automatically receive updates from that server without any extra configuration.
 func installWindowsUpdates(ctx context.Context, logger logging.Logger, securityOnly bool) ([]pendingUpdate, error) {
@@ -305,7 +312,26 @@ func installWindowsUpdates(ctx context.Context, logger logging.Logger, securityO
 		logger.Warnw("Could not determine which Windows updates were installed", "err", err)
 		return nil, nil
 	}
-	return installed, nil
+	return dedupeWindowsUpdates(installed), nil
+}
+
+// dedupeWindowsUpdates collapses the stage rows Get-WindowsUpdate -Install emits —
+// one per update for each of "Accepted", "Downloaded" and "Installed" (or
+// "Failed") — into a single entry per update carrying the last stage it reached.
+// Updates keep the order they first appeared in, and the stage rows arrive in
+// chronological order, so the last row seen for a name is its final stage.
+func dedupeWindowsUpdates(updates []pendingUpdate) []pendingUpdate {
+	indexByName := make(map[string]int, len(updates))
+	deduped := make([]pendingUpdate, 0, len(updates))
+	for _, update := range updates {
+		if i, ok := indexByName[update.Name]; ok {
+			deduped[i] = update
+			continue
+		}
+		indexByName[update.Name] = len(deduped)
+		deduped = append(deduped, update)
+	}
+	return deduped
 }
 
 // windowsRebootRequired checks the Windows Update registry key that signals a pending reboot.

--- a/subsystems/syscfg/managed_upgrades_windows.go
+++ b/subsystems/syscfg/managed_upgrades_windows.go
@@ -11,6 +11,7 @@ package syscfg
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -142,8 +143,14 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) error {
 	updates := updateSummary{updates: pending, listErr: listErr}
 	logPendingUpdates(s.logger, updates, "security_only", securityOnly)
 
-	upgradeErr := installWindowsUpdates(ctx, s.logger, securityOnly)
-	logUpgradeResult(ctx, s.logger, updates, upgradeErr, "security_only", securityOnly)
+	installed, upgradeErr := installWindowsUpdates(ctx, s.logger, securityOnly)
+	result := updateSummary{updates: installed}
+	if len(installed) == 0 {
+		// The install failed, or Windows Update didn't say what it covered. Report what
+		// we set out to install rather than an empty list.
+		result = updates
+	}
+	logUpgradeResult(ctx, s.logger, result, upgradeErr, "security_only", securityOnly)
 	if upgradeErr != nil {
 		return upgradeErr
 	}
@@ -199,40 +206,52 @@ type windowsUpdateInfo struct {
 	Categories []string `json:"categories"`
 }
 
+// windowsUpdatesJSON renders a PowerShell snippet that prints the updates held in
+// the passed variable as JSON, which is all the snippets that use it write to
+// standard output. ConvertTo-Json is fed the array explicitly because piping to it
+// would unroll a single update back into an object.
+func windowsUpdatesJSON(variable string) string {
+	return `ConvertTo-Json -Compress -Depth 3 -InputObject @(` +
+		variable + ` | ForEach-Object { [PSCustomObject]@{ title = [string]$_.Title; kb = [string]$_.KB; ` +
+		`downloadSize = [uint64]$_.MaxDownloadSize; size = [string]$_.Size; ` +
+		`categories = @($_.Categories | ForEach-Object { [string]$_.Name }) } })`
+}
+
 // pendingWindowsUpdates lists the updates that installWindowsUpdates would
 // install. Windows Update reports a download size and update categories, but no
 // unpacked size.
 func pendingWindowsUpdates(ctx context.Context, logger logging.Logger, securityOnly bool) ([]pendingUpdate, error) {
 	// Without -Install, Get-WindowsUpdate only searches, so this reports what the
-	// install below is about to do. ConvertTo-Json is fed the array explicitly
-	// because piping to it would unroll a single update back into an object.
+	// install below is about to do.
 	cmd := "Import-Module PSWindowsUpdate; $pending = @(Get-WindowsUpdate"
 	if securityOnly {
 		cmd += securityCategory
 	}
-	cmd += `); ConvertTo-Json -Compress -Depth 3 -InputObject @($pending | ForEach-Object { ` +
-		`[PSCustomObject]@{ title = [string]$_.Title; kb = [string]$_.KB; ` +
-		`downloadSize = [uint64]$_.MaxDownloadSize; size = [string]$_.Size; ` +
-		`categories = @($_.Categories | ForEach-Object { [string]$_.Name }) } })`
+	cmd += "); " + windowsUpdatesJSON("$pending")
 
 	output, err := runPowerShell(ctx, logger, cmd)
 	if err != nil {
 		return nil, errw.Wrap(err, "listing pending Windows updates")
 	}
+	return parseWindowsUpdates(output)
+}
 
-	trimmed := strings.TrimSpace(output)
-	if trimmed == "" {
+// parseWindowsUpdates converts the JSON printed by [windowsUpdatesJSON] into
+// updates.
+func parseWindowsUpdates(output string) ([]pendingUpdate, error) {
+	output = strings.TrimSpace(output)
+	if output == "" {
 		// Not every PowerShell version renders an empty array as "[]".
 		return nil, nil
 	}
 
-	var found []windowsUpdateInfo
-	if err := json.Unmarshal([]byte(trimmed), &found); err != nil {
-		return nil, errw.Wrapf(err, "parsing pending Windows updates: %s", output)
+	var infos []windowsUpdateInfo
+	if err := json.Unmarshal([]byte(output), &infos); err != nil {
+		return nil, errw.Wrapf(err, "parsing Windows updates: %s", output)
 	}
 
-	updates := make([]pendingUpdate, 0, len(found))
-	for _, info := range found {
+	updates := make([]pendingUpdate, 0, len(infos))
+	for _, info := range infos {
 		updates = append(updates, pendingUpdate{
 			Name:         windowsUpdateName(info),
 			DownloadSize: windowsDownloadSize(info),
@@ -260,20 +279,33 @@ func windowsDownloadSize(info windowsUpdateInfo) uint64 {
 	return parseSize(info.Size)
 }
 
-// installWindowsUpdates installs updates via the PSWindowsUpdate PowerShell module.
+// installWindowsUpdates installs updates via the PSWindowsUpdate PowerShell module,
+// returning the updates it reported installing so the caller can log what actually
+// landed rather than what was merely pending beforehand.
 // Devices already configured to use a WSUS server (via Group Policy or registry) will
 // automatically receive updates from that server without any extra configuration.
-func installWindowsUpdates(ctx context.Context, logger logging.Logger, securityOnly bool) error {
+func installWindowsUpdates(ctx context.Context, logger logging.Logger, securityOnly bool) ([]pendingUpdate, error) {
 	// -IgnoreReboot prevents PSWindowsUpdate from rebooting immediately; the agent
 	// coordinates the reboot via the maintenance window.
-	cmd := "Import-Module PSWindowsUpdate; Get-WindowsUpdate -Install -AcceptAll -IgnoreReboot"
+	cmd := "Import-Module PSWindowsUpdate; $installed = @(Get-WindowsUpdate -Install -AcceptAll -IgnoreReboot"
 	if securityOnly {
 		cmd += securityCategory
 	}
-	if _, err := runPowerShell(ctx, logger, cmd); err != nil {
-		return errw.Wrap(err, "installing Windows updates")
+	cmd += "); " + windowsUpdatesJSON("$installed")
+
+	output, err := runPowerShell(ctx, logger, cmd)
+	if err != nil {
+		return nil, errw.Wrap(err, "installing Windows updates")
 	}
-	return nil
+
+	installed, err := parseWindowsUpdates(output)
+	if err != nil {
+		// The install itself succeeded, we just can't say from its output what it
+		// covered. The caller falls back to the pending list.
+		logger.Warnw("Could not determine which Windows updates were installed", "err", err)
+		return nil, nil
+	}
+	return installed, nil
 }
 
 // windowsRebootRequired checks the Windows Update registry key that signals a pending reboot.
@@ -334,17 +366,29 @@ func trustedInstallerRunning(ctx context.Context) bool {
 	return strings.EqualFold(strings.TrimSpace(string(out)), "Running")
 }
 
-// runPowerShell executes a PowerShell command, returning its combined output, or a
-// wrapped error with that output on failure.
+// silenceProgress suppresses the progress stream for the rest of a script.
+// Install-Module and Windows Update downloads both report progress, which renders
+// into the output we capture and parse.
+const silenceProgress = `$ProgressPreference = 'SilentlyContinue'; `
+
+// runPowerShell executes a PowerShell command, returning its standard output only.
+// Standard error is deliberately kept out of that: callers parse the output, and
+// PSWindowsUpdate writes warnings (a pending reboot, for one) to stderr, which would
+// otherwise land in the middle of the data. It is reported in the error instead.
 func runPowerShell(ctx context.Context, logger logging.Logger, script string) (string, error) {
+	script = silenceProgress + script
 	cmd := exec.CommandContext(ctx, "powershell",
 		"-NonInteractive", "-NoProfile", "-ExecutionPolicy", "RemoteSigned",
 		"-Command", script,
 	)
 	logger.Debugw("Executing powershell command", "script", script)
-	output, err := cmd.CombinedOutput()
+	output, err := cmd.Output()
 	if err != nil {
-		return string(output), fmt.Errorf("powershell: %w\n%s", err, output)
+		var stderr []byte
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+			stderr = exitErr.Stderr
+		}
+		return string(output), fmt.Errorf("powershell: %w\nstdout: %s\nstderr: %s", err, output, stderr)
 	}
 	logger.Debugw("Powershell command succeeded", "script", script, "output", string(output))
 	return string(output), nil

--- a/subsystems/syscfg/managed_upgrades_windows.go
+++ b/subsystems/syscfg/managed_upgrades_windows.go
@@ -10,6 +10,7 @@ package syscfg
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -17,6 +18,7 @@ import (
 
 	errw "github.com/pkg/errors"
 	"github.com/viamrobotics/agent/utils"
+	"go.viam.com/rdk/logging"
 )
 
 // NeedsOSReboot reports whether a reboot is pending from installed updates and can
@@ -119,22 +121,32 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) error {
 	mode := s.cfg.OSAutoUpgradeType
 	s.mu.RUnlock()
 
-	s.logger.Info("Running managed Windows Update")
+	securityOnly := mode == utils.OSAutoUpgradeManagedSecurity
+	s.logger.Infow("Running managed Windows Update",
+		"os_auto_upgrade_type", mode,
+		"security_only", securityOnly,
+	)
 
-	// Block reboots for the duration of the install: Windows sets RebootRequired as
-	// soon as one update needs it, so the key can appear while the rest of the batch
-	// is still being written to the component store.
-	err := func() error {
-		upgradeDone := s.upgrade.begin()
-		defer upgradeDone()
-		return runWindowsUpdate(ctx, mode == utils.OSAutoUpgradeManagedSecurity)
-	}()
-	if err != nil {
-		s.logger.Warnw("Windows Update failed", "error", err)
+	// Block reboots for the duration of the upgrade cycle: Windows sets
+	// RebootRequired as soon as one update needs it, so the key can appear while
+	// the rest of the batch is still being written to the component store.
+	upgradeDone := s.upgrade.begin()
+	defer upgradeDone()
+
+	if err := ensurePSWindowsUpdate(ctx, s.logger); err != nil {
+		s.logger.Errorw("Could not prepare PSWindowsUpdate module, skipping Windows Update", "err", err)
 		return err
 	}
 
-	s.logger.Info("Windows Update completed")
+	pending, listErr := pendingWindowsUpdates(ctx, s.logger, securityOnly)
+	updates := updateSummary{updates: pending, listErr: listErr}
+	logPendingUpdates(s.logger, updates, "security_only", securityOnly)
+
+	upgradeErr := installWindowsUpdates(ctx, s.logger, securityOnly)
+	logUpgradeResult(ctx, s.logger, updates, upgradeErr, "security_only", securityOnly)
+	if upgradeErr != nil {
+		return upgradeErr
+	}
 
 	if windowsRebootRequired(ctx) {
 		s.mu.Lock()
@@ -158,25 +170,107 @@ func (s *Subsystem) stopManagedUpgrades() {
 	}
 }
 
-// runWindowsUpdate installs updates via the PSWindowsUpdate PowerShell module.
-// Devices already configured to use a WSUS server (via Group Policy or registry) will
-// automatically receive updates from that server without any extra configuration.
-func runWindowsUpdate(ctx context.Context, securityOnly bool) error {
-	// Ensure PSWindowsUpdate is available; Install-Module is a no-op if already present.
+// securityCategory restricts PSWindowsUpdate to security updates only.
+const securityCategory = " -Category 'Security Updates'"
+
+// ensurePSWindowsUpdate makes sure the PSWindowsUpdate module is installed.
+// Install-Module is a no-op if the module is already present.
+func ensurePSWindowsUpdate(ctx context.Context, logger logging.Logger) error {
 	ensureModule := `if (-not (Get-Module -ListAvailable -Name PSWindowsUpdate)) { ` +
 		`Install-PackageProvider -Name NuGet -Force; ` +
 		`Install-Module -Name PSWindowsUpdate -Confirm:$False -Force -Scope AllUsers }`
-	if err := runPowerShell(ctx, ensureModule); err != nil {
+	if _, err := runPowerShell(ctx, logger, ensureModule); err != nil {
 		return errw.Wrap(err, "ensuring PSWindowsUpdate module")
 	}
+	return nil
+}
 
-	// Build the update command. -IgnoreReboot prevents PSWindowsUpdate from rebooting
-	// immediately; the agent coordinates the reboot via the maintenance window.
+// windowsUpdateInfo is one update as reported by Get-WindowsUpdate.
+type windowsUpdateInfo struct {
+	Title string `json:"title"`
+	KB    string `json:"kb"`
+	// DownloadSize is the update's MaxDownloadSize in bytes. Windows Update reports
+	// no unpacked size.
+	DownloadSize uint64 `json:"downloadSize"`
+	// Size is PSWindowsUpdate's preformatted size, e.g. "108MB", used as a fallback
+	// for older module versions that don't surface MaxDownloadSize.
+	Size string `json:"size"`
+	// Categories classify the update, e.g. "Security Updates", "Drivers".
+	Categories []string `json:"categories"`
+}
+
+// pendingWindowsUpdates lists the updates that installWindowsUpdates would
+// install. Windows Update reports a download size and update categories, but no
+// unpacked size.
+func pendingWindowsUpdates(ctx context.Context, logger logging.Logger, securityOnly bool) ([]pendingUpdate, error) {
+	// Without -Install, Get-WindowsUpdate only searches, so this reports what the
+	// install below is about to do. ConvertTo-Json is fed the array explicitly
+	// because piping to it would unroll a single update back into an object.
+	cmd := "Import-Module PSWindowsUpdate; $pending = @(Get-WindowsUpdate"
+	if securityOnly {
+		cmd += securityCategory
+	}
+	cmd += `); ConvertTo-Json -Compress -Depth 3 -InputObject @($pending | ForEach-Object { ` +
+		`[PSCustomObject]@{ title = [string]$_.Title; kb = [string]$_.KB; ` +
+		`downloadSize = [uint64]$_.MaxDownloadSize; size = [string]$_.Size; ` +
+		`categories = @($_.Categories | ForEach-Object { [string]$_.Name }) } })`
+
+	output, err := runPowerShell(ctx, logger, cmd)
+	if err != nil {
+		return nil, errw.Wrap(err, "listing pending Windows updates")
+	}
+
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		// Not every PowerShell version renders an empty array as "[]".
+		return nil, nil
+	}
+
+	var found []windowsUpdateInfo
+	if err := json.Unmarshal([]byte(trimmed), &found); err != nil {
+		return nil, errw.Wrapf(err, "parsing pending Windows updates: %s", output)
+	}
+
+	updates := make([]pendingUpdate, 0, len(found))
+	for _, info := range found {
+		updates = append(updates, pendingUpdate{
+			Name:         windowsUpdateName(info),
+			DownloadSize: windowsDownloadSize(info),
+			// Categories are per-update rather than a single classification, so keep all
+			// of them, separated by "/" to stay distinguishable inside a log line.
+			Category: strings.Join(info.Categories, "/"),
+		})
+	}
+	return updates, nil
+}
+
+// windowsUpdateName labels an update by title, prefixed with its KB number when
+// the title doesn't already carry it.
+func windowsUpdateName(info windowsUpdateInfo) string {
+	if info.KB != "" && !strings.Contains(info.Title, info.KB) {
+		return info.KB + " " + info.Title
+	}
+	return info.Title
+}
+
+func windowsDownloadSize(info windowsUpdateInfo) uint64 {
+	if info.DownloadSize > 0 {
+		return info.DownloadSize
+	}
+	return parseSize(info.Size)
+}
+
+// installWindowsUpdates installs updates via the PSWindowsUpdate PowerShell module.
+// Devices already configured to use a WSUS server (via Group Policy or registry) will
+// automatically receive updates from that server without any extra configuration.
+func installWindowsUpdates(ctx context.Context, logger logging.Logger, securityOnly bool) error {
+	// -IgnoreReboot prevents PSWindowsUpdate from rebooting immediately; the agent
+	// coordinates the reboot via the maintenance window.
 	cmd := "Import-Module PSWindowsUpdate; Get-WindowsUpdate -Install -AcceptAll -IgnoreReboot"
 	if securityOnly {
-		cmd += " -Category 'Security Updates'"
+		cmd += securityCategory
 	}
-	if err := runPowerShell(ctx, cmd); err != nil {
+	if _, err := runPowerShell(ctx, logger, cmd); err != nil {
 		return errw.Wrap(err, "installing Windows updates")
 	}
 	return nil
@@ -240,15 +334,18 @@ func trustedInstallerRunning(ctx context.Context) bool {
 	return strings.EqualFold(strings.TrimSpace(string(out)), "Running")
 }
 
-// runPowerShell executes a PowerShell command, returning a wrapped error with output on failure.
-func runPowerShell(ctx context.Context, script string) error {
+// runPowerShell executes a PowerShell command, returning its combined output, or a
+// wrapped error with that output on failure.
+func runPowerShell(ctx context.Context, logger logging.Logger, script string) (string, error) {
 	cmd := exec.CommandContext(ctx, "powershell",
 		"-NonInteractive", "-NoProfile", "-ExecutionPolicy", "RemoteSigned",
 		"-Command", script,
 	)
+	logger.Debugw("Executing powershell command", "script", script)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("powershell: %w\n%s", err, output)
+		return string(output), fmt.Errorf("powershell: %w\n%s", err, output)
 	}
-	return nil
+	logger.Debugw("Powershell command succeeded", "script", script, "output", string(output))
+	return string(output), nil
 }

--- a/subsystems/syscfg/managed_upgrades_windows.go
+++ b/subsystems/syscfg/managed_upgrades_windows.go
@@ -144,13 +144,7 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) error {
 	logPendingUpdates(s.logger, updates, "security_only", securityOnly)
 
 	installed, upgradeErr := installWindowsUpdates(ctx, s.logger, securityOnly)
-	result := updateSummary{updates: installed}
-	if len(installed) == 0 {
-		// The install failed, or Windows Update didn't say what it covered. Report what
-		// we set out to install rather than an empty list.
-		result = updates
-	}
-	logUpgradeResult(ctx, s.logger, result, upgradeErr, "security_only", securityOnly)
+	logUpgradeResult(ctx, s.logger, installed, upgradeErr, "security_only", securityOnly)
 	if upgradeErr != nil {
 		return upgradeErr
 	}

--- a/subsystems/syscfg/managed_upgrades_windows_test.go
+++ b/subsystems/syscfg/managed_upgrades_windows_test.go
@@ -42,6 +42,24 @@ func TestParseWindowsUpdatesKBPrefix(t *testing.T) {
 	})
 }
 
+func TestDedupeWindowsUpdatesInstallStages(t *testing.T) {
+	// Get-WindowsUpdate -Install emits one row per update per stage; only the last
+	// stage each update reached should survive, in first-appearance order.
+	output := `[{"title":"Update A (KB1)","kb":"KB1","downloadSize":100,"result":"Accepted"},` +
+		`{"title":"Update B (KB2)","kb":"KB2","downloadSize":200,"result":"Accepted"},` +
+		`{"title":"Update A (KB1)","kb":"KB1","downloadSize":100,"result":"Downloaded"},` +
+		`{"title":"Update B (KB2)","kb":"KB2","downloadSize":200,"result":"Downloaded"},` +
+		`{"title":"Update A (KB1)","kb":"KB1","downloadSize":100,"result":"Installed"},` +
+		`{"title":"Update B (KB2)","kb":"KB2","downloadSize":200,"result":"Failed"}]`
+
+	updates, err := parseWindowsUpdates(output)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, dedupeWindowsUpdates(updates), test.ShouldResemble, []pendingUpdate{
+		{Name: "Update A (KB1)", DownloadSize: 100, Result: "Installed"},
+		{Name: "Update B (KB2)", DownloadSize: 200, Result: "Failed"},
+	})
+}
+
 func TestParseWindowsUpdatesEmpty(t *testing.T) {
 	updates, err := parseWindowsUpdates("[]\r\n")
 	test.That(t, err, test.ShouldBeNil)

--- a/subsystems/syscfg/managed_upgrades_windows_test.go
+++ b/subsystems/syscfg/managed_upgrades_windows_test.go
@@ -1,0 +1,62 @@
+package syscfg
+
+import (
+	"testing"
+
+	"go.viam.com/test"
+)
+
+func TestParseWindowsUpdates(t *testing.T) {
+	// With the progress stream silenced and stderr kept separate, the JSON is all
+	// that reaches standard output.
+	output := `[{"title":"2024-01 Cumulative Update for Windows 11 (KB5034123)",` +
+		`"kb":"KB5034123","downloadSize":113246208,"size":"108MB",` +
+		`"categories":["Security Updates","Windows 11"]},` +
+		`{"title":"Intel driver update","kb":"","downloadSize":0,"size":"2.5MB","categories":["Drivers"]}]` +
+		"\r\n"
+
+	updates, err := parseWindowsUpdates(output)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, updates, test.ShouldResemble, []pendingUpdate{
+		{
+			// The title already carries the KB number, so it isn't prefixed again.
+			Name:         "2024-01 Cumulative Update for Windows 11 (KB5034123)",
+			DownloadSize: 113246208,
+			Category:     "Security Updates/Windows 11",
+		},
+		{
+			Name: "Intel driver update",
+			// Older module versions don't surface MaxDownloadSize, so the preformatted
+			// size is used instead.
+			DownloadSize: 2621440,
+			Category:     "Drivers",
+		},
+	})
+}
+
+func TestParseWindowsUpdatesKBPrefix(t *testing.T) {
+	updates, err := parseWindowsUpdates(`[{"title":"Security Update for Windows","kb":"KB5034441"}]`)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, updates, test.ShouldResemble, []pendingUpdate{
+		{Name: "KB5034441 Security Update for Windows"},
+	})
+}
+
+func TestParseWindowsUpdatesEmpty(t *testing.T) {
+	updates, err := parseWindowsUpdates("[]\r\n")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, updates, test.ShouldBeEmpty)
+
+	// Some PowerShell versions render an empty array as nothing at all.
+	updates, err = parseWindowsUpdates("\r\n")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, updates, test.ShouldBeEmpty)
+}
+
+func TestParseWindowsUpdatesNotJSON(t *testing.T) {
+	// Anything else on standard output means the snippet didn't run as expected, which
+	// is an error rather than "nothing was installed".
+	_, err := parseWindowsUpdates("Get-WindowsUpdate : Access is denied\r\n")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "Access is denied")
+}


### PR DESCRIPTION
This PR adds logging around os auto updates, primarily by logging which updates will be installed just before applying them, and then which updates were installed (or failed to install) immediately after. Much of the code is dedicated to parsing the package manager output into go structs that can be logged as zap fields to allow for easier db queries in the future if we need to diagnose an issue or set up log based alerts. If parsing fails for whatever reason we log a warning but continue installing updates.

This also uses the new activity logs feature from rdk to log specific events around os updates. The activity log for triggering a reboot in particularly could be used as the basis for a log based alert in the future.

During testing I observed some interesting behavior that I wasn't able to root cause but is probably worth mentioning

- A Windows update was killed mid application. The timeline was successful Windows update installation -> reboot -> agent starts installing more updates -> updates aborted as agent shuts down -> agent starts intsalling more updates -> updates complete. My best guess is that a major Windows update was installed that required multiple automatic reboots, and as a Windows service agent was able to start just long enough to start working before the second reboot hit and it had to shut down

- Alma Linux (RHEL) consistently logs a failure to reboot a couple times before succeeding. Apparently RHEL includes a mechanism for certain tasks to block `systemctl reboot`, even by root. This actually seems like a pretty nice feature, but the logs are potentially confusing
