### PR TITLE
Clarify update log line: new version takes effect after restart

### DIFF
--- a/version_control.go
+++ b/version_control.go
@@ -415,7 +415,8 @@ func (c *VersionCache) UpdateBinary(ctx context.Context, binary string) (bool, e
 	verData.Installed = time.Now()
 
 	// if we made it here we performed an update and need to restart
-	c.logger.Infof("%s updated from %s to %s", binary, data.PreviousVersion, data.CurrentVersion)
+	c.logger.Infof("%s updated from %s to %s; new version takes effect after %s restarts",
+		binary, data.PreviousVersion, data.CurrentVersion, binary)
 	needRestart = true
 
 	// record the cache


### PR DESCRIPTION
## What

Tweaks the log line emitted by `VersionCache.UpdateBinary` (`version_control.go`) when a subsystem binary is updated.

Before:
```
viam-server updated from x to y
```
After:
```
viam-server updated from x to y; new version takes effect after viam-server restarts
```

## Why

The line is logged at the point where the new binary is symlinked into place, but the running process is still the old version — the update only takes effect once the subsystem actually restarts (immediately in the common case, or deferred when a restart isn't currently allowed, e.g. a maintenance sensor holding it off). The original wording reads as "already running the new version", which isn't accurate yet. The new wording works for both the immediate-restart and deferred-restart cases, and reads sensibly for either subsystem (`viam-server` or `viam-agent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)