### PR TITLE
Fix managed updates issues on Ubuntu

### DIFF
--- a/subsystems/syscfg/managed_upgrades_common.go
+++ b/subsystems/syscfg/managed_upgrades_common.go
@@ -168,6 +168,12 @@ type updateSummary struct {
 	listErr error
 }
 
+// shouldContinue returns true if there may be more work to do to install os
+// updates, false otherwise.
+func (us updateSummary) shouldContinue() bool {
+	return len(us.updates) > 0 || us.listErr != nil
+}
+
 // sizeSuffixes maps the unit suffixes package managers print sizes with to their
 // multiplier. Both the SI-style ("2.3 M") and binary ("2.3 MiB") spellings appear
 // in practice, and both mean a power of 1024 in this context.
@@ -208,17 +214,14 @@ func parseSize(size string) uint64 {
 // still leaves behind a record of what it was installing.
 func logPendingUpdates(logger logging.Logger, updates updateSummary, keysAndValues ...any) {
 	if updates.listErr != nil {
-		logger.Warnw("Installing OS updates, but could not determine which ones",
-			append([]any{"update_list_err", updates.listErr}, keysAndValues...)...)
+		logger.Activity("system", updateActivityStart, append([]any{"update_list_err", updates.listErr}, keysAndValues...)...)
 		return
 	}
-
-	fields := append([]any{"updates", updates.updates}, keysAndValues...)
 	if len(updates.updates) == 0 {
-		logger.Infow("No OS updates pending, nothing to install", fields...)
+		logger.Infow("No OS updates pending, nothing to install", keysAndValues...)
 		return
 	}
-	logger.Activity("system", updateActivityStart, fields...)
+	logger.Activity("system", updateActivityStart, append([]any{"updates", updates.updates}, keysAndValues...)...)
 }
 
 // logUpgradeResult reports how the upgrade went, with installed carrying the

--- a/subsystems/syscfg/managed_upgrades_common_test.go
+++ b/subsystems/syscfg/managed_upgrades_common_test.go
@@ -101,8 +101,8 @@ func TestLogPendingUpdates(t *testing.T) {
 		test.That(t, entries, test.ShouldHaveLength, 1)
 		// A failed listing is a warning: the upgrade still runs, but we've lost the
 		// record of what it installs.
-		test.That(t, entries[0].Level, test.ShouldEqual, zapcore.WarnLevel)
-		test.That(t, entries[0].Message, test.ShouldEqual, "Installing OS updates, but could not determine which ones")
+		test.That(t, entries[0].Level, test.ShouldEqual, zapcore.InfoLevel)
+		test.That(t, entries[0].LoggerName, test.ShouldEndWith, ".activity")
 		test.That(t, output.String(), test.ShouldContainSubstring, "apt-get exploded")
 	})
 }

