### PR TITLE
RSDK-14392 Add system log events to improve visibility into device reboots

### DIFF
--- a/boot.go
+++ b/boot.go
@@ -1,0 +1,35 @@
+package agent
+
+import (
+	"time"
+
+	"github.com/viamrobotics/agent/utils"
+	"go.viam.com/rdk/logging"
+)
+
+// systemBootWindow is how soon after an OS boot an agent start is treated as part of
+// that boot rather than as an agent-only restart. It covers the time the service
+// manager takes to bring the agent up plus the agent's own initialization.
+const systemBootWindow = 2 * time.Minute
+
+// SystemBootFields returns activity event fields describing the current OS boot, so a
+// restart of the agent alone can be told apart from a reboot of the whole device.
+// Returns nil if the boot time cannot be determined.
+func SystemBootFields(logger logging.Logger) []any {
+	bootTime, err := utils.SystemBootTime()
+	if err != nil {
+		logger.Warnw("cannot determine system boot time", "err", err)
+		return nil
+	}
+	return bootFields(bootTime, time.Now())
+}
+
+func bootFields(bootTime, now time.Time) []any {
+	uptime := now.Sub(bootTime)
+	return []any{
+		"boot_time", bootTime.UTC().Format(time.RFC3339),
+		"system_uptime", uptime.String(),
+		"system_uptime_us", uptime.Microseconds(),
+		"followed_system_boot", uptime < systemBootWindow,
+	}
+}

--- a/boot.go
+++ b/boot.go
@@ -7,11 +7,6 @@ import (
 	"go.viam.com/rdk/logging"
 )
 
-// systemBootWindow is how soon after an OS boot an agent start is treated as part of
-// that boot rather than as an agent-only restart. It covers the time the service
-// manager takes to bring the agent up plus the agent's own initialization.
-const systemBootWindow = 2 * time.Minute
-
 // SystemBootFields returns activity event fields describing the current OS boot, so a
 // restart of the agent alone can be told apart from a reboot of the whole device.
 // Returns nil if the boot time cannot be determined.
@@ -30,6 +25,5 @@ func bootFields(bootTime, now time.Time) []any {
 		"boot_time", bootTime.UTC().Format(time.RFC3339),
 		"system_uptime", uptime.String(),
 		"system_uptime_us", uptime.Microseconds(),
-		"followed_system_boot", uptime < systemBootWindow,
 	}
 }

--- a/boot_test.go
+++ b/boot_test.go
@@ -10,13 +10,12 @@ import (
 func TestBootFields(t *testing.T) {
 	bootTime := time.Date(2026, time.August, 12, 15, 4, 5, 0, time.UTC)
 
-	t.Run("agent started with the system", func(t *testing.T) {
+	t.Run("agent started shortly after boot", func(t *testing.T) {
 		fields := bootFields(bootTime, bootTime.Add(time.Second*30))
 		test.That(t, fields, test.ShouldResemble, []any{
 			"boot_time", "2026-08-12T15:04:05Z",
 			"system_uptime", "30s",
 			"system_uptime_us", int64(30_000_000),
-			"followed_system_boot", true,
 		})
 	})
 
@@ -26,7 +25,6 @@ func TestBootFields(t *testing.T) {
 			"boot_time", "2026-08-12T15:04:05Z",
 			"system_uptime", "3h0m0s",
 			"system_uptime_us", int64(3 * 60 * 60 * 1_000_000),
-			"followed_system_boot", false,
 		})
 	})
 }

--- a/boot_test.go
+++ b/boot_test.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"go.viam.com/test"
+)
+
+func TestBootFields(t *testing.T) {
+	bootTime := time.Date(2026, time.August, 12, 15, 4, 5, 0, time.UTC)
+
+	t.Run("agent started with the system", func(t *testing.T) {
+		fields := bootFields(bootTime, bootTime.Add(time.Second*30))
+		test.That(t, fields, test.ShouldResemble, []any{
+			"boot_time", "2026-08-12T15:04:05Z",
+			"system_uptime", "30s",
+			"system_uptime_us", int64(30_000_000),
+			"followed_system_boot", true,
+		})
+	})
+
+	t.Run("agent restarted long after boot", func(t *testing.T) {
+		fields := bootFields(bootTime, bootTime.Add(time.Hour*3))
+		test.That(t, fields, test.ShouldResemble, []any{
+			"boot_time", "2026-08-12T15:04:05Z",
+			"system_uptime", "3h0m0s",
+			"system_uptime_us", int64(3 * 60 * 60 * 1_000_000),
+			"followed_system_boot", false,
+		})
+	})
+}

