### PR TITLE
Fix Windows-only bugs in path handling and file syncing

### DIFF
--- a/subsystems/viamserver/viamserver.go
+++ b/subsystems/viamserver/viamserver.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -113,7 +113,7 @@ func (s *Subsystem) Start(ctx context.Context) error {
 		s.mu.Unlock()
 		return nil
 	}
-	binPath := path.Join(utils.ViamDirs.Bin, SubsysName)
+	binPath := filepath.Join(utils.ViamDirs.Bin, SubsysName)
 
 	if runtime.GOOS == "windows" {
 		binPath += ".exe"

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -591,7 +591,7 @@ func allowFirewall(ctx context.Context, logger logging.Logger, outPath string) e
 	// todo: confirm this is right; this isn't the final destination. Does the rule move when the file is renamed? Link to docs.
 	cmd := exec.CommandContext( //nolint:gosec
 		ctx,
-		"netsh", "advfirewall", "firewall", "add", "rule", "name="+path.Base(outPath),
+		"netsh", "advfirewall", "firewall", "add", "rule", "name="+filepath.Base(outPath),
 		"dir=in", "action=allow", "program=\""+outPath+"\"", "enable=yes",
 	)
 	if err := cmd.Start(); err != nil {
@@ -630,10 +630,22 @@ func DecompressFile(inPath string) (outPath string, errRet error) {
 	if err != nil {
 		return "", err
 	}
+	tmpPath := out.Name()
+	// Windows refuses to rename a file that still has an open handle, so the close
+	// has to happen before the rename below rather than only in the defer. The defer
+	// stays as the backstop for the paths that return before reaching it.
+	closed := false
+	closeOut := func() error {
+		if closed {
+			return nil
+		}
+		closed = true
+		return out.Close()
+	}
 
 	defer func() {
-		errRet = errors.Join(errRet, out.Close(), SyncFS(ViamDirs.Tmp))
-		if err := os.Remove(out.Name()); err != nil && !os.IsNotExist(err) {
+		errRet = errors.Join(errRet, closeOut(), SyncFS(ViamDirs.Tmp))
+		if err := os.Remove(tmpPath); err != nil && !os.IsNotExist(err) {
 			errRet = errors.Join(errRet, err)
 		}
 	}()
@@ -643,8 +655,12 @@ func DecompressFile(inPath string) (outPath string, errRet error) {
 		errRet = errors.Join(errRet, err)
 	}
 
+	if err := closeOut(); err != nil {
+		return "", errors.Join(errRet, err)
+	}
+
 	outPath = filepath.Join(ViamDirs.Cache, strings.Replace(filepath.Base(inPath), ".xz", "", 1))
-	errRet = errors.Join(errRet, os.Rename(out.Name(), outPath), SyncFS(outPath))
+	errRet = errors.Join(errRet, os.Rename(tmpPath, outPath), SyncFS(outPath))
 	return outPath, errRet
 }
 
@@ -735,7 +751,7 @@ func WriteFileIfNew(outPath string, data []byte) (bool, error) {
 	}
 
 	//nolint:gosec
-	if err := os.MkdirAll(path.Dir(outPath), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		return true, errw.Wrapf(err, "creating directory for %s", outPath)
 	}
 

--- a/utils/utils_windows.go
+++ b/utils/utils_windows.go
@@ -39,17 +39,40 @@ func checkPathOwner(_ int, _ fs.FileInfo) error {
 	return nil
 }
 
+// SyncFS flushes buffered writes for syncPath to disk.
+//
+// Windows has no equivalent of the syncfs(2) the unix implementation uses:
+// FlushFileBuffers takes a single file handle, and accepts a volume handle only
+// from an administrator. So this flushes syncPath itself when it is a regular
+// file, which covers what every caller is actually after — durability for a file
+// it just wrote.
+//
+// Anything else is a no-op. Opening a directory or a symlink with O_RDWR fails
+// (EISDIR, or ENOENT for a symlink whose target does not exist yet), and there is
+// nothing to flush behind either. Returning nil rather than that error also keeps
+// this in line with the unix implementation, which syncs the *parent* of syncPath
+// and so succeeds for directories, symlinks, and paths that do not exist at all.
 func SyncFS(syncPath string) error {
+	info, err := os.Lstat(syncPath)
+	if err != nil {
+		if errw.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return errw.Wrapf(err, "syncing fs %s", syncPath)
+	}
+	if !info.Mode().IsRegular() {
+		return nil
+	}
+
 	handle, err := syscall.Open(syncPath, syscall.O_RDWR, 0)
 	if err != nil {
-		return err
+		return errw.Wrapf(err, "syncing fs %s", syncPath)
 	}
 	defer func() {
 		goutils.UncheckedError(syscall.CloseHandle(handle))
 	}()
-	err = syscall.Fsync(handle)
-	if err != nil {
-		return err
+	if err := syscall.Fsync(handle); err != nil {
+		return errw.Wrapf(err, "syncing fs %s", syncPath)
 	}
 	return nil
 }

--- a/utils/utils_windows.go
+++ b/utils/utils_windows.go
@@ -39,19 +39,7 @@ func checkPathOwner(_ int, _ fs.FileInfo) error {
 	return nil
 }
 
-// SyncFS flushes buffered writes for syncPath to disk.
-//
-// Windows has no equivalent of the syncfs(2) the unix implementation uses:
-// FlushFileBuffers takes a single file handle, and accepts a volume handle only
-// from an administrator. So this flushes syncPath itself when it is a regular
-// file, which covers what every caller is actually after — durability for a file
-// it just wrote.
-//
-// Anything else is a no-op. Opening a directory or a symlink with O_RDWR fails
-// (EISDIR, or ENOENT for a symlink whose target does not exist yet), and there is
-// nothing to flush behind either. Returning nil rather than that error also keeps
-// this in line with the unix implementation, which syncs the *parent* of syncPath
-// and so succeeds for directories, symlinks, and paths that do not exist at all.
+// Windows has no syncfs(2) syscall equivalent, so here we try our best to replicate it
 func SyncFS(syncPath string) error {
 	info, err := os.Lstat(syncPath)
 	if err != nil {

--- a/utils/utils_windows.go
+++ b/utils/utils_windows.go
@@ -39,7 +39,7 @@ func checkPathOwner(_ int, _ fs.FileInfo) error {
 	return nil
 }
 
-// Windows has no syncfs(2) syscall equivalent, so here we try our best to replicate it
+// Windows has no syncfs(2) syscall equivalent, so here we try our best to replicate it.
 func SyncFS(syncPath string) error {
 	info, err := os.Lstat(syncPath)
 	if err != nil {

--- a/version_control.go
+++ b/version_control.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -197,7 +196,7 @@ func (c *VersionCache) Update(cfg *pb.UpdateInfo, binary string) error {
 
 	info.Version = newVersion
 	info.URL = cfg.GetUrl()
-	info.SymlinkPath = path.Join(utils.ViamDirs.Bin, cfg.GetFilename())
+	info.SymlinkPath = filepath.Join(utils.ViamDirs.Bin, cfg.GetFilename())
 	// The config never carries a real sha for a custom URL, so a steady-state poll
 	// must preserve the locally computed one (see UpdateBinary) or we'd redownload
 	// every cycle. Every other case takes the config's value; for a re-targeted


### PR DESCRIPTION
Four sites used the slash-only `path` package on filesystem paths, plus two Windows file bugs. All are reachable in a running agent on Windows; none are test problems.

Found while working out which existing tests could be turned on in Windows CI (#288), but kept off that branch since these change behaviour. Independent of it — this branch is a single commit off `main`.

### `path` → `filepath`

- **`WriteFileIfNew`** built its parent directory with `path.Dir`. Given a backslashed path that returns `"."`, so `MkdirAll` no-ops and the write fails with `The system cannot find the path specified`. Anything writing into a directory that doesn't exist yet hits this. This is what broke the whole `utils/systemd` package on Windows.
- **`allowFirewall`** named its netsh rule with `path.Base`, so the rule was named with the whole `C:\...` path instead of the file name.
- **`viamserver.Start`** and **`VersionCache.Update`** joined with `path.Join`, yielding mixed separators like `c:\opt\viam\bin/viam-server`. Both feed only filesystem calls, which tolerate it, so these are normalisations rather than repairs.

The `path.Base` in `DownloadFile` is deliberately left alone — it parses a URL path, where the slash-only package is correct.

### `SyncFS`

Opened `syncPath` itself with `O_RDWR`, so it failed with `EISDIR` on a directory and `ENOENT` on a symlink whose target doesn't exist yet. It now flushes regular files and no-ops otherwise, which is also what the unix implementation does in practice: that one syncs the *parent* of `syncPath`, so it already succeeds for directories, symlinks, and paths that aren't there at all. Errors are now wrapped to match the unix side rather than returned bare.

### `DecompressFile`

Renamed its temp file while the handle was still open, since the `Close` sat in a defer that runs after the rename. Windows refuses that, so xz decompression could not work there at all. The close now happens before the rename, with the defer left as the backstop for the early returns.

## Compatibility

`SymlinkPath` is persisted in the version cache, so on Windows newly written entries change from `c:\opt\viam\bin/viam-agent` to `c:\opt\viam\bin\viam-agent`. No consumer compares it as a string — `CheckIfSame` goes through `EvalSymlinks`/`os.SameFile`, `ForceSymlink` through `os.Remove`/`os.Symlink` — so existing caches keep working and get rewritten on the next `Update`.

## Testing

No new tests. On Windows these make `TestForceSymlink`, `TestDecompressFile`, both `TestInstall` subtests, and the whole `utils/systemd` package pass, all of which are currently excluded from the Windows job in #288. Builds and vets clean for Windows and Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)