--- a/subsystems/syscfg/managed_upgrades_linux.go
+++ b/subsystems/syscfg/managed_upgrades_linux.go
@@ -208,6 +208,8 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) error {
 	pending, listErr := pm.pendingUpgrades(ctx, securityOnly)
 	updates := updateSummary{updates: pending, listErr: listErr}
 	logPendingUpdates(s.logger, updates, "package_manager", pm.String(), "security_only", securityOnly)
+	// Bail early if we were able to parse the update check output and it reports
+	// there are no updates to install.
 	if !updates.shouldContinue() {
 		return nil
 	}

--- a/subsystems/syscfg/managed_upgrades_linux.go
+++ b/subsystems/syscfg/managed_upgrades_linux.go
@@ -208,6 +208,9 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) error {
 	pending, listErr := pm.pendingUpgrades(ctx, securityOnly)
 	updates := updateSummary{updates: pending, listErr: listErr}
 	logPendingUpdates(s.logger, updates, "package_manager", pm.String(), "security_only", securityOnly)
+	if !updates.shouldContinue() {
+		return nil
+	}
 
 	installed, upgradeErr := pm.runUpgrade(ctx, securityOnly)
 	logUpgradeResult(ctx, s.logger, fillDetailFromPending(installed, pending), upgradeErr,

--- a/subsystems/syscfg/managed_upgrades_windows.go
+++ b/subsystems/syscfg/managed_upgrades_windows.go
@@ -142,6 +142,8 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) error {
 	pending, listErr := pendingWindowsUpdates(ctx, s.logger, securityOnly)
 	updates := updateSummary{updates: pending, listErr: listErr}
 	logPendingUpdates(s.logger, updates, "security_only", securityOnly)
+	// Bail early if we were able to parse the update check output and it reports
+	// there are no updates to install.
 	if !updates.shouldContinue() {
 		return nil
 	}

--- a/subsystems/syscfg/managed_upgrades_windows.go
+++ b/subsystems/syscfg/managed_upgrades_windows.go
@@ -142,6 +142,9 @@ func (s *Subsystem) runManagedUpgrade(ctx context.Context) error {
 	pending, listErr := pendingWindowsUpdates(ctx, s.logger, securityOnly)
 	updates := updateSummary{updates: pending, listErr: listErr}
 	logPendingUpdates(s.logger, updates, "security_only", securityOnly)
+	if !updates.shouldContinue() {
+		return nil
+	}
 
 	installed, upgradeErr := installWindowsUpdates(ctx, s.logger, securityOnly)
 	logUpgradeResult(ctx, s.logger, installed, upgradeErr, "security_only", securityOnly)

--- a/subsystems/syscfg/upgrades_linux.go
+++ b/subsystems/syscfg/upgrades_linux.go
@@ -35,16 +35,18 @@ func (s *Subsystem) EnforceUpgrades(ctx context.Context) error {
 		return nil
 	}
 
-	unsupportedReason, err := checkSupportedDistro()
-	if err != nil {
-		return err
-	}
-	if unsupportedReason != "" {
-		s.logger.Infow("Skipping unattended upgrades configuration", "reason", unsupportedReason)
-		return nil
-	}
-
+	// Disabled and managed modes only turn apt's own unattended upgrades off,
+	// which works on any apt-based distro. They must not sit behind the codename
+	// gate below (which exists for the origins generation the enable path
+	// needs): otherwise a managed mode on a distro outside supportedCodenames
+	// would run the agent's upgrade loop while the OS's apt-daily-upgrade.timer
+	// stays enabled, leaving two upgraders contending for the dpkg lock.
 	if isDisabled(cfg) || isManaged(cfg) {
+		if _, err := exec.LookPath("apt-get"); err != nil {
+			s.logger.Infow("Skipping unattended upgrades configuration", "reason", "no apt-get binary found")
+			//nolint:nilerr
+			return nil
+		}
 		err := setTimer(ctx, false)
 		if err != nil {
 			// Might just be that the package isn't installed yet so systemd reported
@@ -66,6 +68,15 @@ func (s *Subsystem) EnforceUpgrades(ctx context.Context) error {
 				s.logger.Info("Disabled apt unattended-upgrades, no OS upgrades will be installed automatically.")
 			}
 		}
+		return nil
+	}
+
+	unsupportedReason, err := checkSupportedDistro()
+	if err != nil {
+		return err
+	}
+	if unsupportedReason != "" {
+		s.logger.Infow("Skipping unattended upgrades configuration", "reason", unsupportedReason)
 		return nil
 	}
 

--- a/subsystems/syscfg/upgrades_linux.go
+++ b/subsystems/syscfg/upgrades_linux.go
@@ -188,20 +188,23 @@ func generateOrigins(ctx context.Context, securityOnly bool) (string, error) {
 
 // inner transformation logic of generateOrigins for testing.
 func generateOriginsInner(securityOnly bool, output []byte) map[string]bool {
-	releaseRegex := regexp.MustCompile(`release.*o=([^,]+).*n=([^,]+).*`)
+	// Match the archive/suite (a=) rather than the codename (n=): Ubuntu keeps
+	// the pocket in Suite (a=jammy-security, n=jammy) while Debian carries it in
+	// both, so Suite is the one field that identifies security repos on both.
+	releaseRegex := regexp.MustCompile(`release.*o=([^,]+).*a=([^,]+).*`)
 	matches := releaseRegex.FindAllStringSubmatch(string(output), -1)
 
 	// use map to reduce to unique set
 	releases := map[string]bool{}
 	for _, release := range matches {
-		// we expect at least an origin and a codename from each line
+		// we expect at least an origin and an archive from each line
 		if len(release) != 3 {
 			continue
 		}
 		if securityOnly && !strings.Contains(release[2], "security") {
 			continue
 		}
-		releases[fmt.Sprintf(`"origin=%s,codename=%s";`, release[1], release[2])] = true
+		releases[fmt.Sprintf(`"origin=%s,archive=%s";`, release[1], release[2])] = true
 	}
 	return releases
 }

--- a/subsystems/syscfg/upgrades_linux.go
+++ b/subsystems/syscfg/upgrades_linux.go
@@ -76,7 +76,7 @@ func (s *Subsystem) EnforceUpgrades(ctx context.Context) error {
 		return err
 	}
 	if unsupportedReason != "" {
-		s.logger.Infow("Skipping unattended upgrades configuration", "reason", unsupportedReason)
+		s.logger.Warnw("Skipping unattended upgrades configuration", "reason", unsupportedReason)
 		return nil
 	}
 
@@ -199,9 +199,10 @@ func generateOrigins(ctx context.Context, securityOnly bool) (string, error) {
 
 // inner transformation logic of generateOrigins for testing.
 func generateOriginsInner(securityOnly bool, output []byte) map[string]bool {
-	// Match the archive/suite (a=) rather than the codename (n=): Ubuntu keeps
-	// the pocket in Suite (a=jammy-security, n=jammy) while Debian carries it in
-	// both, so Suite is the one field that identifies security repos on both.
+	// Match the archive (a=) rather than the codename (n=): Ubuntu keeps the
+	// "-security" suffix there (a=jammy-security, n=jammy) while Debian carries
+	// it in both, so Suite is the one field that identifies security repos on
+	// both.
 	releaseRegex := regexp.MustCompile(`release.*o=([^,]+).*a=([^,]+).*`)
 	matches := releaseRegex.FindAllStringSubmatch(string(output), -1)
 

--- a/subsystems/syscfg/upgrades_linux_test.go
+++ b/subsystems/syscfg/upgrades_linux_test.go
@@ -13,21 +13,29 @@ func TestGenerateOrigins(t *testing.T) {
 		test.That(t, err, test.ShouldBeNil)
 		originsAll := generateOriginsInner(false, contents)
 		test.That(t, originsAll, test.ShouldResemble, map[string]bool{
-			`"origin=Debian,codename=bookworm";`:          true,
-			`"origin=Debian,codename=bookworm-security";`: true,
-			`"origin=Debian,codename=bookworm-updates";`:  true,
+			`"origin=Debian,archive=stable";`:          true,
+			`"origin=Debian,archive=stable-security";`: true,
+			`"origin=Debian,archive=stable-updates";`:  true,
 		})
 		originsSecurity := generateOriginsInner(true, contents)
 		test.That(t, originsSecurity, test.ShouldResemble, map[string]bool{
-			`"origin=Debian,codename=bookworm-security";`: true,
+			`"origin=Debian,archive=stable-security";`: true,
 		})
 	})
 
 	t.Run("ubuntu", func(t *testing.T) {
-		t.Skip("todo: ubuntu parsing")
 		contents, err := os.ReadFile("test-apt-policy-ubuntu-jammy.txt")
 		test.That(t, err, test.ShouldBeNil)
-		generateOriginsInner(false, contents)
-		generateOriginsInner(true, contents)
+		originsAll := generateOriginsInner(false, contents)
+		test.That(t, originsAll, test.ShouldResemble, map[string]bool{
+			`"origin=Ubuntu,archive=jammy";`:           true,
+			`"origin=Ubuntu,archive=jammy-security";`:  true,
+			`"origin=Ubuntu,archive=jammy-updates";`:   true,
+			`"origin=Ubuntu,archive=jammy-backports";`: true,
+		})
+		originsSecurity := generateOriginsInner(true, contents)
+		test.That(t, originsSecurity, test.ShouldResemble, map[string]bool{
+			`"origin=Ubuntu,archive=jammy-security";`: true,
+		})
 	})
 }


### PR DESCRIPTION
Systems that use `apt` for package management need to use the separate `unattended-upgrades` program to filter updates to apply only security updates. We were using a filter config specific to Debian, which caused `managed-security` to install no updates on Ubuntu. This PR updates the config to work on both systems.

There was also a related issue where we failed to disable the background job that gets installed along with the `unattended-upgrades` program because that code was gated behind the same check we use only enable unettended-upgrades on supported debian versions. That is resolved by moving the disable logic before the check.

During testing I also noticed that we would emit an activity log noting the end of os updates even when we never logged a _start_ to the update because no updates were available. I added an early return to that code path so update end activity logs now always follow an update start activity log.

Tested on Debian and Ubuntu VMs