--- a/cmd/viam-agent/main.go
+++ b/cmd/viam-agent/main.go
@@ -253,11 +253,11 @@ func commonMain(runningAsService bool) {
 	// version; keep the format in sync with agentVersionRegex there.
 	globalLogger.Infof("Viam Agent Version: %s Git Revision: %s", utils.GetVersion(), utils.GetRevision())
 	startupStarted := time.Now()
-	globalLogger.Activity("startup", "start",
+	globalLogger.Activity("startup", "start", append([]any{
 		"pid", os.Getpid(),
 		"version", utils.GetVersion(),
 		"git_rev", utils.GetRevision(),
-	)
+	}, agent.SystemBootFields(globalLogger)...)...)
 
 	if cfg.AdvancedSettings.WaitForUpdateCheck.Get() {
 		// wait to be online
@@ -318,7 +318,7 @@ func setupExitSignalHandling() (context.Context, context.CancelFunc) {
 			case syscall.SIGABRT:
 				fallthrough
 			case syscall.SIGTERM:
-				agent.RecordExitReason("signal", sig.String())
+				agent.RecordExitReason(exitReasonForSignal(sig))
 				signal.Ignore(os.Interrupt, syscall.SIGTERM, syscall.SIGABRT) // keeping SIGQUIT for stack trace debugging
 				return
 
@@ -336,6 +336,17 @@ func setupExitSignalHandling() (context.Context, context.CancelFunc) {
 
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM, syscall.SIGABRT)
 	return ctx, cancel
+}
+
+// exitReasonForSignal classifies a termination signal for the shutdown activity events,
+// separating a shutdown of the whole device from a restart of the agent service alone.
+func exitReasonForSignal(sig os.Signal) (reason, detail string) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	if utils.SystemIsShuttingDown(ctx, globalLogger) {
+		return "system_shutdown", fmt.Sprintf("received %s while the system was shutting down", sig)
+	}
+	return "signal", sig.String()
 }
 
 // helper to log.Fatal if error is non-nil.

--- a/cmd/viam-agent/main_windows.go
+++ b/cmd/viam-agent/main_windows.go
@@ -33,6 +33,11 @@ func (*agentService) Execute(args []string, r <-chan svc.ChangeRequest, changes 
 		c := <-r
 		if c.Cmd == svc.Stop || c.Cmd == svc.Shutdown {
 			goutils.UncheckedError(elog.Info(1, fmt.Sprintf("%s service stopping", serviceName)))
+			if c.Cmd == svc.Shutdown {
+				agent.RecordExitReason("system_shutdown", "service control manager reported a system shutdown")
+			} else {
+				agent.RecordExitReason("service_stop", "service control manager requested a stop")
+			}
 			changes <- svc.Status{State: svc.StopPending}
 			globalCancel()
 			break

--- a/manager.go
+++ b/manager.go
@@ -1022,6 +1022,8 @@ func (m *Manager) CheckIfOSNeedsReboot(ctx context.Context) {
 		return
 	}
 
+	m.logger.Activity("system", "reboot", "reason", "os_update")
+
 	m.Exit("system reboot initiated for OS package updates", "os_reboot")
 }
 

--- a/subsystems/networking/networkmanager_linux.go
+++ b/subsystems/networking/networkmanager_linux.go
@@ -1123,6 +1123,9 @@ func (n *Subsystem) doReboot(ctx context.Context) bool {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		n.logger.Warnw("Error running systemctl reboot", "output", output, "err", err.Error())
+	} else {
+		n.logger.Activity("system", "reboot", "reason", "offline_too_long",
+			"offline_timeout", time.Duration(n.Config().DeviceRebootAfterOfflineMinutes).String())
 	}
 	const rebootWaitDuration = time.Minute * 5
 	if !n.mainLoopHealth.Sleep(ctx, rebootWaitDuration) {

--- a/utils/boot.go
+++ b/utils/boot.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"context"
+	"time"
+
+	"go.viam.com/rdk/logging"
+)
+
+// SystemBootTime returns the time at which the operating system last booted.
+func SystemBootTime() (time.Time, error) {
+	return systemBootTime()
+}
+
+// SystemIsShuttingDown reports whether the whole system (not just this service) is on
+// its way down, so a termination signal can be attributed to a reboot or poweroff
+// rather than to a restart of the agent alone. Returns false when it cannot be
+// determined, including on platforms where we have no way to ask.
+func SystemIsShuttingDown(ctx context.Context, logger logging.Logger) bool {
+	return systemIsShuttingDown(ctx, logger)
+}

--- a/utils/boot_darwin.go
+++ b/utils/boot_darwin.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"context"
+	"time"
+
+	errw "github.com/pkg/errors"
+	"go.viam.com/rdk/logging"
+	"golang.org/x/sys/unix"
+)
+
+func systemBootTime() (time.Time, error) {
+	tv, err := unix.SysctlTimeval("kern.boottime")
+	if err != nil {
+		return time.Time{}, errw.Wrap(err, "reading kern.boottime")
+	}
+	return time.Unix(tv.Unix()), nil
+}
+
+func systemIsShuttingDown(_ context.Context, _ logging.Logger) bool {
+	// launchd gives no equivalent of systemd's system state.
+	return false
+}

--- a/utils/boot_linux.go
+++ b/utils/boot_linux.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+
+	errw "github.com/pkg/errors"
+	"go.viam.com/rdk/logging"
+	"golang.org/x/sys/unix"
+)
+
+func systemBootTime() (time.Time, error) {
+	var info unix.Sysinfo_t
+	if err := unix.Sysinfo(&info); err != nil {
+		return time.Time{}, errw.Wrap(err, "getting sysinfo")
+	}
+	// Uptime is int32 on 32 bit platforms, so widen before converting to a Duration.
+	return time.Now().Add(-time.Duration(int64(info.Uptime)) * time.Second), nil
+}
+
+func systemIsShuttingDown(ctx context.Context, logger logging.Logger) bool {
+	// systemctl exits non-zero for every state other than "running", so only the
+	// output matters here.
+	output, err := exec.CommandContext(ctx, "systemctl", "is-system-running").Output()
+	if err != nil && len(output) == 0 {
+		logger.Debugw("cannot determine system state", "err", err)
+		return false
+	}
+	return strings.TrimSpace(string(output)) == "stopping"
+}

