### PR TITLE
Fix flaky TestGetLastModified

### DIFF
--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -123,11 +123,7 @@ func TestGetLastModified(t *testing.T) {
 	mux.HandleFunc("/badlm", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Last-Modified", "asdfghjkl")
 	})
-	// httptest binds the listener before it returns, so the requests below cannot
-	// race the server coming up. Serving on a port that ListenAndServe had not
-	// reached yet made this test flaky: GetLastModified reports a failed HEAD as a
-	// zero time, which is what the /nolm case asserts, so a refused connection was
-	// only ever caught by the /lm case below.
+
 	server := httptest.NewServer(mux)
 	defer server.Close()
 	baseURLWithScheme := server.URL

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -15,7 +15,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -115,12 +114,6 @@ func TestWriteFileIfNew(t *testing.T) {
 func TestGetLastModified(t *testing.T) {
 	logger := logging.NewTestLogger(t)
 
-	port, err := goutils.TryReserveRandomPort()
-	test.That(t, err, test.ShouldBeNil)
-
-	baseURL := fmt.Sprintf(":%d", port)
-	baseURLWithScheme := fmt.Sprintf("%s://%s", "http", baseURL)
-
 	mux := http.NewServeMux()
 	mux.HandleFunc("/nolm", func(w http.ResponseWriter, r *http.Request) {
 	})
@@ -130,15 +123,14 @@ func TestGetLastModified(t *testing.T) {
 	mux.HandleFunc("/badlm", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Last-Modified", "asdfghjkl")
 	})
-	server := &http.Server{Addr: baseURL, Handler: mux}
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if err := server.ListenAndServe(); err != nil {
-			test.That(t, err, test.ShouldEqual, http.ErrServerClosed)
-		}
-	}()
+	// httptest binds the listener before it returns, so the requests below cannot
+	// race the server coming up. Serving on a port that ListenAndServe had not
+	// reached yet made this test flaky: GetLastModified reports a failed HEAD as a
+	// zero time, which is what the /nolm case asserts, so a refused connection was
+	// only ever caught by the /lm case below.
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	baseURLWithScheme := server.URL
 
 	// Test Last-Modified not present
 	ctx := t.Context()
@@ -162,10 +154,6 @@ func TestGetLastModified(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	lm = GetLastModified(ctx, badLmURL, logger)
 	test.That(t, lm.IsZero(), test.ShouldBeTrue)
-
-	err = server.Shutdown(ctx)
-	test.That(t, err, test.ShouldBeNil)
-	wg.Wait()
 }
 
 func TestDownloadFile(t *testing.T) {


### PR DESCRIPTION
`TestGetLastModified` started its server with `go server.ListenAndServe()` and issued its first request immediately after, with nothing synchronising the two. When the goroutine hadn't reached `Listen` yet, the requests were refused:

```
Head "http://:49209/nolm": dial tcp :49209: connect: connection refused
Head "http://:49209/lm":   dial tcp :49209: connect: connection refused
```

Caught on the macOS runner in #288, where the same commit (`55dadce`) passed one run and failed the next — [passing run](https://github.com/viamrobotics/agent/actions/runs/32053399751), [failing run](https://github.com/viamrobotics/agent/actions/runs/32064405879). That PR doesn't touch this file.

There was a second, narrower window too: `goutils.TryReserveRandomPort` closes its listener before returning the port number, so nothing owned the port between that call and `ListenAndServe`.

`httptest.NewServer` binds before it returns, which closes both windows. It also reports a URL with a real host instead of the bare `:49209` above, and lets the goroutine, `WaitGroup`, and explicit `Shutdown` go away — matching how `TestDownloadFile` in the same file already sets up its server.

## Why it only ever failed on one line

Worth flagging, because it made the test weaker than it looked. `GetLastModified` reports a failed HEAD as a zero time, and the `/nolm` case asserts exactly that — so it passed even though its request never reached a server. Only `/lm`, which asserts a non-zero time, could notice. The old test would have passed against a server that never started at all.

## Testing

`go test -count=20 -run TestGetLastModified ./utils` clean. Vets clean for Windows and Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)