--- a/utils/boot_linux.go
+++ b/utils/boot_linux.go
@@ -16,8 +16,9 @@ func systemBootTime() (time.Time, error) {
 	if err := unix.Sysinfo(&info); err != nil {
 		return time.Time{}, errw.Wrap(err, "getting sysinfo")
 	}
-	// Uptime is int32 on 32 bit platforms, so widen before converting to a Duration.
-	return time.Now().Add(-time.Duration(int64(info.Uptime)) * time.Second), nil
+	// Uptime is int32 on 32 bit platforms and int64 on 64 bit ones; converting to a
+	// Duration handles both.
+	return time.Now().Add(-time.Duration(info.Uptime) * time.Second), nil
 }
 
 func systemIsShuttingDown(ctx context.Context, logger logging.Logger) bool {

--- a/utils/boot_test.go
+++ b/utils/boot_test.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"go.viam.com/rdk/logging"
+	"go.viam.com/test"
+)
+
+func TestSystemBootTime(t *testing.T) {
+	bootTime, err := SystemBootTime()
+	test.That(t, err, test.ShouldBeNil)
+
+	uptime := time.Since(bootTime)
+	test.That(t, uptime, test.ShouldBeGreaterThan, time.Duration(0))
+	// A machine reporting an uptime of decades has given us a bogus boot time.
+	test.That(t, uptime, test.ShouldBeLessThan, time.Hour*24*365*10)
+}
+
+func TestSystemIsShuttingDown(t *testing.T) {
+	// The machine running the tests is not on its way down, and neither systemd being
+	// absent nor it reporting some other state should be mistaken for a shutdown.
+	test.That(t, SystemIsShuttingDown(t.Context(), logging.NewTestLogger(t)), test.ShouldBeFalse)
+}

--- a/utils/boot_windows.go
+++ b/utils/boot_windows.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"context"
+	"time"
+
+	"go.viam.com/rdk/logging"
+	"golang.org/x/sys/windows"
+)
+
+func systemBootTime() (time.Time, error) {
+	return time.Now().Add(-windows.DurationSinceBoot()), nil
+}
+
+func systemIsShuttingDown(_ context.Context, _ logging.Logger) bool {
+	// A system shutdown reaches us as an svc.Shutdown control request instead, which
+	// the service handler in cmd/viam-agent records directly.
+	return false
+}


### PR DESCRIPTION
Today an agent restart and a full device reboot look the same in the activity events added in #274: both produce a `shutdown` with reason `signal` followed by a `startup`. Telling them apart means going to the device and reading journald. This adds the missing system-level signals on both ends of the restart.

## Changes

**Boot context on startup** — `startup`/`start` now carries the OS boot time and system uptime:

- `boot_time` (RFC3339, UTC) — a stable key for correlating every event from the same boot
- `system_uptime` / `system_uptime_us`

A restart of just the agent reports a long uptime against an unchanged `boot_time`; a device reboot reports a new `boot_time` and an uptime of seconds.

`utils.SystemBootTime` is implemented per platform: `sysinfo` on Linux, `kern.boottime` on darwin, `GetTickCount64` on Windows.

**Shutdown reason distinguishes a device going down from an agent restart** — a termination signal is now classified before being recorded:

- Linux: `systemctl is-system-running` reporting `stopping` means the whole system is on its way down, recorded as reason `system_shutdown` instead of `signal`. The check is bounded by a 2s timeout and falls back to `signal` if systemd can't be reached.
- Windows: `svc.Shutdown` (system shutdown) is recorded as `system_shutdown`, `svc.Stop` as `service_stop`.

**Agent-initiated reboots are explicit** — a `system`/`reboot` activity event is emitted once the reboot command succeeds, with a reason of `os_update` (managed package upgrades) or `offline_too_long` (networking's offline reboot). Previously these were plain info logs.

## Testing

- New unit tests for the boot fields (started shortly after boot vs. restarted long after boot) and for `SystemBootTime` / `SystemIsShuttingDown`.
- `go test -race ./...` passes; the only failure is the pre-existing `TestInitPaths/failure_cannot_create_directory`, which fails on `main` too when the suite runs as root.
- Cross-builds verified for linux, windows, and darwin.

Key: RSDK-14392

Co-authored by Claude agent for Jira.
